### PR TITLE
chore(STONEO11Y-63): Add pint to gitignore & install in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 promtool
 yq
 test/promql/extracted-rules.yaml
+pint

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -94,7 +94,7 @@ spec:
             - name: lint-rules
               image: registry.access.redhat.com/ubi8/ubi:latest
               workingDir: $(workspaces.workspace.path)
-              script: yum install -y make && make pint
+              script: yum install -y make && make pint_lint
       - name: run-gitlint
         params:
           - name: target-branch

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
+PINT_VERSION='0.42.2'
+
 .PHONY: all
-all: prepare lint test_rules
+all: prepare lint test_rules pint_lint
 
 .PHONY: prepare
-prepare:
+prepare: pint
 	./automation/promtool_tests.sh prepare
 
 .PHONY: lint
@@ -13,6 +15,13 @@ lint:
 test_rules:
 	./automation/promtool_tests.sh test_rules
 
-.PHONY: pint
 pint:
+	echo 'Installing pint...'
+	curl -OJL 'https://github.com/cloudflare/pint/releases/download/v${PINT_VERSION}/pint-${PINT_VERSION}-linux-amd64.tar.gz'
+	tar xvzf 'pint-${PINT_VERSION}-linux-amd64.tar.gz' pint-linux-amd64
+	mv pint-linux-amd64 pint
+	rm 'pint-${PINT_VERSION}-linux-amd64.tar.gz'	
+	
+.PHONY: pint_lint
+pint_lint:	
 	./automation/pint_lint.sh

--- a/automation/pint_lint.sh
+++ b/automation/pint_lint.sh
@@ -3,18 +3,8 @@
 main() {
     local extracted_rule_file=test/promql/extracted-rules.yaml
     
-    install_pint
-
     echo "Linting Prometheus rules..."
     ./pint --no-color lint $extracted_rule_file
-}
-
-install_pint() {
-    echo "Installing pint..."
-    VERSION="0.42.1"
-    curl -OJL "https://github.com/cloudflare/pint/releases/download/v${VERSION}/pint-$VERSION-linux-amd64.tar.gz"     
-    tar xvzf pint-$VERSION-linux-amd64.tar.gz pint-linux-amd64 && mv pint-linux-amd64 pint
-    rm pint-$VERSION-linux-amd64.tar.gz
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then


### PR DESCRIPTION
* pint installation have being moved from `pint_lint` to the Makefile. This saves a check if pint is already installed.

* Added pint to .gitignore

* Added pint to the makefile `all` target