### PR TITLE
chore(RHTAPWATCH-110): Add "label_app_kubernetes_io_managed_by" label to recording rule

### DIFF
--- a/prometheus/base/recording/prometheus.rules.yaml
+++ b/prometheus/base/recording/prometheus.rules.yaml
@@ -21,7 +21,7 @@ spec:
           expr: |
             {__name__=~"kube_pod_.*container_resource_limits"}
             * on (namespace, pod)
-            group_left(label_pipelines_appstudio_openshift_io_type) kube_pod_labels
+            group_left(label_pipelines_appstudio_openshift_io_type, label_app_kubernetes_io_managed_by) kube_pod_labels
     - name: appstudio-resource-gauge
       interval: 1m
       rules:

--- a/test/promql/tests/resource-min-labeling.yaml
+++ b/test/promql/tests/resource-min-labeling.yaml
@@ -16,7 +16,7 @@ tests:
         values: '0.5x10'
       - series: 'kube_pod_init_container_resource_limits{resource="cpu", namespace="ns1", pod="ns1p1", container="ns1p1c2"}'
         values: '0.5x10'
-      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="t1", namespace="ns1", pod="ns1p1"}'
+      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="t1", label_app_kubernetes_io_managed_by="tekton-pipelines", namespace="ns1", pod="ns1p1"}'
         values: '1x10'
 
       - series: 'kube_pod_container_resource_limits{resource="memory", namespace="ns1", pod="ns1p2", container="ns1p2c1"}'
@@ -29,16 +29,16 @@ tests:
     promql_expr_test:
       # labeled containers and init containers for a specific namespace with specific pipeline type
       - expr: |
-          appstudio_container_resource_limits{namespace="ns1", label_pipelines_appstudio_openshift_io_type="t1"}
+          appstudio_container_resource_limits{namespace="ns1", label_pipelines_appstudio_openshift_io_type="t1", label_app_kubernetes_io_managed_by="tekton-pipelines"}
         eval_time: 4m
         exp_samples:
-          - labels: 'appstudio_container_resource_limits{resource="memory", namespace="ns1", pod="ns1p1", container="ns1p1c1", label_pipelines_appstudio_openshift_io_type="t1"}'
+          - labels: 'appstudio_container_resource_limits{resource="memory", namespace="ns1", pod="ns1p1", container="ns1p1c1", label_pipelines_appstudio_openshift_io_type="t1", label_app_kubernetes_io_managed_by="tekton-pipelines"}'
             value: 2
-          - labels: 'appstudio_container_resource_limits{resource="memory", namespace="ns1", pod="ns1p1", container="ns1p1c2", label_pipelines_appstudio_openshift_io_type="t1"}'
+          - labels: 'appstudio_container_resource_limits{resource="memory", namespace="ns1", pod="ns1p1", container="ns1p1c2", label_pipelines_appstudio_openshift_io_type="t1", label_app_kubernetes_io_managed_by="tekton-pipelines"}'
             value: 2
-          - labels: 'appstudio_container_resource_limits{resource="cpu", namespace="ns1", pod="ns1p1", container="ns1p1c1", label_pipelines_appstudio_openshift_io_type="t1"}'
+          - labels: 'appstudio_container_resource_limits{resource="cpu", namespace="ns1", pod="ns1p1", container="ns1p1c1", label_pipelines_appstudio_openshift_io_type="t1", label_app_kubernetes_io_managed_by="tekton-pipelines"}'
             value: 0.5
-          - labels: 'appstudio_container_resource_limits{resource="cpu", namespace="ns1", pod="ns1p1", container="ns1p1c2", label_pipelines_appstudio_openshift_io_type="t1"}'
+          - labels: 'appstudio_container_resource_limits{resource="cpu", namespace="ns1", pod="ns1p1", container="ns1p1c2", label_pipelines_appstudio_openshift_io_type="t1", label_app_kubernetes_io_managed_by="tekton-pipelines"}'
             value: 0.5
 
       # labeled containers and init containers for a specific namespace without pipeline type

