### PR TITLE
chore(RHTAPWATCH-563): Update o11y pipeline checks in custom build

### DIFF
--- a/.tekton/o11y-pull-request.yaml
+++ b/.tekton/o11y-pull-request.yaml
@@ -30,6 +30,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: target-branch
+    value: '{{target_branch}}'
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -71,6 +73,9 @@ spec:
     - default: ""
       description: Revision of the Source Repository
       name: revision
+      type: string
+    - default: ""
+      name: target-branch
       type: string
     - description: Fully Qualified Output Image
       name: output-image
@@ -163,6 +168,8 @@ spec:
         value: $(params.git-url)
       - name: revision
         value: $(params.revision)
+      - name: depth
+        value: 20
       runAfter:
       - init
       taskRef:
@@ -207,6 +214,90 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: check-and-test-prometheus-rules
+      workspaces:
+        - name: workspace
+          workspace: workspace
+      runAfter:
+        - clone-repository
+      taskSpec:
+        workspaces:
+          - name: workspace
+        steps:
+          - name: check-and-test-all
+            image: quay.io/rhobs/obsctl-reloader-rules-checker:1.0.4
+            workingDir: $(workspaces.workspace.path)/source
+            script: |
+              yum install -y make && \
+              CMD=obsctl-reloader-rules-checker make check-and-test
+    - name: yaml-lint
+      workspaces:
+        - name: workspace
+          workspace: workspace
+      runAfter:
+        - clone-repository
+      taskSpec:
+        workspaces:
+          - name: workspace
+        steps:
+          - name: yaml-lint
+            image: registry.access.redhat.com/ubi9/python-39:latest
+            workingDir: $(workspaces.workspace.path)/source
+            script: make install_pipenv sync_pipenv lint_yamls
+    - name: run-gitlint
+      params:
+        - name: target-branch
+          value: $(params.target-branch)
+      workspaces:
+        - name: workspace
+          workspace: workspace
+      runAfter:
+        - clone-repository
+      taskSpec:
+        params:
+          - name: target-branch
+        workspaces:
+          - name: workspace
+        steps:
+          - name: run-gitlint
+            image: registry.access.redhat.com/ubi9/python-39:latest
+            workingDir: $(workspaces.workspace.path)/source
+            script: |
+              #!/bin/bash -ex
+              python -m pip install gitlint
+              git config --global --add safe.directory '*'
+              git fetch origin "$(params.target-branch)"
+              gitlint --fail-without-commits --commits "origin/$(params.target-branch)..HEAD"
+    - name: run-go-unit-tests
+      workspaces:
+        - name: workspace
+          workspace: workspace
+      runAfter:
+        - clone-repository
+      taskSpec:
+        workspaces:
+          - name: workspace
+        steps:
+          - name: go-unit-tests
+            image: registry.access.redhat.com/ubi9/go-toolset:1.20.10-2
+            workingDir: $(workspaces.workspace.path)/source
+            script: |
+              go get -v -t -d ./...
+              go test -v ./...
+    - name: test-kustomize-build
+      workspaces:
+        - name: workspace
+          workspace: workspace
+      runAfter:
+        - clone-repository
+      taskSpec:
+        workspaces:
+          - name: workspace
+        steps:
+          - name: kustomize-build
+            image: registry.access.redhat.com/ubi8/ubi:latest
+            workingDir: $(workspaces.workspace.path)/source
+            script: yum install -y make && make kustomize-build
     - name: build-container
       params:
       - name: IMAGE

--- a/.tekton/o11y-push.yaml
+++ b/.tekton/o11y-push.yaml
@@ -27,6 +27,9 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: infra-deployment-update-script
+    value: |
+        sed -i -e 's|\(https://github.com/redhat-appstudio/o11y/.*?ref=\)\(.*\)|\1{{ revision }}|' components/monitoring/grafana/base/kustomization.yaml
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -69,6 +72,8 @@ spec:
       description: Revision of the Source Repository
       name: revision
       type: string
+    - name: infra-deployment-update-script
+      default: ""
     - description: Fully Qualified Output Image
       name: output-image
       type: string
@@ -204,6 +209,19 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: infra-deployments-mr
+      params:
+      - name: ORIGIN_REPO
+        value: $(params.git-url)
+      - name: REVISION
+        value: $(params.revision)
+      - name: SCRIPT
+        value: $(params.infra-deployment-update-script)
+      runAfter:
+      - clone-repository
+      taskRef:
+        bundle: quay.io/redhat-appstudio-tekton-catalog/task-update-infra-deployments:0.1
+        name: update-infra-deployments
     - name: build-container
       params:
       - name: IMAGE


### PR DESCRIPTION
After moving to custom build pipeline o11y existing checks are removed. So, adding existing checks to the new pipeline.