### PR TITLE
chore(RHTAPWATCH-566): Write service monitor to scrape the metrics

### DIFF
--- a/config/exporters/monitoring/grafana/base/prometheus-exporter-service.yaml
+++ b/config/exporters/monitoring/grafana/base/prometheus-exporter-service.yaml
@@ -35,13 +35,15 @@ roleRef:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: grafana-datasource-exporter
   name: exporter-service
   namespace: appstudio-grafana-datasource-exporter
 spec:
   ports:
-  - name: https
+  - name: http
     port: 8090
-    targetPort: https
+    targetPort: http
   selector:
     app: grafana-datasource-exporter
 ---
@@ -66,7 +68,7 @@ spec:
         image: quay.io/redhat-appstudio/o11y-prometheus-exporters:latest
         ports:
         - containerPort: 8090
-          name: https
+          name: http
         resources:
           limits:
             cpu: 100m
@@ -77,3 +79,17 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: metrics-reader
+  namespace: appstudio-grafana-datasource-exporter
+spec:
+  endpoints:
+  - path: /metrics
+    port: http
+    scheme: http
+  selector:
+    matchLabels:
+      app: grafana-datasource-exporter

--- a/exporters/dsexporter/dsexporter.go
+++ b/exporters/dsexporter/dsexporter.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -41,6 +42,9 @@ func main() {
 	reg := prometheus.NewPedanticRegistry()
 	exporter := NewCustomCollector()
 	reg.MustRegister(exporter)
+
+	fmt.Println("Server is listening on http://localhost:8090/metrics")
+
 	http.Handle("/metrics", promhttp.HandlerFor(
 		reg,
 		promhttp.HandlerOpts{


### PR DESCRIPTION
- Add a Servicemonitor file
- metrics should be available on the /metrics endpoint
- Add print statement for dsexporter.go when the server starts

![image](https://github.com/redhat-appstudio/o11y/assets/113047440/a4721682-362f-49b1-b09b-de136929c7b2)