--- a/test/promql/tests/resource-min-sum.yaml
+++ b/test/promql/tests/resource-min-sum.yaml
@@ -19,24 +19,24 @@ tests:
         values: '200+60x10'
       - series: 'container_last_seen{namespace="ns1", pod="ns1p1", container="ns1p1c2"}'
         values: '100+60x10'
-      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="t1", namespace="ns1", pod="ns1p1"}'
+      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="t1", label_app_kubernetes_io_managed_by="tekton-pipelines", namespace="ns1", pod="ns1p1"}'
         values: '1x10'
 
     promql_expr_test:
       - expr: |
-          sum_over_time(appstudio_container_resource_minutes_gauge{resource="memory",label_pipelines_appstudio_openshift_io_type="t1", namespace="ns1"}[10m])
+          sum_over_time(appstudio_container_resource_minutes_gauge{resource="memory",label_pipelines_appstudio_openshift_io_type="t1", label_app_kubernetes_io_managed_by="tekton-pipelines", namespace="ns1"}[10m])
         eval_time: 10m
         exp_samples:
-          - labels: '{resource="memory", namespace="ns1", pod="ns1p1", container="ns1p1c1", label_pipelines_appstudio_openshift_io_type="t1"}'
+          - labels: '{resource="memory", namespace="ns1", pod="ns1p1", container="ns1p1c1", label_pipelines_appstudio_openshift_io_type="t1", label_app_kubernetes_io_managed_by="tekton-pipelines"}'
             value: 20
-          - labels: '{resource="memory", namespace="ns1", pod="ns1p1", container="ns1p1c2", label_pipelines_appstudio_openshift_io_type="t1"}'
+          - labels: '{resource="memory", namespace="ns1", pod="ns1p1", container="ns1p1c2", label_pipelines_appstudio_openshift_io_type="t1", label_app_kubernetes_io_managed_by="tekton-pipelines"}'
             value: 20
 
       - expr: |
-          sum_over_time(appstudio_container_resource_minutes_gauge{resource="cpu",label_pipelines_appstudio_openshift_io_type="t1", namespace="ns1", container="ns1p1c2"}[10m])
+          sum_over_time(appstudio_container_resource_minutes_gauge{resource="cpu",label_pipelines_appstudio_openshift_io_type="t1", label_app_kubernetes_io_managed_by="tekton-pipelines", namespace="ns1", container="ns1p1c2"}[10m])
         eval_time: 10m
         exp_samples:
-          - labels: '{resource="cpu", namespace="ns1", pod="ns1p1", container="ns1p1c2", label_pipelines_appstudio_openshift_io_type="t1"}'
+          - labels: '{resource="cpu", namespace="ns1", pod="ns1p1", container="ns1p1c2", label_pipelines_appstudio_openshift_io_type="t1", label_app_kubernetes_io_managed_by="tekton-pipelines"}'
             value: 5
 
   # container created within the time window and dies after it ends

--- a/test/promql/tests/test_network.yaml
+++ b/test/promql/tests/test_network.yaml
@@ -12,22 +12,22 @@ tests:
 
       - series: 'container_network_transmit_bytes_total{namespace="prod", pod="prod-pod"}'
         values: '0 1 1 1 4 6 _ _ 8 10 _'
-      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="release", namespace="prod", pod="prod-pod"}'
+      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="release", label_app_kubernetes_io_managed_by="tekton-pipelines", namespace="prod", pod="prod-pod"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
 
       - series: 'container_network_transmit_bytes_total{namespace="prod", pod="pre-prod-pod"}'
         values: '0 2 2 2 4 5 5 0 4 4 5'
-      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="", namespace="prod", pod="pre-prod-pod"}'
+      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="", label_app_kubernetes_io_managed_by="tekton-pipelines", namespace="prod", pod="pre-prod-pod"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
 
       - series: 'container_network_transmit_bytes_total{namespace="test", pod="test-pod"}'
         values: '0 2 2 2 4 5 5 7 8 9 10'
-      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="test", namespace="test", pod="test-pod"}'
+      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="test", label_app_kubernetes_io_managed_by="tekton-pipelines", namespace="test", pod="test-pod"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
 
       - series: 'container_network_transmit_bytes_total{namespace="another-test", pod="test-pod"}'
         values: '0 2 2 2 4 5 5 7 8 9 10'
