### PR TITLE
fix(STONEO11Y-86): change namespace on which prom rules are deployed

### DIFF
--- a/prometheus/base/prometheus.rules.yaml
+++ b/prometheus/base/prometheus.rules.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     openshift.io/prometheus-rule-evaluation-scope: leaf-prometheus
   name: o11y-rules
-  namespace: o11y
+  namespace: openshift-user-workload-monitoring
 spec:
   groups:
     - name: appstudio-container-labeling


### PR DESCRIPTION
Prometheus rules were deployed on namespace o11y, but this way they are not being loaded by Prometheus. Here we change the namespace to be openshift-user-workload-monitoring so that they are picked up and evaluated