### PR TITLE
chore(RHTAPWATCH-163): Add dashboard linting to o11y CI

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -148,6 +148,20 @@ spec:
               image: registry.access.redhat.com/ubi9/python-39:latest
               workingDir: $(workspaces.workspace.path)
               script: make install_pipenv sync_pipenv lint_yamls
+      - name: run-grafana-dashboard-lint
+        workspaces:
+          - name: workspace
+            workspace: workspace
+        runAfter:
+          - clone-repository
+        taskSpec:
+          workspaces:
+            - name: workspace
+          steps:
+            - name: run-grafana-dashboard-lint
+              image: registry.access.redhat.com/ubi9/go-toolset:latest
+              workingDir: $(workspaces.workspace.path)
+              script: make dashboard_linter lint_grafana_dashboards
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ This section describes the main steps required before you can add your code and 
 * Linux machine with x86-64 architecture with bash installed.
 * Basic tools: curl, tar, make.
 * Python3 and pipenv. (run: `python3 -m pip install pipenv --user`)
+* Go installed. Intructions in Go's [docs](https://go.dev/doc/install)
 
 ### Running the Automated Tests
 1. Clone your fork of the project.
@@ -25,6 +26,7 @@ The following tools are currently used for automated testing within the project:
 * [pint](https://cloudflare.github.io/pint) - PromQL linting
 * [gitlint](https://jorisroovers.com/gitlint/) - commit message linting
 * [yamllint](https://yamllint.readthedocs.io) - YAML linting
+* [dashboard-linter](https://github.com/grafana/dashboard-linter/blob/main/docs/index.md) - Grafana Dashboards linting
 
 ### Unit Tests
 PromQL unit tests are stored in YAML files under [test/promql/tests](test/promql/tests).

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,11 @@ YQ_VERSION = 4.31.2
 EXTRACTED_RULE_FILE = test/promql/extracted-rules.yaml
 RECORDING_RULE_FILES = prometheus/base/recording/*.yaml
 ALERTING_RULE_FILES = prometheus/base/alerting/*.yaml
+GRAFANA_DASHBOARDS = $(shell ls grafana/dashboards) 
+GOPATH = $(shell go env GOPATH)
 
 .PHONY: all
-all: prepare sync_pipenv lint test_rules pint_lint lint_yamls kustomize_build
+all: prepare sync_pipenv lint test_rules pint_lint lint_yamls dashboard_linter lint_grafana_dashboards kustomize_build
 
 .PHONY: prepare
 prepare: pint promtool yq kustomize
@@ -46,6 +48,9 @@ yq:
 kustomize:
 	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
 
+dashboard_linter:
+	go install github.com/grafana/dashboard-linter@v0.0.0-20230531105903-cd7fcaf3bec8
+
 .PHONY: pint_lint
 pint_lint:
 	echo "Linting Prometheus rules..."
@@ -62,6 +67,13 @@ sync_pipenv:
 .PHONY: lint_yamls
 lint_yamls:
 	python3 -m pipenv run yamllint . && echo "lint_yamls: SUCCESS"
+
+.PHONY: lint_grafana_dashboards
+lint_grafana_dashboards:
+	@for dashboard in ${GRAFANA_DASHBOARDS} ; do \
+		echo -e "Linting dashboard $$dashboard\n"; \
+		${GOPATH}/bin/dashboard-linter lint grafana/dashboards/$$dashboard; done
+	@echo
 
 .PHONY: kustomize_build
 kustomize_build:

--- a/grafana/dashboards/.lint
+++ b/grafana/dashboards/.lint
@@ -1,0 +1,5 @@
+exclusions:
+  template-datasource-rule:
+    reason: "We remove the datasource from our json files to get the default datasource."
+  panel-datasource-rule:
+    reason: "We remove the datasource from our json files to get the default datasource."


### PR DESCRIPTION
- Add Grafana dashboard linting for all dashboards in the `grafana/dashboards` directory
- Add a `.lint` file in the `grafana/dashboards` directory with the rules to be excluded in the linting