### PR TITLE
chore(RHTAPWATCH-514): limit namespace for control plane alerts

### DIFF
--- a/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
+++ b/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
@@ -10,7 +10,10 @@ spec:
     interval: 1m
     rules:
     - alert: DegradedArgocdApp
-      expr: last_over_time(argocd_app_info{health_status="Degraded"}[2m]) == 1
+      expr: |
+        last_over_time(
+          argocd_app_info{health_status="Degraded", namespace=~"argocd-staging|argocd"}[2m]
+        ) == 1
       for: 5m
       labels:
         severity: warning
@@ -24,9 +27,13 @@ spec:
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
     - alert: ProgressingArgocdApp
       expr: |
-        max_over_time(argocd_app_info{health_status="Progressing", dest_namespace!~".+-tenant"}[19m]) == 1
+        max_over_time(
+          argocd_app_info{health_status="Progressing", namespace=~"argocd-staging|argocd"}[19m]
+        ) == 1
         unless ignoring (health_status)
-        max_over_time(argocd_app_info{health_status!="Progressing", dest_namespace!~".+-tenant"}[19m]) == 1
+        max_over_time(
+          argocd_app_info{health_status!="Progressing", namespace=~"argocd-staging|argocd"}[19m]
+        ) == 1
       for: 1m
       labels:
         severity: warning

--- a/test/promql/tests/control_plane/argocd_test.yaml
+++ b/test/promql/tests/control_plane/argocd_test.yaml
@@ -9,32 +9,37 @@ tests:
     input_series:
 
       # no app is degraded - shouldn't trigger alerts
-      - series: 'argocd_app_info{health_status="Degraded", name="not-degraded-app", dest_namespace="not-degraded", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Degraded", name="not-degraded-app", namespace="argocd-staging", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
         values: _x9
 
       # an app is constantly degraded - should trigger alerts
-      - series: 'argocd_app_info{health_status="Degraded", name="degraded-app", dest_namespace="degraded", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Degraded", name="degraded-app", namespace="argocd-staging", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
         values: 1x9
 
       # an app with some 1m degraded status - shouldn't trigger alerts
-      - series: 'argocd_app_info{health_status="Degraded", name="degraded-1m-app", dest_namespace="degraded-1m", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Degraded", name="degraded-1m-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: 1 _ _ _ 1 _ _ _ _ _
 
       # an app with a 4m degraded status - shouldn't trigger alerts
-      - series: 'argocd_app_info{health_status="Degraded", name="degraded-4m-app", dest_namespace="degraded-4m", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Degraded", name="degraded-4m-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: _ 1 1 1 1 _ _ _ _ _
 
       # an app is flapping every 1m - should trigger alerts triggers
-      - series: 'argocd_app_info{health_status="Degraded", name="flapping-1m-app", dest_namespace="flapping-1m", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Degraded", name="flapping-1m-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: 1 _ 1 _ 1 _ 1 _ 1 _
 
       # an app is flapping every 2m - should trigger alerts triggers
-      - series: 'argocd_app_info{health_status="Degraded", name="flapping-2m-app", dest_namespace="flapping-2m", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Degraded", name="flapping-2m-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+        values: 1 _ _ 1 _ _ 1 _ _ 1
+
+      # an app is flapping every 2m but on arbitrary namespace - should not trigger
+      - series: 'argocd_app_info{health_status="Degraded", name="flapping-2m-app", namespace="baz", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: 1 _ _ 1 _ _ 1 _ _ 1
 
       # an app is in another health status which is not 'Degraded' - the rule shouldn't alert.
-      - series: 'argocd_app_info{health_status="Progressing", name="progressing-app", dest_namespace="nothing-wrong", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Progressing", name="progressing-app", namespace="argocd-staging", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
         values: 1x9
+
 
     alert_rule_test:
       - eval_time: 5m
@@ -43,7 +48,7 @@ tests:
           - exp_labels:
               severity: warning
               dest_server: https://api.foo.openshiftapps.com:6443
-              dest_namespace: degraded
+              namespace: argocd-staging
               health_status: Degraded
               name: degraded-app
               source_environment: staging-cluster
@@ -59,14 +64,14 @@ tests:
           - exp_labels:
               severity: warning
               dest_server: https://api.foo.openshiftapps.com:6443
-              dest_namespace: flapping-1m
+              namespace: argocd
               health_status: Degraded
               name: flapping-1m-app
-              source_environment: staging-cluster
+              source_environment: production-cluster
               team: rhtap
             exp_annotations:
               message: |
-                Environment: staging-cluster
+                Environment: production-cluster
                 Application: flapping-1m-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 Health status Degraded.
@@ -75,14 +80,14 @@ tests:
           - exp_labels:
               severity: warning
               dest_server: https://api.foo.openshiftapps.com:6443
-              dest_namespace: flapping-2m
+              namespace: argocd
               health_status: Degraded
               name: flapping-2m-app
-              source_environment: staging-cluster
+              source_environment: production-cluster
               team: rhtap
             exp_annotations:
               message: |
-                Environment: staging-cluster
+                Environment: production-cluster
                 Application: flapping-2m-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 Health status Degraded.
