### PR TITLE
fix(GITOPSRVCE-753): Fix grafana dashboard for Gitops Service SLO for cluster-agent panel

### DIFF
--- a/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
+++ b/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
@@ -386,9 +386,9 @@ data:
             "h": 7,
             "w": 10,
             "x": 0,
-            "y": 11
+            "y": 19
           },
-          "id": 50,
+          "id": 55,
           "links": [],
           "options": {
             "code": {
@@ -478,9 +478,9 @@ data:
             "h": 7,
             "w": 12,
             "x": 10,
-            "y": 11
+            "y": 19
           },
-          "id": 52,
+          "id": 56,
           "maxDataPoints": 30,
           "options": {
             "legend": {
@@ -531,7 +531,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 19
+            "y": 26
           },
           "id": 40,
           "panels": [],
@@ -548,7 +548,7 @@ data:
             "h": 7,
             "w": 10,
             "x": 0,
-            "y": 20
+            "y": 27
           },
           "id": 41,
           "links": [],
@@ -623,7 +623,7 @@ data:
             "h": 7,
             "w": 5,
             "x": 10,
-            "y": 20
+            "y": 27
           },
           "id": 42,
           "links": [],
@@ -661,7 +661,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 27
+            "y": 34
           },
           "id": 35,
           "panels": [],
@@ -678,7 +678,7 @@ data:
             "h": 7,
             "w": 10,
             "x": 0,
-            "y": 28
+            "y": 35
           },
           "id": 36,
           "links": [],
@@ -733,7 +733,8 @@ data:
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -753,7 +754,7 @@ data:
             "h": 7,
             "w": 5,
             "x": 10,
-            "y": 28
+            "y": 35
           },
           "id": 37,
           "links": [],
@@ -791,7 +792,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 35
+            "y": 42
           },
           "id": 33,
           "panels": [],
@@ -808,7 +809,7 @@ data:
             "h": 7,
             "w": 10,
             "x": 0,
-            "y": 36
+            "y": 43
           },
           "id": 10,
           "links": [],
@@ -860,7 +861,8 @@ data:
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -876,7 +878,7 @@ data:
             "h": 7,
             "w": 5,
             "x": 10,
-            "y": 36
+            "y": 43
           },
           "id": 6,
           "links": [],
@@ -934,7 +936,8 @@ data:
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -950,7 +953,7 @@ data:
             "h": 7,
             "w": 5,
             "x": 15,
-            "y": 36
+            "y": 43
           },
           "id": 29,
           "links": [],
@@ -1041,7 +1044,7 @@ data:
       "timezone": "",
       "title": "RHTAP SLOs",
       "uid": "rhtap-slos",
-      "version": 3,
+      "version": 5,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
Issue - As my recent PR got merged [PR](https://github.com/redhat-appstudio/o11y/pull/96 ), I was checking the metrics panel in grafana dashboard, but I found this issue 
 - Whenever I tried to click edit/view in this right panel as shown here :
<img width="1657" alt="Screenshot 2023-11-08 at 1 18 04 PM" src="https://github.com/redhat-appstudio/o11y/assets/76523858/ab1e45f4-92f3-40ec-af0a-84e78806c2eb">

- It is redirecting me to this panel : 
   
<img width="1728" alt="Screenshot 2023-11-08 at 1 18 27 PM" src="https://github.com/redhat-appstudio/o11y/assets/76523858/1ba372dd-ddb2-412a-bbde-05f7320771cf">

- and whenever I tried clicking edit/view on left panel as shown here : 
   
<img width="1728" alt="Screenshot 2023-11-08 at 1 18 47 PM" src="https://github.com/redhat-appstudio/o11y/assets/76523858/846c4866-2c79-4759-917d-04cfd9813590">

- it is giving this error(permission denied which you can see in top right hand corner)
   
<img width="1728" alt="Screenshot 2023-11-08 at 1 18 47 PM" src="https://github.com/redhat-appstudio/o11y/assets/76523858/7f4eb54e-b6e1-4070-a788-247e969b6495">

- I think this happend because of rebase and Id has been mismatched, fixed that in this PR and it is working fine and as expected:
<img width="1713" alt="Screenshot 2023-11-08 at 1 22 46 PM" src="https://github.com/redhat-appstudio/o11y/assets/76523858/2668f43f-d3a2-4aab-b825-7274cd97866e">

