### PR TITLE
test(STONEO11Y-52): run promtool linter in ci

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -37,7 +37,7 @@ spec:
         taskRef:
           bundle: quay.io/redhat-appstudio/appstudio-tasks:510fa6e99f1fa1f816c96354bbaf1ad155c6d9c3-1
           name: git-clone
-      - name: run-tests
+      - name: prepare-for-prometheus-tests
         workspaces:
           - name: workspace
             workspace: workspace
@@ -49,7 +49,36 @@ spec:
           steps:
             - name: run-tests
               image: registry.access.redhat.com/ubi8/ubi:latest
-              script: cd $(workspaces.workspace.path) && ./automation/test.sh
+              workingDir: $(workspaces.workspace.path)
+              script: ./automation/promtool_tests.sh prepare
+      - name: run-prometheus-rules-unit-tests
+        workspaces:
+          - name: workspace
+            workspace: workspace
+        runAfter:
+          - prepare-for-prometheus-tests
+        taskSpec:
+          workspaces:
+            - name: workspace
+          steps:
+            - name: run-tests
+              image: registry.access.redhat.com/ubi8/ubi:latest
+              workingDir: $(workspaces.workspace.path)
+              script: ./automation/promtool_tests.sh test_rules
+      - name: run-prometheus-rules-lint-tests
+        workspaces:
+          - name: workspace
+            workspace: workspace
+        runAfter:
+          - prepare-for-prometheus-tests
+        taskSpec:
+          workspaces:
+            - name: workspace
+          steps:
+            - name: run-tests
+              image: registry.access.redhat.com/ubi8/ubi:latest
+              workingDir: $(workspaces.workspace.path)
+              script: ./automation/promtool_tests.sh lint
       - name: run-gitlint
         params:
           - name: target-branch

--- a/test/promql/tests/example.yaml
+++ b/test/promql/tests/example.yaml
@@ -7,15 +7,15 @@ tests:
   # base query - query will be made by the rule
   - interval: 30s
     input_series:
-        - series: 'container_network_transmit_bytes_total{namespace="mynamespace", pod="mypod"}'
-          values: '0 1 2 3 4 5 6 7 8 9 10'
-        - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="mypipe", namespace="mynamespace", pod="mypod"}'
-          values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'container_network_transmit_bytes_total{namespace="mynamespace", pod="mypod"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10'
+      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="mypipe", namespace="mynamespace", pod="mypod"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
 
     # Unit tests for promql expressions.
     promql_expr_test:
-        - expr: appstudio_container_network_transmit_bytes_total
-          eval_time: 4m
-          exp_samples:
-          - labels: 'appstudio_container_network_transmit_bytes_total{namespace="mynamespace", pod="mypod", label_pipelines_appstudio_openshift_io_type="mypipe"}'
-            value: 8
+      - expr: appstudio_container_network_transmit_bytes_total
+        eval_time: 4m
+        exp_samples:
+        - labels: 'appstudio_container_network_transmit_bytes_total{namespace="mynamespace", pod="mypod", label_pipelines_appstudio_openshift_io_type="mypipe"}'
+          value: 8

--- a/test/promql/tests/example2.yaml
+++ b/test/promql/tests/example2.yaml
@@ -11,11 +11,11 @@ tests:
           - series: 'up{job="prometheus", instance="localhost:9090"}'
             values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
           - series: 'up{job="node_exporter", instance="localhost:9100"}'
-            values: '1+0x6 0 0 0 0 0 0 0 0' # 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0
+            values: '1+0x6 0 0 0 0 0 0 0 0'  # 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0
           - series: 'go_goroutines{job="prometheus", instance="localhost:9090"}'
-            values: '10+10x2 30+20x5' # 10 20 30 30 50 70 90 110 130
+            values: '10+10x2 30+20x5'  # 10 20 30 30 50 70 90 110 130
           - series: 'go_goroutines{job="node_exporter", instance="localhost:9100"}'
-            values: '10+10x7 10+30x4' # 10 20 30 40 50 60 70 80 10 40 70 100 130
+            values: '10+10x7 10+30x4'  # 10 20 30 40 50 60 70 80 10 40 70 100 130
 
       # Unit tests for promql expressions.
       promql_expr_test:


### PR DESCRIPTION
Change the test script to support also lint tests, and have the CI
trigger it once for testing the rules and once for test linting.

Depends on #9 