### PR TITLE
chore(RHTAPWATCH-9): allow recording rules scraping

### DIFF
--- a/prometheus/base/namespaces.yaml
+++ b/prometheus/base/namespaces.yaml
@@ -2,4 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: o11y
+  labels:
+    kubernetes.io/part-of: appstudio-federate-billing-ms
+    monitoring.rhobs/stack: appstudio-federate-billing-ms
 spec: {}

--- a/prometheus/base/recording/prometheus.rules.yaml
+++ b/prometheus/base/recording/prometheus.rules.yaml
@@ -1,8 +1,9 @@
-apiVersion: monitoring.coreos.com/v1
+apiVersion: monitoring.rhobs/v1
 kind: PrometheusRule
 metadata:
   labels:
-    openshift.io/prometheus-rule-evaluation-scope: leaf-prometheus
+    kubernetes.io/part-of: appstudio-federate-billing-ms
+    monitoring.rhobs/stack: appstudio-federate-billing-ms
   name: o11y-recording-rules
   namespace: o11y
 spec:


### PR DESCRIPTION
In order to make the billing monitoring stack Prometheus process our billing recording rules, the Prometheus rule resource needs to have rhobs's apiVersion and the resource and the namespace should have the labels the monitoring stack expects.