### PR TITLE
test: add always firing alert to test pagerduty integration

### DIFF
--- a/rhobs/alerting/always_firing.yaml
+++ b/rhobs/alerting/always_firing.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-always-firing-rule
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: always_firing
+    interval: 1m
+    rules:
+    - alert: AlwaysFiring
+      expr: 1
+      for: 1m
+      labels:
+        severity: info
+        source_cluster: no-cluster
+      annotations:
+        summary: Test alert - please ignore
+        description: Test alert description - please ignore

--- a/test/promql/tests/always_firing_test.yaml
+++ b/test/promql/tests/always_firing_test.yaml
@@ -1,0 +1,18 @@
+evaluation_interval: 1m
+
+rule_files:
+  - always_firing.yaml
+
+tests:
+  - interval: 1m
+    input_series: []
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: AlwaysFiring
+        exp_alerts:
+          - exp_labels:
+              severity: info
+              source_cluster: no-cluster
+            exp_annotations:
+              summary: Test alert - please ignore
+              description: Test alert description - please ignore


### PR DESCRIPTION
Temporarily adding a constant alert in order to test pagerduty integration.