### PR TITLE
chore(STONEO11Y-61): add makefile

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -50,7 +50,7 @@ spec:
             - name: run-tests
               image: registry.access.redhat.com/ubi8/ubi:latest
               workingDir: $(workspaces.workspace.path)
-              script: ./automation/promtool_tests.sh prepare
+              script: yum install -y make && make prepare
       - name: run-prometheus-rules-unit-tests
         workspaces:
           - name: workspace
@@ -64,7 +64,7 @@ spec:
             - name: run-tests
               image: registry.access.redhat.com/ubi8/ubi:latest
               workingDir: $(workspaces.workspace.path)
-              script: ./automation/promtool_tests.sh test_rules
+              script: yum install -y make && make test_rules
       - name: run-prometheus-rules-lint-tests
         workspaces:
           - name: workspace
@@ -78,7 +78,7 @@ spec:
             - name: run-tests
               image: registry.access.redhat.com/ubi8/ubi:latest
               workingDir: $(workspaces.workspace.path)
-              script: ./automation/promtool_tests.sh lint
+              script: yum install -y make && make lint
       - name: lint-prometheus-rules
         workspaces:
           - name: workspace
@@ -92,7 +92,7 @@ spec:
             - name: lint-rules
               image: registry.access.redhat.com/ubi8/ubi:latest
               workingDir: $(workspaces.workspace.path)
-              script: ./automation/pint_lint.sh
+              script: yum install -y make && make pint
       - name: run-gitlint
         params:
           - name: target-branch

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: all
+all: prepare lint test_rules
+
+.PHONY: prepare
+prepare:
+	./automation/promtool_tests.sh prepare
+
+.PHONY: lint
+lint:
+	./automation/promtool_tests.sh lint
+
+.PHONY: test_rules
+test_rules:
+	./automation/promtool_tests.sh test_rules
+
+.PHONY: pint
+pint:
+	./automation/pint_lint.sh


### PR DESCRIPTION
Run tests using makefile. This will allow developers running test prep steps together with the tests themselves using `make all`.