### PR TITLE
feat(GITOPSRVCE-751): Add alert rule/test for Route SLO

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.gitops_routes_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.gitops_routes_alerts.yaml
@@ -1,0 +1,32 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-gitops-routes-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: gitops_routes_alerts
+    interval: 1m
+    rules:
+    - alert: GitOpsRoutesHealthErrors
+      expr: |
+        (
+          sum(openshift_route_status{ status="True", namespace="gitops-service-argocd"})
+          by (source_cluster)
+        )
+        /
+        (
+          sum(openshift_route_status{namespace="gitops-service-argocd"})
+          by (source_cluster)
+        ) < 0.95
+      for: 5m
+      labels:
+        severity: warning
+        slo: "true"
+      annotations:
+        summary: >-
+          Less than 95% of GitOps Routes are in Healthy state: {{ $value | humanizePercentage }} in cluster: {{ $labels.source_cluster }}
+        description: >-
+          The percentage total of Argo CD Routes that are in Healthy state is less than 95% in cluster: {{ $labels.source_cluster }}.
+        runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/gitops/routes.md

--- a/test/promql/tests/data_plane/gitops_routes_test.yaml
+++ b/test/promql/tests/data_plane/gitops_routes_test.yaml
@@ -1,0 +1,332 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.gitops_routes_alerts.yaml
+
+tests:
+  - interval: 1m
+    input_series:
+      # We don't want to be alerted in this situation (don't care situation)
+      - series: 'openshift_route_status{status="True", name="route-001", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ _ _ _ _ _ _ _'
+
+      - series: 'openshift_route_status{status="False",  name="route-002", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ _ _ _ _ _ _ _'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: GitOpsRoutesHealthErrors
+
+  - interval: 1m
+    input_series:
+      # One healthy route, but one unhealthy. 50% health rate, so alert
+      - series: 'openshift_route_status{status="True", name="route-001", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1'
+
+      - series: 'openshift_route_status{status="False",  name="route-002", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: GitOpsRoutesHealthErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "true"
+              source_cluster: stonesoupp01ue1
+            exp_annotations:
+              summary: >-
+                Less than 95% of GitOps Routes are in Healthy state: 50% in cluster: stonesoupp01ue1
+              description: >-
+                The percentage total of Argo CD Routes that are in Healthy state is less than 95% in cluster: stonesoupp01ue1.
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/gitops/routes.md
+
+  - interval: 1m
+    input_series:
+      # Less than 95% health rate (at 50%), should alert
+      - series: 'openshift_route_status{status="True", name="route-001", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-002", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1'
+
+      - series: 'openshift_route_status{status="False",  name="route-003", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="False",  name="route-004", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: GitOpsRoutesHealthErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "true"
+              source_cluster: stonesoupp01ue1
+            exp_annotations:
+              summary: >-
+                Less than 95% of GitOps Routes are in Healthy state: 50% in cluster: stonesoupp01ue1
+              description: >-
+                The percentage total of Argo CD Routes that are in Healthy state is less than 95% in cluster: stonesoupp01ue1.
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/gitops/routes.md
+
+  - interval: 1m
+    input_series:
+      # One healthy route for entire window period. Basic scenario. Should not alert
+      - series: 'openshift_route_status{status="True", name="route-001", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+
+      - series: 'openshift_route_status{status="False",  name="route-003", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ _ _ _ _ _ _ _'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: GitOpsRoutesHealthErrors
+
+  - interval: 1m
+    input_series:
+      # No route. No alerts
+      - series: 'openshift_route_status{status="True", name="route-001", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ _ _ _ _ _ _ _'
+
+      - series: 'openshift_route_status{status="False",  name="route-003", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ _ _ _ _ _ _ _'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: GitOpsRoutesHealthErrors
+
+  - interval: 1m
+    input_series:
+      # Two healthy routes, no unhealthy. So no alert
+      - series: 'openshift_route_status{status="True", name="route-001", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ _ 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-002", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ _ 1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: GitOpsRoutesHealthErrors
+
+  - interval: 1m
+    input_series:
+      # One healthy route. Two routes periodically go from unhealthy to no state. However
+      # even though the percentage of health is below the threshold, there is no alert because it falls
+      # outside the alert/evaluation window.
+      - series: 'openshift_route_status{status="True", name="route-001", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+
+      - series: 'openshift_route_status{status="False", name="route-002", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ 1 _ 1 _ _ _ _ _ _ _ _ _ 1 _ 1 _ _ _ _ _ _'
+      - series: 'openshift_route_status{status="False",  name="route-003", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ 1 _ 1 _ _ _ _ _ _ _ _ _ 1 _ 1 _ _ _ _ _'
+    alert_rule_test:
+      - eval_time: 23m
+        alertname: GitOpsRoutesHealthErrors
+
+  - interval: 1m
+    input_series:
+      # One healthy route. Two routes periodically go from unhealthy to no state. The
+      # percentage of health is below the threshold at the point of the active alert/evaluation.
+      - series: 'openshift_route_status{status="True", name="route-001", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+
+      - series: 'openshift_route_status{status="False",  name="route-002", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ 1 _ 1 _ _ _ _ _ _ _ _ _ 1 _ 1 _ 1 _ _ _ _'
+      - series: 'openshift_route_status{status="False",  name="route-003", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ 1 _ 1 _ _ _ _ _ _ _ _ _ 1 _ 1 _ _ _ _ _'
+
+    alert_rule_test:
+      - eval_time: 19m
+        alertname: GitOpsRoutesHealthErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "true"
+              source_cluster: stonesoupp01ue1
+            exp_annotations:
+              summary: >-
+                Less than 95% of GitOps Routes are in Healthy state: 33.33% in cluster: stonesoupp01ue1
+              description: >-
+                The percentage total of Argo CD Routes that are in Healthy state is less than 95% in cluster: stonesoupp01ue1.
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/gitops/routes.md
+
+  - interval: 1m
+    input_series:
+      # Two healthy routes, one is unhealthy at the eval time 14 minutes into the series. 66% healthy, so alert.
+      - series: 'openshift_route_status{status="True", name="route-001", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-002", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+
+      - series: 'openshift_route_status{status="False",  name="route-003", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ _ _ _ _ _ 1 1 1 1 1 _ _ _ _ _ _'
+
+    alert_rule_test:
+      - eval_time: 14m
+        alertname: GitOpsRoutesHealthErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "true"
+              source_cluster: stonesoupp01ue1
+            exp_annotations:
+              summary: >-
+                Less than 95% of GitOps Routes are in Healthy state: 66.67% in cluster: stonesoupp01ue1
+              description: >-
+                The percentage total of Argo CD Routes that are in Healthy state is less than 95% in cluster: stonesoupp01ue1.
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/gitops/routes.md
+
+  - interval: 1m
+    input_series:
+      # Two healthy routes, and one unhealthy for 5 minutes. However, at the eval time at 20m, the alert
+      # should not be firing and it missed the earlier window where it should have fired. But since the recent
+      # measurements meet the SLO and perhaps the health status stabilized, it is acceptable.
+      - series: 'openshift_route_status{status="True", name="route-001", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-002", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+
+      - series: 'openshift_route_status{status="False",  name="route-003", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ _ _ _ _ _ 1 1 1 1 1 _ _ _ _ _ _'
+
+    alert_rule_test:
+      - eval_time: 19m
+        alertname: GitOpsRoutesHealthErrors
+
+  - interval: 1m
+    input_series:
+      # Two healthy routes, one unhealthy. At the eval time of 21m, the alert should not be firing.
+      # At this point, route 3 is unhealthy, but it hasn't been measured to be in that state
+      # for an acceptable 5 minute window of time according to the rule. Also, we missed and ignore the
+      # earlier window when it was unhealthy for 5 minutes.
+      - series: 'openshift_route_status{status="True", name="route-001", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-002", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+
+      - series: 'openshift_route_status{status="False", name="route-003", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ _ _ _ _ _ 1 1 1 1 1 _ _ _ _ _ _ 1 _ _ _ _ _'
+
+    alert_rule_test:
+      - eval_time: 19m
+        alertname: GitOpsRoutesHealthErrors
+
+  - interval: 1m
+    input_series:
+      # Two healthy rotes, one unhealthy. At the eval time of 20m, the route 3 has been unhealthy for a good
+      # amount of time on average, so the alert should fire.
+      - series: 'openshift_route_status{status="True", name="route-001", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-002", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+
+      - series: 'openshift_route_status{status="False",  name="route-003", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ _ _ _ _ _ 1 1 1 1 1 _ 1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: GitOpsRoutesHealthErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "true"
+              source_cluster: stonesoupp01ue1
+            exp_annotations:
+              summary: >-
+                Less than 95% of GitOps Routes are in Healthy state: 66.67% in cluster: stonesoupp01ue1
+              description: >-
+                The percentage total of Argo CD Routes that are in Healthy state is less than 95% in cluster: stonesoupp01ue1.
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/gitops/routes.md
+
+  - interval: 1m
+    input_series:
+      # Ten routes. Nine are healthy, one unhealthy. At the eval time of 20m, the last route has been unhealthy
+      # so the alert should fire. 9/10 = 0.9
+      - series: 'openshift_route_status{status="True", name="route-001", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-002", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-003", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-004", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-005", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-006", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-007", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-008", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-009", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+
+      - series: 'openshift_route_status{status="False",  name="route-010", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ _ _ _ _ _ 1 1 1 1 1 _ 1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: GitOpsRoutesHealthErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "true"
+              source_cluster: stonesoupp01ue1
+            exp_annotations:
+              summary: >-
+                Less than 95% of GitOps Routes are in Healthy state: 90% in cluster: stonesoupp01ue1
+              description: >-
+                The percentage total of Argo CD Routes that are in Healthy state is less than 95% in cluster: stonesoupp01ue1.
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/gitops/routes.md
+
+  - interval: 1m
+    input_series:
+      # Twenty routes. Nineteen are healthy. At the eval time of 20m, the last route has been unhealthy
+      # but the percentage is 19/20 = 0.95, which does not meet the rule, so no alert is fired.
+      - series: 'openshift_route_status{status="True", name="route-001", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-002", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-003", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-004", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-005", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-006", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-007", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-008", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-009", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-010", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-011", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-012", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-013", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-014", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-014", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-015", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-016", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-017", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-018", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-019", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'openshift_route_status{status="True", name="route-020", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+
+      - series: 'openshift_route_status{status="False", name="route-021", namespace="gitops-service-argocd", source_cluster="stonesoupp01ue1"}'
+        values: '_ _ _ _ _ _ _ _ _ 1 1 1 1 1 _ 1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: GitOpsRoutesHealthErrors


### PR DESCRIPTION
## Description
This PR is to add alert rules and their tests for Routes SLOs added by GitOps Service team.

## Jira Ticket
https://issues.redhat.com/browse/GITOPSRVCE-751