### PR TITLE
feat(RHTAPWATCH-452): Add initial grafana dashboard for SLOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # RHTAP Observability 
 
-This repository is maintained by the RHTAP O11Y team.
+This repository contains the following definitions for RHTAP:
+  * Prometheus alerting rules (deployed to RHOBS)
+  * Grafana dashboards (deployed to AppSRE's Grafana)
+
+## Alerting Rules
 
 The repository contains Prometheus alert rules [files](rhobs/alerting) for monitoring
 RHTAP data plane clusters along with their [tests](test/promql).
 
 Control plane clusters alert rules are maintained by the same team, but are kept in a
 different
-[repository](https://gitlab.cee.redhat.com/service/app-interface/-/tree/master/resources/stonesoup/argocd-control-plane/monitoring)
+[repository](https://gitlab.cee.redhat.com/service/app-interface/-/tree/master/resources/stonesoup/argocd-control-plane/monitoring).
 
-## Updating Data Plane Alerts
+### Updating Data Plane Alerts
 
 Alert rules for data plane clusters are being deployed by app-interface to RHOBS, to where the data plane metrics are also being forwarded. For deploying the alert rules,
 app-interface references the location of the rules together with a git reference -
@@ -28,3 +32,16 @@ Steps for updating the rules:
 reference in app-interface to the commit hash of the changes you made.
 3. Once merged and ready to be promoted to production, update the
 [production environment](https://gitlab.cee.redhat.com/service/app-interface/-/blob/0486ef164e70259e5b85c46ab749529238368414/data/services/osd-operators/cicd/saas/saas-rhtap-rules.yaml#L39) reference in a similar manner.
+
+## Grafana Dashboards
+
+Refer to the app-interface [instructions](
+https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/monitoring.md#visualization-with-grafana)
+to learn how to develop AppSRE dashboards for RHTAP. This repository serves as
+versioned storage for the [dashboard definitions](dashboards/) and nothing more.
+
+## Support
+
+The RHTAP o11y team maintains this repository.
+Reach out to us on our [slack channel](https://redhat-internal.slack.com/archives/C04FDFTF8EB)
+for further assistance.

--- a/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
+++ b/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
@@ -1,0 +1,328 @@
+apiVersion: v1
+data:
+  rhtap-slo-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "RHTAP Service Level Objectives",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 171906,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "",
+          "gridPos": {
+            "h": 3,
+            "w": 20,
+            "x": 0,
+            "y": 0
+          },
+          "id": 31,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "This dashboard shows all SLOs for RHTAP over a specified time window.\n\nSelect a datasource to switch between environments.",
+            "mode": "markdown"
+          },
+          "pluginVersion": "9.3.8",
+          "transparent": true,
+          "type": "text"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 3
+          },
+          "id": 33,
+          "panels": [],
+          "title": "SLO Template",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The objective for the given time window.",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 4
+          },
+          "id": 10,
+          "links": [],
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>SLO Definition</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "9.3.8",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "SLO",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The current measurement for the given time window.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 4
+          },
+          "id": 6,
+          "links": [],
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.3.8",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Measured",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The remaining error budget for the given time window.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 15,
+            "y": 4
+          },
+          "id": 29,
+          "links": [],
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.3.8",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Error Budget (%)",
+          "type": "stat"
+        }
+      ],
+      "schemaVersion": 37,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": true,
+              "text": "rhtap-observatorium-production",
+              "value": "rhtap-observatorium-production"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "queryValue": "",
+            "refresh": 1,
+            "regex": "/^rhtap-/",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-28d",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "",
+      "title": "RHTAP SLOs",
+      "uid": "rhtap-slos",
+      "version": 1,
+      "weekStart": ""
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: grafana-dashboard-rhtap-slos
+  labels:
+    grafana_dashboard: "true"
+  annotations:
+    grafana-folder: /grafana-dashboard-definitions/RHTAP


### PR DESCRIPTION
app-interface will be configured to pull the dashboard ConfigMaps from the dashboards/ directory and deploy them to AppSRE's grafana.

Other teams are expected to update this dashboard as they contribute SLOs. The barebones version looks like this:
![image](https://github.com/redhat-appstudio/o11y/assets/22659204/d964c867-f385-401f-94f6-5f65378adc9d)