### PR TITLE
feat(RHTAPWATCH-578): write Dockerfile for exporter service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20.10-2 AS builder
+
+# Set the working directory
+WORKDIR /opt/app-root/src
+
+COPY go.mod go.sum ./
+
+# Download required dependencies
+RUN go mod download
+COPY --chown=default:root exporters/**/*.go .
+
+RUN ["go", "build", "."]
+
+EXPOSE 8090
+CMD ["go", "run", "."]


### PR DESCRIPTION
Dockerfile is added to the o11y repo to build the docker image for the prometheus exporters.

Jira-Url: https://issues.redhat.com/browse/RHTAPWATCH-578