### PR TITLE
chore(RHTAPWATCH-518): modify file changed on push

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -14,7 +14,7 @@ spec:
     value: '{{revision}}'
   - name: infra-deployment-update-script
     value: |
-        sed -i -e 's|\(https://github.com/redhat-appstudio/o11y/.*?ref=\)\(.*\)|\1{{ revision }}|' components/o11y/base/kustomization.yaml
+        sed -i -e 's|\(https://github.com/redhat-appstudio/o11y/.*?ref=\)\(.*\)|\1{{ revision }}|' components/monitoring/grafana/base/kustomization.yaml
   pipelineSpec:
     params:
     - name: git-url


### PR DESCRIPTION
We had a tekton pipeline running on push that was used for updating a reference in infra-deployments that does not exist anymore. This change have it pointing to a new path which now needs to be updated.