### PR TITLE
fix(RHTAPWATCH-523): control plane alerts unsupported severity

### DIFF
--- a/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
+++ b/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
@@ -13,7 +13,7 @@ spec:
       expr: last_over_time(argocd_app_info{health_status="Degraded"}[2m]) == 1
       for: 5m
       labels:
-        severity: medium
+        severity: warning
         team: rhtap
       annotations:
         message: |
@@ -29,7 +29,7 @@ spec:
         max_over_time(argocd_app_info{health_status!="Progressing", dest_namespace!~".+-tenant"}[19m]) == 1
       for: 1m
       labels:
-        severity: medium
+        severity: warning
         team: rhtap
       annotations:
         message: |-

--- a/test/promql/tests/control_plane/argocd_test.yaml
+++ b/test/promql/tests/control_plane/argocd_test.yaml
@@ -41,7 +41,7 @@ tests:
         alertname: DegradedArgocdApp
         exp_alerts:
           - exp_labels:
-              severity: medium
+              severity: warning
               dest_server: https://api.foo.openshiftapps.com:6443
               dest_namespace: degraded
               health_status: Degraded
@@ -57,7 +57,7 @@ tests:
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
 
           - exp_labels:
-              severity: medium
+              severity: warning
               dest_server: https://api.foo.openshiftapps.com:6443
               dest_namespace: flapping-1m
               health_status: Degraded
@@ -73,7 +73,7 @@ tests:
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
 
           - exp_labels:
-              severity: medium
+              severity: warning
               dest_server: https://api.foo.openshiftapps.com:6443
               dest_namespace: flapping-2m
               health_status: Degraded
@@ -111,7 +111,7 @@ tests:
         alertname: ProgressingArgocdApp
         exp_alerts:
           - exp_labels:
-              severity: medium
+              severity: warning
               dest_server: https://api.foo.openshiftapps.com:6443
               dest_namespace: Still-Progressing
               health_status: Progressing
@@ -181,7 +181,7 @@ tests:
         alertname: ProgressingArgocdApp
         exp_alerts:
           - exp_labels:
-              severity: medium
+              severity: warning
               dest_server: https://api.foo.openshiftapps.com:6443
               dest_namespace: Progressing_first
               health_status: Progressing


### PR DESCRIPTION
The control plane alerts contained severity `medium` which is not one of the values supported by PagerDuty, which caused errors in RHOBS. This change addresses that.