### PR TITLE
chore(RHTAPWATCH-518): create grafana probe namespace

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -52,7 +52,9 @@ spec:
             - name: check-and-test-all
               image: quay.io/rhobs/obsctl-reloader-rules-checker:1.0.4
               workingDir: $(workspaces.workspace.path)
-              script: yum install -y make && CMD=obsctl-reloader-rules-checker make all
+              script: |
+                yum install -y make && \
+                CMD=obsctl-reloader-rules-checker make check-and-test
       - name: run-gitlint
         params:
           - name: target-branch
@@ -78,6 +80,20 @@ spec:
                 git config --global --add safe.directory '*'
                 git fetch origin "$(params.target-branch)"
                 gitlint --fail-without-commits --commits "origin/$(params.target-branch)..HEAD"
+      - name: test-kustomize-build
+        workspaces:
+          - name: workspace
+            workspace: workspace
+        runAfter:
+          - clone-repository
+        taskSpec:
+          workspaces:
+            - name: workspace
+          steps:
+            - name: kustomize-build
+              image: registry.access.redhat.com/ubi8/ubi:latest
+              workingDir: $(workspaces.workspace.path)
+              script: yum install -y make && make kustomize-build
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,17 @@ CMD := ${BASE_CMD}
 endif
 
 .PHONY: all
-all: check-and-test
+all: check-and-test kustomize-build
+
+kustomize:
+	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
 
 .PHONY: check-and-test
 check-and-test:
 	$(CMD) -t rhtap -d rhobs/alerting/data_plane -y -p --tests-dir test/promql/tests/data_plane
 	$(CMD) -t rhtap -d rhobs/alerting/control_plane -y -p --tests-dir test/promql/tests/control_plane
+
+.PHONY: kustomize-build
+kustomize-build: kustomize
+	# This validates that the build command passes and not its output's validity.
+	kustomize build config/probes/monitoring/grafana/base 1>/dev/null

--- a/config/probes/monitoring/grafana/base/kustomization.yaml
+++ b/config/probes/monitoring/grafana/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/config/probes/monitoring/grafana/base/namespace.yaml
+++ b/config/probes/monitoring/grafana/base/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: appstudio-probe-monitoring-grafana
+spec: {}


### PR DESCRIPTION
Create a namespace to be used by a probe that will monitor the Grafana deployment.

This is how the namespace will be used: https://github.com/redhat-appstudio/infra-deployments/pull/2454