### PR TITLE
fix: add positive for-value to progressing argo app rule

### DIFF
--- a/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
+++ b/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
@@ -24,10 +24,10 @@ spec:
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
     - alert: ProgressingArgocdApp
       expr: |
-        max_over_time(argocd_app_info{health_status="Progressing", dest_namespace!~".+-tenant"}[20m]) == 1
+        max_over_time(argocd_app_info{health_status="Progressing", dest_namespace!~".+-tenant"}[19m]) == 1
         unless ignoring (health_status)
-        max_over_time(argocd_app_info{health_status!="Progressing", dest_namespace!~".+-tenant"}[20m]) == 1
-      for: 0m
+        max_over_time(argocd_app_info{health_status!="Progressing", dest_namespace!~".+-tenant"}[19m]) == 1
+      for: 1m
       labels:
         severity: medium
         team: rhtap


### PR DESCRIPTION
It seems as the ProgressingArgocdApp rule is not loaded correctly to RHOBS due to the for field set to 0m. Setting it to 1m to work around that.