### PR TITLE
chore(RHTAPWATCH-327): offboard o11y prometheus rules

### DIFF
--- a/prometheus/base/alerting/kustomization.yaml
+++ b/prometheus/base/alerting/kustomization.yaml
@@ -1,8 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- prometheus.pod_alerts.yaml
-- prometheus.quota_alerts.yaml
-- prometheus.pv_alerts.yaml
-- prometheus.controller_alerts.yaml
-- prometheus.argocd_alerts.yaml

--- a/prometheus/base/kustomization.yaml
+++ b/prometheus/base/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- recording
-- alerting
 - namespaces.yaml

--- a/prometheus/base/recording/kustomization.yaml
+++ b/prometheus/base/recording/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- prometheus.rules.yaml


### PR DESCRIPTION
The Prometheus rules coming from the o11y repo should not be deployed to RHTAP using argoCD. Instead, they are to be deployed using app-interface.

Later on we might want to offboard the o11y component altogether