### PR TITLE
chore(RHTAPWATCH-579): Update libcurl in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,7 @@ RUN ["go", "build", "."]
 
 EXPOSE 8090
 CMD ["go", "run", "."]
+
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-751
+RUN microdnf update --setopt=install_weak_deps=0 -y && microdnf install libcurl-minimal libcurl-devel


### PR DESCRIPTION
Added commands to update libcurl in Dockerfile to mitigate the vulnerabilities in quay container registry.

Jira-Url: https://issues.redhat.com/browse/RHTAPWATCH-579