### PR TITLE
docs(RHTAPWATCH-328): update readme with rules procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,30 @@
 # RHTAP Observability 
 
-This repository contains Prometheus recording rule files and alert rule files for
-observability use, as well as unit tests for these rules.
+This repository is maintained by the RHTAP O11Y team.
 
-## Recording Rules
+The repository contains Prometheus alert rules [files](rhobs/alerting) for monitoring
+RHTAP data plane clusters along with their [tests](test/promql).
 
-- `appstudio_container_network_transmit_bytes_total` collects the network egress of
-containers and adds the `label_pipelines_appstudio_openshift_io_type` label to our
-metric.
+Control plane clusters alert rules are maintained by the same team, but are kept in a
+different
+[repository](https://gitlab.cee.redhat.com/service/app-interface/-/tree/master/resources/stonesoup/argocd-control-plane/monitoring)
 
-- `appstudio_container_resource_limits` collects all the resource limits
-(cpu and memory) for all containers and init_containers, and adds
-the `label_pipelines_appstudio_openshift_io_type` label to the new metric
+## Updating Data Plane Alerts
 
-- `appstudio_container_resource_minutes_gauge` uses the resource limit configured on
-the container, as captured by `appstudio_container_resource_limits`, and transforms it to a
-fixed time window gauge representing the resource-limit per minute multiplied by the
-period the container was alive in that time window.
+Alert rules for data plane clusters are being deployed by app-interface to RHOBS, to where the data plane metrics are also being forwarded. For deploying the alert rules,
+app-interface references the location of the rules together with a git reference -
+branch name or commit hash.
 
-Examples (assuming 1-minute time window)
-- A container lived for the entire minute and had a limit of 0.5 CPU cores --> 0.5 CPU
-minutes.
-- A container lived for 30 seconds within the measured time frame and had a limit of
-2 CPU cores --> 1 CPU minutes.
-This metric is intended to then be summed over the time frame the metric consumer wants
-to measure for.
+It holds separate references to both staging and production RHOBS instances (monitoring
+RHTAP staging and production deployments). For both environments, we maintain the
+reference to the rules as a commit hash (rather than a branch). This means that any
+changes to the rules will not take effect until the references are updated.
 
+Steps for updating the rules:
 
-### Limitations
-
-When a pod contains one or more init_containers that transmit data, only the first
-init_container will be taken into account while the other init_containers and containers
-are ignored from the metric `appstudio_container_network_transmit_bytes_total`
+1. Merge the necessary changes to this repository - alerts and tests.
+2. Update the
+[staging environment](https://gitlab.cee.redhat.com/service/app-interface/-/blob/0486ef164e70259e5b85c46ab749529238368414/data/services/osd-operators/cicd/saas/saas-rhtap-rules.yaml#L35)
+reference in app-interface to the commit hash of the changes you made.
+3. Once merged and ready to be promoted to production, update the
+[production environment](https://gitlab.cee.redhat.com/service/app-interface/-/blob/0486ef164e70259e5b85c46ab749529238368414/data/services/osd-operators/cicd/saas/saas-rhtap-rules.yaml#L39) reference in a similar manner.


### PR DESCRIPTION
The README file was out of date as it was about content revolving around recording rules, which since then were removed from this repo.

This change removes that content and replaces it with instructions for maintaining alert rules.