### PR TITLE
fix(STONEO11Y-55): change git fetch command used before gitlint

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -31,6 +31,8 @@ spec:
             value: $(params.git-url)
           - name: revision
             value: $(params.revision)
+          - name: depth
+            value: 20
         workspaces:
           - name: output
             workspace: workspace
@@ -101,8 +103,8 @@ spec:
                 #!/bin/bash -ex
 
                 python -m pip install gitlint
-                git fetch --unshallow
-                gitlint --commits "origin/$(params.target-branch)..HEAD"
+                git fetch origin "$(params.target-branch)"
+                gitlint --fail-without-commits --commits "origin/$(params.target-branch)..HEAD"
       - name: yaml-lint
         workspaces:
           - name: workspace


### PR DESCRIPTION
Using the default depth of 1 required using unshallow later on.
This introduced flakiness as sometimes an error appears for
shallow file has changed since we read it.

With this change, we specifically fetch the target remote branch
and increase the depth of the PR branch which hopefully together
will work around the flakiness.