-      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="test", namespace="another-test", pod="test-pod"}'
+      - series: 'kube_pod_labels{label_pipelines_appstudio_openshift_io_type="test", label_app_kubernetes_io_managed_by="tekton-pipelines", namespace="another-test", pod="test-pod"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
 
 
@@ -38,23 +38,23 @@ tests:
         # The time the query is evaluated
         eval_time: 3m
         exp_samples:
-        - labels: 'appstudio_container_network_transmit_bytes_total{namespace="prod", pod="prod-pod", label_pipelines_appstudio_openshift_io_type="release"}'
+        - labels: 'appstudio_container_network_transmit_bytes_total{namespace="prod", pod="prod-pod", label_pipelines_appstudio_openshift_io_type="release", label_app_kubernetes_io_managed_by="tekton-pipelines"}'
           value: 6
-        - labels: 'appstudio_container_network_transmit_bytes_total{namespace="prod", pod="pre-prod-pod"}'
+        - labels: 'appstudio_container_network_transmit_bytes_total{namespace="prod", pod="pre-prod-pod", label_app_kubernetes_io_managed_by="tekton-pipelines"}'
           value: 5
 
       # Test the core metric with namespace="test"
       - expr: appstudio_container_network_transmit_bytes_total{namespace="test"}
         eval_time: 4m
         exp_samples:
-        - labels: 'appstudio_container_network_transmit_bytes_total{namespace="test", pod="test-pod", label_pipelines_appstudio_openshift_io_type="test"}'
+        - labels: 'appstudio_container_network_transmit_bytes_total{namespace="test", pod="test-pod", label_pipelines_appstudio_openshift_io_type="test", label_app_kubernetes_io_managed_by="tekton-pipelines"}'
           value: 8
 
       # Test the core metric with namespace="another-test"
       - expr: appstudio_container_network_transmit_bytes_total{namespace="another-test"}
         eval_time: 4m
         exp_samples:
-        - labels: 'appstudio_container_network_transmit_bytes_total{namespace="another-test", pod="test-pod", label_pipelines_appstudio_openshift_io_type="test"}'
+        - labels: 'appstudio_container_network_transmit_bytes_total{namespace="another-test", pod="test-pod", label_pipelines_appstudio_openshift_io_type="test", label_app_kubernetes_io_managed_by="tekton-pipelines"}'
           value: 8
 
       # Test the increase in the last 4 minutes after 5 minutes of samples, filtered by namespace="prod"
@@ -68,7 +68,7 @@ tests:
         # The increase function range is [5m-4m] to [5m]
         # Since the sample in 5m is `_` we get the last captured value (10)
         # so the increase between 1 and 10 is 9
-        - labels: '{namespace="prod", pod="prod-pod", label_pipelines_appstudio_openshift_io_type="release"}'
+        - labels: '{namespace="prod", pod="prod-pod", label_pipelines_appstudio_openshift_io_type="release", label_app_kubernetes_io_managed_by="tekton-pipelines"}'
           value: 9
 
         # In the middle of the samples we collected a 0 sample and the count was reset.
@@ -79,7 +79,7 @@ tests:
         # values: '0 2 2 2 4 5 5 0 4 4 5'
         # When increase detects the reset (0, followed by 4), it adds the (0) to the last count and increase all
         # the values afterwards so '0 2 2 2 4 5 5 0 4 4 5' becomes '0 2 2 2 4 5 5 5 9 9 10'
-        - labels: '{namespace="prod", pod="pre-prod-pod"}'
+        - labels: '{namespace="prod", pod="pre-prod-pod", label_app_kubernetes_io_managed_by="tekton-pipelines"}'
           value: 8
 
       # Test the sum by namespace of the increase in the last 4 minutes after 5 minutes of samples


### PR DESCRIPTION
* This is a second commit regarding RHTAPWATCH-110, the label "label_app_kubernetes_io_managed_by"
was added to appstudio_container_resource_limits.

* Added test cases.