### PR TITLE
chore: fix kube linting issue for exporters image

### DIFF
--- a/config/exporters/monitoring/grafana/base/prometheus-exporter-service.yaml
+++ b/config/exporters/monitoring/grafana/base/prometheus-exporter-service.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: exporter-sa
       containers:
       - name: grafana-datasource-exporter
-        image: quay.io/redhat-appstudio/o11y-prometheus-exporters:latest
+        image: quay.io/redhat-appstudio/o11y-prometheus-exporters:v0.1
         ports:
         - containerPort: 8090
           name: https


### PR DESCRIPTION
Updated the image tag used in the deployment resource to fix the kube linting issue.