### PR TITLE
chore(RHTAPWATCH-346 RHTAPWATCH-347): add sop links to 2 pod alerts

### DIFF
--- a/rhobs/alerting/prometheus.pod_alerts.yaml
+++ b/rhobs/alerting/prometheus.pod_alerts.yaml
@@ -15,16 +15,24 @@ spec:
       labels:
         severity: warning
       annotations:
-        summary: "Pod {{ $labels.pod }} cannot be scheduled."
-        description: "Pod {{ $labels.pod }} for namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is unscheduled for more than 30 minutes."
+        summary: Pod {{ $labels.pod }} cannot be scheduled.
+        description: >-
+          Pod {{ $labels.pod }} for namespace {{ $labels.namespace }} on cluster
+          {{ $labels.source_cluster }} is unscheduled for more than 30 minutes.
+          Related SOP:
+          https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-unschedualablePods.md
     - alert: CrashLoopBackOff
       expr: max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace!~"(.*-tenant|openshift-.*|kube-.*|default)"}[5m]) >= 1
       for: 15m
       labels:
         severity: warning
       annotations:
-        summary: "Pod {{ $labels.pod }} is crash looping"
-        description: "Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is in waiting state (reason: 'CrashLoopBackOff') on cluster {{ $labels.source_cluster }} for more than 15 minutes."
+        summary: Pod {{ $labels.pod }} is crash looping
+        description: >-
+          Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is in
+          waiting state (reason: 'CrashLoopBackOff') on cluster
+          {{ $labels.source_cluster }} for more than 15 minutes. Related SOP:
+          https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-crashLoopBackOff.md
     - alert: PodsNotReady
       expr: |
             kube_pod_status_phase{phase=~"Pending|Unknown|Failed", namespace!~"(.*-tenant|openshift-.*|kube-.*|default)"} == 1

--- a/test/promql/tests/test_crashloopbackoff.yaml
+++ b/test/promql/tests/test_crashloopbackoff.yaml
@@ -51,8 +51,12 @@ tests:
               reason: CrashLoopBackOff
               source_cluster: cluster01
             exp_annotations:
-              summary: "Pod prod-pod-2 is crash looping"
-              description: "Pod test-ns/prod-pod-2 (test-container) is in waiting state (reason: 'CrashLoopBackOff') on cluster cluster01 for more than 15 minutes."
+              summary: Pod prod-pod-2 is crash looping
+              description: >-
+                Pod test-ns/prod-pod-2 (test-container) is in waiting state
+                (reason: 'CrashLoopBackOff') on cluster cluster01 for more than 15
+                minutes. Related SOP:
+                https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-crashLoopBackOff.md
           - exp_labels:
               severity: warning
               namespace: prod-ns
@@ -61,5 +65,9 @@ tests:
               reason: CrashLoopBackOff
               source_cluster: cluster02
             exp_annotations:
-              summary: "Pod prod-pod-4 is crash looping"
-              description: "Pod prod-ns/prod-pod-4 (test-container) is in waiting state (reason: 'CrashLoopBackOff') on cluster cluster02 for more than 15 minutes."
+              summary: Pod prod-pod-4 is crash looping
+              description: >-
+                Pod prod-ns/prod-pod-4 (test-container) is in waiting state
+                (reason: 'CrashLoopBackOff') on cluster cluster02 for more than 15
+                minutes. Related SOP:
+                https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-crashLoopBackOff.md

--- a/test/promql/tests/test_unschedulable_pods.yaml
+++ b/test/promql/tests/test_unschedulable_pods.yaml
@@ -45,5 +45,9 @@ tests:
               pod: prod-pod-2
               source_cluster: cluster02
             exp_annotations:
-              summary: "Pod prod-pod-2 cannot be scheduled."
-              description: "Pod prod-pod-2 for namespace prod-test on cluster cluster02 is unscheduled for more than 30 minutes."
+              summary: Pod prod-pod-2 cannot be scheduled.
+              description: >-
+                Pod prod-pod-2 for namespace prod-test on cluster cluster02 is
+                unscheduled for more than 30 minutes.
+                Related SOP:
+                https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-unschedualablePods.md


### PR DESCRIPTION
Adding link to SOPs to alerts CrashLoopBackOff and UnschedulablePods to provide instructions for dealing with those alerts.