@@ -92,9 +97,9 @@ tests:
   - interval: 1m
     input_series:
       # App was progessing and then healthy for the last 9 min, should not raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="Progressing-Healthy-9min-app", dest_namespace="Progressing-Healthy-9min", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Progressing", name="Progressing-Healthy-9min-app", namespace="argocd-staging", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
         values: 1x10 _x8
-      - series: 'argocd_app_info{health_status="Healthy", name="Progressing-Healthy-9min-app", dest_namespace="Progressing-Healthy-9min", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Healthy", name="Progressing-Healthy-9min-app", namespace="argocd-staging", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
         values: _x10 1x8
     alert_rule_test:
       - eval_time: 20m
@@ -104,7 +109,7 @@ tests:
   - interval: 1m
     input_series:
       # App is always progressing, should raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="progressing-only-app", dest_namespace="Still-Progressing", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Progressing", name="progressing-only-app", namespace="argocd-staging", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
         values: 1x19
     alert_rule_test:
       - eval_time: 20m
@@ -113,7 +118,7 @@ tests:
           - exp_labels:
               severity: warning
               dest_server: https://api.foo.openshiftapps.com:6443
-              dest_namespace: Still-Progressing
+              namespace: argocd-staging
               health_status: Progressing
               name: progressing-only-app
               source_environment: staging-cluster
@@ -128,12 +133,22 @@ tests:
 
   - interval: 1m
     input_series:
-      # Apps are always healthy, should not raise an alert
-      - series: 'argocd_app_info{health_status="Healthy", name="Healthy-only-app", dest_namespace="Still-Progressing", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      # App is always progressing, but on unrelated namespace. should NOT raise an alert
+      - series: 'argocd_app_info{health_status="Progressing", name="progressing-only-app", namespace="not-us", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
         values: 1x19
-      - series: 'argocd_app_info{health_status="Progressing", name="Healthy-only-app", dest_namespace="Still-Progressing", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: ProgressingArgocdApp
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      # Apps are always healthy, should not raise an alert
+      - series: 'argocd_app_info{health_status="Healthy", name="Healthy-only-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+        values: 1x19
+      - series: 'argocd_app_info{health_status="Progressing", name="Healthy-only-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: _x19
-      - series: 'argocd_app_info{health_status="Healthy", name="another-Healthy-only-app", dest_namespace="Still-Progressing", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Healthy", name="another-Healthy-only-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: 1x19
     alert_rule_test:
       - eval_time: 20m
@@ -143,9 +158,9 @@ tests:
   - interval: 1m
     input_series:
       # App was progessing and then healthy for the last 4 min, should not raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="progressing-healthy-4min-app", dest_namespace="Progressing-Healthy-4min", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Progressing", name="progressing-healthy-4min-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: 1x15 _x3
-      - series: 'argocd_app_info{health_status="Healthy", name="progressing-healthy-4min-app", dest_namespace="Progressing-Healthy-4min", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Healthy", name="progressing-healthy-4min-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: _x15 1x3
     alert_rule_test:
       - eval_time: 20m
@@ -155,9 +170,9 @@ tests:
   - interval: 1m
     input_series:
       # the app is switching health states (flapping), should not raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="flapping-should-not-alert-app", dest_namespace="Flapping-Should-Not-Alert", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Progressing", name="flapping-should-not-alert-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: '_ 1 _ 1 1 _ 1 1 1 _ _ _ _ 1 _ 1 1 1 1 _'
-      - series: 'argocd_app_info{health_status="Healthy", name="flapping-should-not-alert-app", dest_namespace="Flapping-Should-Not-Alert", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Healthy", name="flapping-should-not-alert-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: '1 _ 1 _ _ 1 _ _ _ 1 1 1 1 _ 1 _ _ _ _ 1'
     alert_rule_test:
       - eval_time: 20m
@@ -167,14 +182,14 @@ tests:
   - interval: 1m
     input_series:
       # App 1: Progressing all of the time, should raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="Progressing_first-app", dest_namespace="Progressing_first", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Progressing", name="Progressing_first-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: 1x19
-      - series: 'argocd_app_info{health_status="Healthy", name="Progressing_first-app", dest_namespace="Progressing_first", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Healthy", name="Progressing_first-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: _x19
       # App 2: Progressing for 17 minutes and then healthy for 3 minutes, should not raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="Progressing_second-app", dest_namespace="Progressing_second", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Progressing", name="Progressing_second-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: 1x16 _ _ _
-      - series: 'argocd_app_info{health_status="Healthy", name="Progressing_second-app", dest_namespace="Progressing_second", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Healthy", name="Progressing_second-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: _x16 1 1 1
     alert_rule_test:
       - eval_time: 20m
@@ -183,14 +198,14 @@ tests:
           - exp_labels:
               severity: warning
               dest_server: https://api.foo.openshiftapps.com:6443
-              dest_namespace: Progressing_first
+              namespace: argocd
               health_status: Progressing
               name: Progressing_first-app
-              source_environment: staging-cluster
+              source_environment: production-cluster
               team: rhtap
             exp_annotations:
               message: |-
-                Environment: staging-cluster
+                Environment: production-cluster
                 Application: Progressing_first-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 App progressing for too long.


### PR DESCRIPTION
The metric currently used for the control plane alerts is also going to be forwarded from the data plane clusters to allow some other alerts.

With this change, we specify the exact namespace for the control plane alerts so they don't trigger on metrics coming from other namespaces.