### PR TITLE
chore(RHTAPWATCH-334): Remove the o11y namespace resource definition from the o11y repo

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -53,20 +53,6 @@ spec:
               image: quay.io/rhobs/obsctl-reloader-rules-checker:1.0.4
               workingDir: $(workspaces.workspace.path)
               script: obsctl-reloader-rules-checker -t rhtap -d rhobs/alerting -y -p --tests-dir test/promql/tests
-      - name: test-kustomize-build
-        workspaces:
-          - name: workspace
-            workspace: workspace
-        runAfter:
-          - clone-repository
-        taskSpec:
-          workspaces:
-            - name: workspace
-          steps:
-            - name: kustomize-build
-              image: registry.access.redhat.com/ubi8/ubi:latest
-              workingDir: $(workspaces.workspace.path)
-              script: yum install -y make && make kustomize-build
       - name: run-gitlint
         params:
           - name: target-branch

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ IMG_VERSION=1.0.4
 BASE_CMD=$(CONTAINER_ENGINE) run -v "$(shell pwd):/work" --rm --privileged -t quay.io/rhobs/obsctl-reloader-rules-checker:$(IMG_VERSION) -t rhtap -d rhobs/alerting -y -p
 
 .PHONY: all
-all: check-and-test kustomize-build
+all: check-and-test
 
 .PHONY: check-and-test
 check-and-test:
@@ -19,12 +19,3 @@ check-and-test:
 check:
 	$(BASE_CMD)
 
-kustomize:
-	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
-
-.PHONY: kustomize-build
-kustomize-build: kustomize
-	# This validates that the build command passes and not its output's validity.
-	# It will fail once we have more than one subdirectory, which will prevent us from
-	# adding untested configurations (this target will have to chage when that happens).
-	kustomize build prometheus/* 1>/dev/null

--- a/prometheus/base/kustomization.yaml
+++ b/prometheus/base/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- namespaces.yaml

--- a/prometheus/base/namespaces.yaml
+++ b/prometheus/base/namespaces.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: o11y
-spec: {}


### PR DESCRIPTION
 * The o11y namespace definition and all kustomization files should be removed from the o11y repo
 * The [prometheus/base path](https://github.com/redhat-appstudio/o11y/tree/main/prometheus) should be removed and the kustomize build test should be removed from the makefile and the [CI file](https://github.com/redhat-appstudio/o11y/blob/main/.tekton/pull-request.yaml).
 * kustomize installation should be removed from local tests and CI.