### PR TITLE
chore(DEVHAS-452): Add visualization for application deletion SLO

### DIFF
--- a/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
+++ b/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
@@ -28,7 +28,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 171906,
+      "id": 174751,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -66,6 +66,137 @@ data:
             "x": 0,
             "y": 3
           },
+          "id": 35,
+          "panels": [],
+          "title": "Application Deletion SLO",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The objective for the given time window.",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 4
+          },
+          "id": 36,
+          "links": [],
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>99% of application deletions must succeed</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "9.3.8",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Application Deletion SLO",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The current measurement for the given time window.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "noValue": "-",
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 0
+                  },
+                  {
+                    "color": "green",
+                    "value": 99
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 4
+          },
+          "id": 37,
+          "links": [],
+          "maxDataPoints": 100,
+          "options": {
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false
+          },
+          "pluginVersion": "9.3.8",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "1-sum(increase(has_application_failed_deletion_total[$__range]))\n/\nsum(increase(has_application_deletion_total[$__range]))",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Measured",
+          "type": "gauge"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 11
+          },
           "id": 33,
           "panels": [],
           "title": "SLO Template",
@@ -81,7 +212,7 @@ data:
             "h": 7,
             "w": 10,
             "x": 0,
-            "y": 4
+            "y": 12
           },
           "id": 10,
           "links": [],
@@ -150,7 +281,7 @@ data:
             "h": 7,
             "w": 5,
             "x": 10,
-            "y": 4
+            "y": 12
           },
           "id": 6,
           "links": [],
@@ -225,7 +356,7 @@ data:
             "h": 7,
             "w": 5,
             "x": 15,
-            "y": 4
+            "y": 12
           },
           "id": 29,
           "links": [],


### PR DESCRIPTION
This PR adds a very basic visualization of the Application Deletion SLO: [99% of deleted applications must succeed](https://docs.google.com/document/d/1OVVZeCmv6o2qsZ1BhPaVPVzkJSa8cxLAN5ImF1eugOE/edit#bookmark=id.xouxmpbq76k4) to the Grafana dashboard. 

<img width="1077" alt="Screenshot 2023-09-08 at 10 44 11 AM" src="https://github.com/redhat-appstudio/o11y/assets/6880023/f87c18ab-0c58-4a57-b045-996f153aa0ab">
