### PR TITLE
chore(DEVHAS-547): Bump down Application deletion SLO to 95%

### DIFF
--- a/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
+++ b/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
@@ -1204,7 +1204,7 @@ data:
               "showLineNumbers": false,
               "showMiniMap": false
             },
-            "content": "<h1><center>99% of application deletions must succeed</center></h1>",
+            "content": "<h1><center>95% of application deletions must succeed</center></h1>",
             "mode": "html"
           },
           "pluginVersion": "9.3.8",
@@ -1254,7 +1254,7 @@ data:
                   },
                   {
                     "color": "green",
-                    "value": 99
+                    "value": 95
                   }
                 ]
               },

--- a/rhobs/alerting/data_plane/prometheus.application_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.application_alerts.yaml
@@ -13,18 +13,18 @@ spec:
       expr: |
         (increase(has_application_failed_deletion_total[1h]))
         /
-        (increase(has_application_deletion_total[1h]))  > 0.01
+        (increase(has_application_deletion_total[1h]))  > 0.05
       for: 5m
       labels:
         severity: warning
         slo: true
       annotations:
         summary: >-
-          HAS is experiencing application deletion failures of >1%
+          HAS is experiencing application deletion failures of >5%
         description: >-
           Application controller in Pod {{ $labels.pod }} for namespace
           {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
-          successfully delete at least 99% of applications over the past hour
+          successfully delete at least 95% of applications over the past hour
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-delete-failed.md
     - alert: ApplicationCreationErrors
       expr: |

--- a/test/promql/tests/data_plane/application_errors_test.yaml
+++ b/test/promql/tests/data_plane/application_errors_test.yaml
@@ -26,11 +26,11 @@ tests:
               source_cluster: cluster01
             exp_annotations:
               summary: >-
-                HAS is experiencing application deletion failures of >1%
+                HAS is experiencing application deletion failures of >5%
               description: >-
                 Application controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
-                successfully delete at least 99% of applications over the past hour
+                successfully delete at least 95% of applications over the past hour
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-delete-failed.md
 
   - interval: 1m
@@ -54,17 +54,17 @@ tests:
               source_cluster: cluster01
             exp_annotations:
               summary: >-
-                HAS is experiencing application deletion failures of >1%
+                HAS is experiencing application deletion failures of >5%
               description: >-
                 Application controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
-                successfully delete at least 99% of applications over the past hour
+                successfully delete at least 95% of applications over the past hour
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-delete-failed.md
 
   - interval: 1m
     input_series:
 
-      # HAS experienced 5% deletion failure rate, should still alert
+      # HAS experienced 5% deletion failure rate, should not alert
       - series: 'has_application_deletion_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
         values: '20+20x64'
       - series: 'has_application_failed_deletion_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
@@ -73,21 +73,6 @@ tests:
     alert_rule_test:
       - eval_time: 65m
         alertname: ApplicationDeletionErrors
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              slo: true
-              namespace: application-service
-              pod: has
-              source_cluster: cluster01
-            exp_annotations:
-              summary: >-
-                HAS is experiencing application deletion failures of >1%
-              description: >-
-                Application controller in Pod has for namespace
-                application-service on cluster cluster01 is failing to
-                successfully delete at least 99% of applications over the past hour
-              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-delete-failed.md
 
   - interval: 1m
     input_series:
@@ -101,6 +86,7 @@ tests:
     alert_rule_test:
       - eval_time: 65m
         alertname: ApplicationDeletionErrors
+
 
   # ----- Application Creation Alerting Tests -----
   - interval: 1m


### PR DESCRIPTION
As part of the fix for [DEVHAS-547](https://issues.redhat.com/browse/DEVHAS-547), the HAS team has decided to adjust down the "Application Deletion" SLO from 99% to 95%. This PR updates the Prometheus alerts and Grafana dashboard accordingly