### PR TITLE
chore(STONEO11Y-99): Alerting rule for Pods Not Ready

### DIFF
--- a/prometheus/base/alerting/prometheus.pod_alerts.yaml
+++ b/prometheus/base/alerting/prometheus.pod_alerts.yaml
@@ -25,3 +25,13 @@ spec:
       annotations:
         summary: "Pod {{ $labels.pod }} is crash looping"
         description: "Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is in waiting state (reason: 'CrashLoopBackOff') for more than 15 minutes."
+    - alert: PodsNotReady
+      expr: |
+            kube_pod_status_phase{phase=~"Pending|Unknown|Failed", namespace!~"(.*-tenant|openshift-.*|kube-.*|default)"} == 1
+            unless ignoring (phase) (kube_pod_status_unschedulable == 1)
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Pod {{ $labels.pod }} is not ready"
+        description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} is not ready for more than 15 minutes."

--- a/test/promql/tests/test_notready_pods.yaml
+++ b/test/promql/tests/test_notready_pods.yaml
@@ -1,0 +1,167 @@
+evaluation_interval: 1m
+
+rule_files:
+  - ../extracted-rules.yaml
+
+tests:
+  - interval: 1m
+    input_series:
+      # Alerted cases:
+      # Pod is in the Pending state and scheduled, so it will be alerted.
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-1", phase="Pending"}'
+        values: '1x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-1", phase="Unknown"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-1", phase="Failed"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-1", phase="Running"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-1", phase="Succeeded"}'
+        values: '0x14'
+      - series: 'kube_pod_status_unschedulable{namespace="ns-1", pod="pod-1"}'
+        values: '0x14'
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: PodsNotReady
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              namespace: ns-1
+              pod: pod-1
+              phase: Pending
+            exp_annotations:
+              summary: "Pod pod-1 is not ready"
+              description: "Pod pod-1 in namespace ns-1 is not ready for more than 15 minutes."
+
+  - interval: 1m
+    input_series:
+      # Pod is in the Unknown state and scheduled, so it will be alerted.
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-2", phase="Pending"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-2", phase="Unknown"}'
+        values: '1x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-2", phase="Failed"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-2", phase="Running"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-2", phase="Succeeded"}'
+        values: '0x14'
+      - series: 'kube_pod_status_unschedulable{namespace="ns-2", pod="pod-1"}'
+        values: '0x14'
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: PodsNotReady
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              namespace: ns-2
+              pod: pod-1
+              phase: Unknown
+            exp_annotations:
+              summary: "Pod pod-1 is not ready"
+              description: "Pod pod-1 in namespace ns-2 is not ready for more than 15 minutes."
+
+  - interval: 1m
+    input_series:
+      # Pod is in the Failed state and scheduled, so it will be alerted.
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-3", phase="Pending"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-3", phase="Unknown"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-3", phase="Failed"}'
+        values: '1x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-3", phase="Running"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-3", phase="Succeeded"}'
+        values: '0x14'
+      - series: 'kube_pod_status_unschedulable{namespace="ns-3", pod="pod-1"}'
+        values: '0x14'
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: PodsNotReady
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              namespace: ns-3
+              pod: pod-1
+              phase: Failed
+            exp_annotations:
+              summary: "Pod pod-1 is not ready"
+              description: "Pod pod-1 in namespace ns-3 is not ready for more than 15 minutes."
+
+  - interval: 1m
+    input_series:
+      # Not Alerted cases:
+
+      # Pod is in the Unknown state and unscheduled (unscheduled once in the 15 min
+      # interval), so it will not be alerted.
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-4", phase="Pending"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-4", phase="Unknown"}'
+        values: '1x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-4", phase="Failed"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-4", phase="Running"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-4", phase="Succeeded"}'
+        values: '0x14'
+      - series: 'kube_pod_status_unschedulable{namespace="ns-4", pod="pod-1"}'
+        values: '1x0 0x13'
+
+      # Pod is in Succeeded state and scheduled, so it will not be alerted.
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-5", phase="Pending"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-5", phase="Unknown"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-5", phase="Failed"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-5", phase="Running"}'
+        values: '0x14'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-5", phase="Succeeded"}'
+        values: '1x14'
+      - series: 'kube_pod_status_unschedulable{namespace="ns-5", pod="pod-1"}'
+        values: '0x14'
+
+      # Pod is in the Running state for the first 14 min, then it's in the Failed state
+      # for the last 1 min and unscheduled, so it will not be alerted.
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-7", phase="Running"}'
+        values: '1x13 0'
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-7", phase="Failed"}'
+        values: '0x13 1'
+      - series: 'kube_pod_status_unschedulable{namespace="ns-7", pod="pod-1"}'
+        values: '0x14'
+
+      # Pod is in the Failed state and scheduled, but it has a namespace that ends
+      # with 'tenant' so it's ignored.
+      - series: 'kube_pod_status_phase{pod="pod-1", namespace="prod-tenant", phase="Failed"}'
+        values: '1x14'
+      - series: 'kube_pod_status_unschedulable{namespace="prod-tenant", pod="pod-1"}'
+        values: '0x14'
+
+      # Pod is in the Pending state and scheduled, but it has a namespace that starts
+      # with 'openshift' so it's ignored.
+      - series: 'kube_pod_status_phase{pod="pod-2", namespace="openshift-prod-test", phase="Pending"}'
+        values: '1x14'
+      - series: 'kube_pod_status_unschedulable{namespace="openshift-prod-test", pod="pod-2"}'
+        values: '0x14'
+
+      # Pod is in the Pending state and scheduled, but it has a namespace that starts
+      # with 'kube' so it's ignored.
+      - series: 'kube_pod_status_phase{pod="pod-3", namespace="kube-test", phase="Unknown"}'
+        values: '1x14'
+      - series: 'kube_pod_status_unschedulable{namespace="kube-test", pod="pod-3"}'
+        values: '0x14'
+
+      # Pod is in the Pending state and scheduled, but it has a namespace 'default'
+      # so it's ignored.
+      - series: 'kube_pod_status_phase{pod="pod-4", namespace="default", phase="Failed"}'
+        values: '1x14'
+      - series: 'kube_pod_status_unschedulable{namespace="default", pod="pod-4"}'
+        values: '0x14'
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: PodsNotReady


### PR DESCRIPTION
* Created a new alerting rule for pods not ready.
* Added related unit test cases.