### PR TITLE
chore(DEVHAS-481): Add alerting rules for the Application creation SLO

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.application_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.application_alerts.yaml
@@ -11,10 +11,9 @@ spec:
     rules:
     - alert: ApplicationDeletionErrors
       expr: |
-        (sum(increase(has_application_failed_deletion_total[1h]))
-        by(namespace, pod, source_cluster) /
-        sum(increase(has_application_deletion_total[1h]))
-        by(namespace, pod, source_cluster)) > 0.01
+        (increase(has_application_failed_deletion_total[1h]))
+        /
+        (increase(has_application_deletion_total[1h]))  > 0.01
       for: 5m
       labels:
         severity: warning
@@ -26,4 +25,21 @@ spec:
           Application controller in Pod {{ $labels.pod }} for namespace
           {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
           successfully delete at least 99% of applications over the past hour
+        runbook_url: TBD
+    - alert: ApplicationCreationErrors
+      expr: |
+        (increase(has_application_failed_creation_total[1h]))
+        /
+        (increase(has_application_creation_total[1h])) > 0.05
+      for: 5m
+      labels:
+        severity: warning
+        slo: true
+      annotations:
+        summary: >-
+          HAS is experiencing application creation failures of >5%
+        description: >-
+          Application controller in Pod {{ $labels.pod }} for namespace
+          {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
+          successfully create at least 95% of applications over the past hour
         runbook_url: TBD

--- a/test/promql/tests/data_plane/application_errors_test.yaml
+++ b/test/promql/tests/data_plane/application_errors_test.yaml
@@ -4,7 +4,7 @@ rule_files:
   - prometheus.application_alerts.yaml
 
 tests:
-  # Alerted cases:
+  # ----- Application Deletion Alerting Tests -----
   - interval: 1m
     input_series:
 
@@ -101,3 +101,86 @@ tests:
     alert_rule_test:
       - eval_time: 65m
         alertname: ApplicationDeletionErrors
+
+  # ----- Application Creation Alerting Tests -----
+  - interval: 1m
+    input_series:
+
+      # HAS is experiencing application creation failure rate of 100%, so it will be alerted
+      - series: 'has_application_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '1+1x64'
+      - series: 'has_application_failed_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '1+1x64'
+
+    alert_rule_test:
+      - eval_time: 65m
+        alertname: ApplicationCreationErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: true
+              namespace: application-service
+              pod: has
+              source_cluster: cluster01
+            exp_annotations:
+              summary: >-
+                HAS is experiencing application creation failures of >5%
+              description: >-
+                Application controller in Pod has for namespace
+                application-service on cluster cluster01 is failing to
+                successfully create at least 95% of applications over the past hour
+              runbook_url: TBD
+
+  - interval: 1m
+    input_series:
+
+      # HAS experienced ~10% (10.9%) creation failure rate, should still alert
+      - series: 'has_application_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '10+10x64'
+      - series: 'has_application_failed_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '0x20 0+10x7 70x38'
+
+    alert_rule_test:
+      - eval_time: 65m
+        alertname: ApplicationCreationErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: true
+              namespace: application-service
+              pod: has
+              source_cluster: cluster01
+            exp_annotations:
+              summary: >-
+                HAS is experiencing application creation failures of >5%
+              description: >-
+                Application controller in Pod has for namespace
+                application-service on cluster cluster01 is failing to
+                successfully create at least 95% of applications over the past hour
+              runbook_url: TBD
+
+  - interval: 1m
+    input_series:
+
+      # HAS experienced 5% creation failure rate, should not alert
+      - series: 'has_application_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '20+20x64'
+      - series: 'has_application_failed_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '1+1x64'
+
+    alert_rule_test:
+      - eval_time: 65m
+        alertname: ApplicationCreationErrors
+
+  - interval: 1m
+    input_series:
+
+      # HAS experienced ~1% creation failure rate, should not alert
+      - series: 'has_application_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '0+10x64'
+      - series: 'has_application_failed_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '0x9 5x54'
+
+    alert_rule_test:
+      - eval_time: 65m
+        alertname: ApplicationCreationErrors


### PR DESCRIPTION
This PR adds alerting rules for the Application creation SLO as found [here](https://docs.google.com/document/d/1OVVZeCmv6o2qsZ1BhPaVPVzkJSa8cxLAN5ImF1eugOE/edit#bookmark=id.78n0do63qmep) (95% of created applications should have succeeded)

Corresponding alert tests have also been added