### PR TITLE
feat(STONEINTG-561): add alert IS SLO 5

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.latency_release_creation_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_release_creation_alerts.yaml
@@ -1,0 +1,33 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-latency-release-creation-alerting-rules
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: latency-release-creation
+    interval: 1m
+    rules:
+    - alert: LatencyReleaseCreation
+      expr: |
+        (
+          (
+            increase(integration_svc_release_latency_seconds_bucket{le="+Inf"}[5m])
+            - ignoring(le)
+            increase(integration_svc_release_latency_seconds_bucket{le="10"}[5m])
+          ) / ignoring(le)
+          increase(integration_svc_release_latency_seconds_bucket{le="+Inf"}[5m])
+        ) > 0.10
+      for: 1m
+      labels:
+        severity: warning
+        slo: true
+      annotations:
+        summary: >-
+          Latency of release creation time exceeded
+        description: >
+          Time from Snapshot marked as passed to release created has been over
+          10s for more than 10% of requests during the last 5 minutes on cluster
+          {{ $labels.source_cluster }}
+        runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md

--- a/test/promql/tests/data_plane/latency_release_creation_test.yaml
+++ b/test/promql/tests/data_plane/latency_release_creation_test.yaml
@@ -1,0 +1,99 @@
+evaluation_interval: 1m
+
+rule_files:
+  - 'prometheus.latency_release_creation_alerts.yaml'
+
+tests:
+  - interval: 1m
+    input_series:
+      # Simulating data from Cluster 1 (crosses the 10% threshold)
+      - series: 'integration_svc_release_latency_seconds_bucket{le="10", source_cluster="cluster01"}'
+        values: '0+10x10'  # 10 requests took less than 10s
+      - series: 'integration_svc_release_latency_seconds_bucket{le="+Inf", source_cluster="cluster01"}'
+        values: '0+100x10'  # 100 total occurrences in cluster01
+
+      # Simulating data from Cluster 2 (does not cross the 10% threshold)
+      - series: 'integration_svc_release_latency_seconds_bucket{le="10", source_cluster="cluster02"}'
+        values: '0+90x10'  # 90 requests took less than 10s
+      - series: 'integration_svc_release_latency_seconds_bucket{le="+Inf", source_cluster="cluster02"}'
+        values: '0+100x10'  # 100 total occurrences in cluster02
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: LatencyReleaseCreation
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: true
+              source_cluster: cluster01
+            exp_annotations:
+              summary: Latency of release creation time exceeded
+              description: >
+                Time from Snapshot marked as passed to release created has been over
+                10s for more than 10% of requests during the last 5 minutes on cluster
+                cluster01
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md
+
+# Scenario where both clusters cross the 10% threshold
+# Alert triggered for both clusters
+  - interval: 1m
+    input_series:
+      # Simulating data from Cluster 1 (crosses the 10% threshold)
+      - series: 'integration_svc_release_latency_seconds_bucket{le="10", source_cluster="cluster01"}'
+        values: '0+5x10'  # 5 requests took less than 10s
+      - series: 'integration_svc_release_latency_seconds_bucket{le="+Inf", source_cluster="cluster01"}'
+        values: '0+100x10'  # 100 total occurrences in cluster01
+
+      # Simulating data from Cluster 2 (also crosses the 10% threshold)
+      - series: 'integration_svc_release_latency_seconds_bucket{le="10", source_cluster="cluster02"}'
+        values: '0+5x10'  # 5 requests took less than 10s
+      - series: 'integration_svc_release_latency_seconds_bucket{le="+Inf", source_cluster="cluster02"}'
+        values: '0+100x10'  # 100 total occurrences in cluster02
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: LatencyReleaseCreation
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: true
+              source_cluster: cluster01
+            exp_annotations:
+              summary: Latency of release creation time exceeded
+              description: >
+                Time from Snapshot marked as passed to release created has been over
+                10s for more than 10% of requests during the last 5 minutes on cluster
+                cluster01
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md
+          - exp_labels:
+              severity: warning
+              slo: true
+              source_cluster: cluster02
+            exp_annotations:
+              summary: Latency of release creation time exceeded
+              description: >
+                Time from Snapshot marked as passed to release created has been over
+                10s for more than 10% of requests during the last 5 minutes on cluster
+                cluster02
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md
+
+# Scenario where neither cluster crosses the 10% threshold
+# Alert not triggered
+  - interval: 1m
+    input_series:
+      # Simulating data from Cluster 1 (does not cross the 10% threshold)
+      - series: 'integration_svc_release_latency_seconds_bucket{le="10", source_cluster="cluster01"}'
+        values: '0+95x10'  # 95 requests took less than 10s
+      - series: 'integration_svc_release_latency_seconds_bucket{le="+Inf", source_cluster="cluster01"}'
+        values: '0+100x10'  # 100 total occurrences in cluster01
+
+      # Simulating data from Cluster 2 (does not cross the 10% threshold)
+      - series: 'integration_svc_release_latency_seconds_bucket{le="10", source_cluster="cluster02"}'
+        values: '0+95x10'  # 95 requests took less than 10s
+      - series: 'integration_svc_release_latency_seconds_bucket{le="+Inf", source_cluster="cluster02"}'
+        values: '0+100x10'  # 100 total occurrences in cluster02
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: LatencyReleaseCreation
+        exp_alerts: []  # No alerts are expected in this scenario


### PR DESCRIPTION
add alert for snapshot marked as passed to
release created where >10% of requests takes
longer than 10s
Add alert testing, 3 cases with 2 clusters each:
Where neither cluster triggers alert
Where one cluster triggers alert
Where both clusters trigger alert