### PR TITLE
chore(DEVHAS-571): Add component creation alerting rules and tests

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.component_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.component_alerts.yaml
@@ -25,4 +25,21 @@ spec:
           Component controller in Pod {{ $labels.pod }} for namespace
           {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
           successfully delete at least 95% of components over the past hour
+        runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
+    - alert: ComponentCreationErrors
+      expr: |
+        (increase(has_component_failed_creation_total[1h]))
+        /
+        (increase(has_component_creation_total[1h]))  > 0.05
+      for: 5m
+      labels:
+        severity: warning
+        slo: "true"
+      annotations:
+        summary: >-
+          HAS is experiencing component creation failures of {{ $value | humanizePercentage }}
+        description: >-
+          Component controller in Pod {{ $labels.pod }} for namespace
+          {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
+          successfully create at least 95% of components over the past hour
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md

--- a/test/promql/tests/data_plane/component_errors_test.yaml
+++ b/test/promql/tests/data_plane/component_errors_test.yaml
@@ -41,7 +41,7 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of components over the past hour
-              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
 
   - interval: 1m
     input_series:
@@ -69,7 +69,7 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of components over the past hour
-              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
 
   - interval: 1m
     input_series:
@@ -98,7 +98,7 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of components over the past hour
-              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
 
   - interval: 1m
     input_series:
@@ -126,3 +126,126 @@ tests:
     alert_rule_test:
       - eval_time: 65m
         alertname: ComponentDeletionErrors
+
+  # ----- Component Creation Alerting Tests -----
+  - interval: 1m
+    input_series:
+
+      # HAS is experiencing no component creation and no failures, should not alert
+      - series: 'has_component_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '0+0x64'
+      - series: 'has_component_failed_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '0+0x64'
+
+
+  - interval: 1m
+    input_series:
+
+      # HAS is experiencing component creation failure rate of 100%, so it will be alerted
+      - series: 'has_component_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '1+1x64'
+      - series: 'has_component_failed_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '1+1x64'
+
+    alert_rule_test:
+      - eval_time: 65m
+        alertname: ComponentCreationErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "true"
+              namespace: application-service
+              pod: has
+              source_cluster: cluster01
+            exp_annotations:
+              summary: >-
+                HAS is experiencing component creation failures of 100%
+              description: >-
+                Component controller in Pod has for namespace
+                application-service on cluster cluster01 is failing to
+                successfully create at least 95% of components over the past hour
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md
+
+  - interval: 1m
+    input_series:
+
+      # HAS experienced ~10% (11.67%) creation failure rate, should still alert
+      - series: 'has_component_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '10+10x64'
+      - series: 'has_component_failed_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '0x20 0+10x7 70x37'
+
+    alert_rule_test:
+      - eval_time: 65m
+        alertname: ComponentCreationErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "true"
+              namespace: application-service
+              pod: has
+              source_cluster: cluster01
+            exp_annotations:
+              summary: >-
+                HAS is experiencing component creation failures of 11.67%
+              description: >-
+                Component controller in Pod has for namespace
+                application-service on cluster cluster01 is failing to
+                successfully create at least 95% of components over the past hour
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md
+
+  - interval: 1m
+    input_series:
+
+      # HAS experienced ~10% (10.83%) creation failure rate with counter reset, should still alert
+      - series: 'has_component_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '10+10x64'
+      # Increment failures by 1 for 20min, reset counter to 0 and increment failures by 10 for another 5 mins
+      - series: 'has_component_failed_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '1+1x20 0+10x5 50x38'
+
+    alert_rule_test:
+      - eval_time: 65m
+        alertname: ComponentCreationErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "true"
+              namespace: application-service
+              pod: has
+              source_cluster: cluster01
+            exp_annotations:
+              summary: >-
+                HAS is experiencing component creation failures of 10.83%
+              description: >-
+                Component controller in Pod has for namespace
+                application-service on cluster cluster01 is failing to
+                successfully create at least 95% of components over the past hour
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md
+
+  - interval: 1m
+    input_series:
+
+      # HAS experienced 5% creation failure rate, should not alert
+      - series: 'has_component_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '20+20x64'
+      - series: 'has_component_failed_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '1+1x64'
+
+    alert_rule_test:
+      - eval_time: 65m
+        alertname: ComponentCreationErrors
+
+
+  - interval: 1m
+    input_series:
+
+      # HAS experienced ~1% creation failure rate, should not alert
+      - series: 'has_component_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '0+10x64'
+      - series: 'has_component_failed_creation_total{namespace="application-service", pod="has", source_cluster="cluster01"}'
+        values: '0x9 5x54'
+
+    alert_rule_test:
+      - eval_time: 65m
+        alertname: ComponentCreationErrors


### PR DESCRIPTION
This PR:
* Similar to component deletion, adds component component creation alerting rules and tests.
* Fixes the runbook links for the component deletion rules.