### PR TITLE
chore(STONEO11Y-28): dummy Prometheus recordingRule resource

### DIFF
--- a/prometheus/base/kustomization.yaml
+++ b/prometheus/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- prometheus.rules.yaml
+- namespaces.yaml

--- a/prometheus/base/namespaces.yaml
+++ b/prometheus/base/namespaces.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: o11y
+spec: {}

--- a/prometheus/base/prometheus.rules.yaml
+++ b/prometheus/base/prometheus.rules.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    openshift.io/prometheus-rule-evaluation-scope: leaf-prometheus
+  name: o11y-example-rule
+  namespace: o11y
+spec:
+  groups:
+    - name: example
+      rules:
+        - record: o11y_prometheus_http_requests_total
+          expr: sum by (code) (prometheus_http_requests_total)


### PR DESCRIPTION
Adding dummy Prometheus recording rules to verify
o11y repository's infrastructure.

The expected behavior is that infra-deployments' ArgoCD instance should automatically deploy any PrometheusRules when there are new commits to the main branch of the 011y repository.