### PR TITLE
chore: gitlint ignores bot users

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -8,3 +8,8 @@ line-length=72
 line-length=72
 
 [body-first-line-empty]
+
+# Bot users tends to generate invalid commits.
+[ignore-by-author-name]
+regex=(dependabot|red-hat-trusted-app-pipeline)
+ignore=all


### PR DESCRIPTION
gitlint now ignores commits made by dependabot and red-hat-trusted-app-pipeline as those are usually
invalid (either have long lines or do not sign off commits)