### PR TITLE
chore(STONEO11Y-21): add network egress metric and tests

### DIFF
--- a/prometheus/base/prometheus.rules.yaml
+++ b/prometheus/base/prometheus.rules.yaml
@@ -3,15 +3,16 @@ kind: PrometheusRule
 metadata:
   labels:
     openshift.io/prometheus-rule-evaluation-scope: leaf-prometheus
-  name: o11y-example-rule
+  name: o11y-rules
   namespace: o11y
 spec:
   groups:
-    - name: example
-      rules:
-        - record: appstudio_container_network_transmit_bytes_total
-          expr: |
-            container_network_transmit_bytes_total
-            * on (namespace, pod)
-            group_left (label_pipelines_appstudio_openshift_io_type)
-            kube_pod_labels
+  - name: appstudio-metering
+    interval: 30s
+    rules:
+      - record: appstudio_container_network_transmit_bytes_total
+        expr: |
+          container_network_transmit_bytes_total
+          * on (namespace, pod)
+          group_left (label_pipelines_appstudio_openshift_io_type)
+          kube_pod_labels

--- a/test/promql/tests/test_network.yaml
+++ b/test/promql/tests/test_network.yaml
@@ -1,0 +1,121 @@
+rule_files:
+  - ../extracted-rules.yaml
+
+# interval for evaluating the rules in rule_files
+evaluation_interval: 30s
+
+tests:
+  # Interval for the samples of the series
+  - interval: 30s
+    # Series data
+    input_series:
+
+      - series: 'container_network_transmit_bytes_total{namespace="prod", pod="prod-pod"}'
+        values: '0 1 1 1 4 6 _ _ 8 10 _'
+      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="release", namespace="prod", pod="prod-pod"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+
+      - series: 'container_network_transmit_bytes_total{namespace="prod", pod="pre-prod-pod"}'
+        values: '0 2 2 2 4 5 5 0 4 4 5'
+      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="", namespace="prod", pod="pre-prod-pod"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+
+      - series: 'container_network_transmit_bytes_total{namespace="test", pod="test-pod"}'
+        values: '0 2 2 2 4 5 5 7 8 9 10'
+      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="test", namespace="test", pod="test-pod"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+
+      - series: 'container_network_transmit_bytes_total{namespace="another-test", pod="test-pod"}'
+        values: '0 2 2 2 4 5 5 7 8 9 10'
+      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="test", namespace="another-test", pod="test-pod"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+
+
+    promql_expr_test:
+      # Test the core metric with namespace="prod"
+      # Since the sample at 3m is `_` (no sample), the value we get is the last captured value (6)
+      - expr: appstudio_container_network_transmit_bytes_total{namespace="prod"}
+        # The time the query is evaluated
+        eval_time: 3m
+        exp_samples:
+        - labels: 'appstudio_container_network_transmit_bytes_total{namespace="prod", pod="prod-pod", label_pipelines_appstudio_openshift_io_type="release"}'
+          value: 6
+        - labels: 'appstudio_container_network_transmit_bytes_total{namespace="prod", pod="pre-prod-pod"}'
+          value: 5
+
+      # Test the core metric with namespace="test"
+      - expr: appstudio_container_network_transmit_bytes_total{namespace="test"}
+        eval_time: 4m
+        exp_samples:
+        - labels: 'appstudio_container_network_transmit_bytes_total{namespace="test", pod="test-pod", label_pipelines_appstudio_openshift_io_type="test"}'
+          value: 8
+
+      # Test the core metric with namespace="another-test"
+      - expr: appstudio_container_network_transmit_bytes_total{namespace="another-test"}
+        eval_time: 4m
+        exp_samples:
+        - labels: 'appstudio_container_network_transmit_bytes_total{namespace="another-test", pod="test-pod", label_pipelines_appstudio_openshift_io_type="test"}'
+          value: 8
+
+      # Test the increase in the last 4 minutes after 5 minutes of samples, filtered by namespace="prod"
+      - expr: increase(appstudio_container_network_transmit_bytes_total{namespace="prod"}[4m])
+        eval_time: 5m
+        exp_samples:
+        # We have 2 results:
+        #    one for the results that includes the label_pipelines_appstudio_openshift_io_type="release"
+        #    and one for label_pipelines_appstudio_openshift_io_type=""
+        #
+        # The increase function range is [5m-4m] to [5m]
+        # Since the sample in 5m is `_` we get the last captured value (10)
+        # so the increase between 1 and 10 is 9
+        - labels: '{namespace="prod", pod="prod-pod", label_pipelines_appstudio_openshift_io_type="release"}'
+          value: 9
+
+        # In the middle of the samples we collected a 0 sample and the count was reset.
+        # In this case, the `increase` function knows to handle resets by comparing
+        # the values to the previous values, if the value is lower than the value before,
+        # the value is added to the previous value and the counter continues.
+        # In our example. we have:
+        # values: '0 2 2 2 4 5 5 0 4 4 5'
+        # When increase detects the reset (0, followed by 4), it adds the (0) to the last count and increase all
+        # the values afterwards so '0 2 2 2 4 5 5 0 4 4 5' becomes '0 2 2 2 4 5 5 5 9 9 10'
+        - labels: '{namespace="prod", pod="pre-prod-pod"}'
+          value: 8
+
+      # Test the sum by namespace of the increase in the last 4 minutes after 5 minutes of samples
+      # Basically that's the total amount of bytes transmitted in the last 4 minutes by namespace
+      - expr: sum(increase(appstudio_container_network_transmit_bytes_total[4m])) by (namespace)
+        eval_time: 5m
+        exp_samples:
+        - labels: '{namespace="prod"}'
+          value: 17
+        - labels: '{namespace="test"}'
+          value: 8
+        - labels: '{namespace="another-test"}'
+          value: 8
+
+      # Test the sum by label_pipelines_appstudio_openshift_io_type of the increase in the last 4 minutes after 5 minutes of samples
+      # Basically that's the total amount of bytes transmitted in the last 4 minutes by label_pipelines_appstudio_openshift_io_type
+      - expr: sum(increase(appstudio_container_network_transmit_bytes_total[4m])) by (label_pipelines_appstudio_openshift_io_type)
+        eval_time: 5m
+        exp_samples:
+        - labels: '{label_pipelines_appstudio_openshift_io_type="test"}'
+          value: 16
+        - labels: '{label_pipelines_appstudio_openshift_io_type="release"}'
+          value: 9
+        - labels: '{}'
+          value: 8
+
+      # Test the total amount of bytes transmitted in the last 4 minutes by label_pipelines_appstudio_openshift_io_type="test"
+      - expr: sum(increase(appstudio_container_network_transmit_bytes_total{label_pipelines_appstudio_openshift_io_type="test"}[4m]))
+        eval_time: 5m
+        exp_samples:
+        - labels: '{}'
+          value: 16
+
+      # Test the total amount of bytes transmitted in the last 4 minutes by label_pipelines_appstudio_openshift_io_type that has value in
+      - expr: sum(increase(appstudio_container_network_transmit_bytes_total{label_pipelines_appstudio_openshift_io_type!=""}[4m]))
+        eval_time: 5m
+        exp_samples:
+        - labels: '{}'
+          value: 25


### PR DESCRIPTION
# add network egress metric

This PR is for adding metric in the rule file that will assist us in getting the network egress (transmit)  
of all the containers, and to filter them by namespace or pipeline type

## Adding a rule file

Adding a rule file with a `container_network_transmit_bytes_total` metric and attach the `label_pipelines_appstudio_openshift_io_type` to the result. 

This way we will be able to filter our results both by `namespace` and `label_pipelines_appstudio_openshift_io_type`  
The new metric is called `appstudio_container_network_transmit_bytes_total`

## Query examples:
- To get the total amount of transmitted bytes in the last day, filtering by namespace:
`sum(increase(appstudio_container_network_transmit_bytes_total[1d])) by (namespace)`

- To get the total amount of transmitted bytes in the last day, filtering by pipeline type:
`sum(increase(appstudio_container_network_transmit_bytes_total[1d])) by (label_pipelines_appstudio_openshift_io_type)`

- These can also be used with the `@` operator to the query to query it at a specific timestamp:
`sum(increase(appstudio_container_network_transmit_bytes_total[1d] @ 1678210200)) by (namespace)`
