### PR TITLE
chore(RHTAPWATCH-530): namespace annotation on pod alerts

### DIFF
--- a/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
+++ b/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
@@ -24,6 +24,7 @@ spec:
           Application: {{ $labels.name }}
           Cluster: {{ $labels.dest_server }}
           Health status Degraded.
+        alert_route_namespace: '{{ $labels.dest_namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
     - alert: ProgressingArgocdApp
       expr: |
@@ -44,4 +45,5 @@ spec:
           Application: {{ $labels.name }}
           Cluster: {{ $labels.dest_server }}
           App progressing for too long.
+        alert_route_namespace: '{{ $labels.dest_namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-ProgressingArgocdApp.md

--- a/rhobs/alerting/data_plane/prometheus.gitops_argocd_app_reconcile_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.gitops_argocd_app_reconcile_alerts.yaml
@@ -17,6 +17,7 @@ spec:
           Argo CD in namespace {{ $labels.namespace }}
           has failed to reconcile at least 99% of applications
           within 4 seconds over the past 30 minutes
+        alert_route_namespace: gitops-service-argocd
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/gitops/argocd-app-reconcile.md
       expr: |
         increase(argocd_app_reconcile_bucket{namespace="gitops-service-argocd", le="4"}[30m])

--- a/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
@@ -19,6 +19,7 @@ spec:
         description: >-
           Pod {{ $labels.pod }} for namespace {{ $labels.namespace }} on cluster
           {{ $labels.source_cluster }} is unscheduled for more than 30 minutes.
+        alert_route_namespace: '{{ $labels.namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-unschedualablePods.md
     - alert: CrashLoopBackOff
       expr: max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace!~"(.*-tenant|openshift-.*|kube-.*|default)"}[5m]) >= 1
@@ -31,6 +32,7 @@ spec:
           Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is in
           waiting state (reason: 'CrashLoopBackOff') on cluster
           {{ $labels.source_cluster }} for more than 15 minutes.
+        alert_route_namespace: '{{ $labels.namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-crashLoopBackOff.md
     - alert: PodNotReady
       expr: |
@@ -45,4 +47,5 @@ spec:
         description: >-
           Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster
           {{ $labels.source_cluster }} is not ready for more than 15 minutes.
+        alert_route_namespace: '{{ $labels.namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-PodNotReady.md

--- a/test/promql/tests/control_plane/argocd_test.yaml
+++ b/test/promql/tests/control_plane/argocd_test.yaml
@@ -9,35 +9,35 @@ tests:
     input_series:
 
       # no app is degraded - shouldn't trigger alerts
-      - series: 'argocd_app_info{health_status="Degraded", name="not-degraded-app", namespace="argocd-staging", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Degraded", name="not-degraded-app", namespace="argocd-staging", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
         values: _x9
 
       # an app is constantly degraded - should trigger alerts
-      - series: 'argocd_app_info{health_status="Degraded", name="degraded-app", namespace="argocd-staging", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Degraded", name="degraded-app", namespace="argocd-staging", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
         values: 1x9
 
       # an app with some 1m degraded status - shouldn't trigger alerts
-      - series: 'argocd_app_info{health_status="Degraded", name="degraded-1m-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series: 'argocd_app_info{health_status="Degraded", name="degraded-1m-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: 1 _ _ _ 1 _ _ _ _ _
 
       # an app with a 4m degraded status - shouldn't trigger alerts
-      - series: 'argocd_app_info{health_status="Degraded", name="degraded-4m-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series: 'argocd_app_info{health_status="Degraded", name="degraded-4m-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: _ 1 1 1 1 _ _ _ _ _
 
       # an app is flapping every 1m - should trigger alerts triggers
-      - series: 'argocd_app_info{health_status="Degraded", name="flapping-1m-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series: 'argocd_app_info{health_status="Degraded", name="flapping-1m-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: 1 _ 1 _ 1 _ 1 _ 1 _
 
       # an app is flapping every 2m - should trigger alerts triggers
-      - series: 'argocd_app_info{health_status="Degraded", name="flapping-2m-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series: 'argocd_app_info{health_status="Degraded", name="flapping-2m-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: 1 _ _ 1 _ _ 1 _ _ 1
 
       # an app is flapping every 2m but on arbitrary namespace - should not trigger
-      - series: 'argocd_app_info{health_status="Degraded", name="flapping-2m-app", namespace="baz", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series: 'argocd_app_info{health_status="Degraded", name="flapping-2m-app", namespace="baz", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: 1 _ _ 1 _ _ 1 _ _ 1
 
       # an app is in another health status which is not 'Degraded' - the rule shouldn't alert.
-      - series: 'argocd_app_info{health_status="Progressing", name="progressing-app", namespace="argocd-staging", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Progressing", name="progressing-app", namespace="argocd-staging", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
         values: 1x9
 
 
@@ -47,6 +47,7 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: warning
+              dest_namespace: test_dest_namespace
               dest_server: https://api.foo.openshiftapps.com:6443
               namespace: argocd-staging
               health_status: Degraded
@@ -59,10 +60,12 @@ tests:
                 Application: degraded-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 Health status Degraded.
+              alert_route_namespace: test_dest_namespace
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
 
           - exp_labels:
               severity: warning
+              dest_namespace: test_dest_namespace
               dest_server: https://api.foo.openshiftapps.com:6443
               namespace: argocd
               health_status: Degraded
@@ -75,10 +78,12 @@ tests:
                 Application: flapping-1m-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 Health status Degraded.
+              alert_route_namespace: test_dest_namespace
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
 
           - exp_labels:
               severity: warning
+              dest_namespace: test_dest_namespace
               dest_server: https://api.foo.openshiftapps.com:6443
               namespace: argocd
               health_status: Degraded
@@ -91,6 +96,7 @@ tests:
                 Application: flapping-2m-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 Health status Degraded.
+              alert_route_namespace: test_dest_namespace
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
 
   # ProgressingArgocdApp alert
@@ -109,7 +115,7 @@ tests:
   - interval: 1m
     input_series:
       # App is always progressing, should raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="progressing-only-app", namespace="argocd-staging", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series: 'argocd_app_info{health_status="Progressing", name="progressing-only-app", namespace="argocd-staging", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
         values: 1x19
     alert_rule_test:
       - eval_time: 20m
@@ -117,6 +123,7 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: warning
+              dest_namespace: test_dest_namespace
               dest_server: https://api.foo.openshiftapps.com:6443
               namespace: argocd-staging
               health_status: Progressing
@@ -129,6 +136,7 @@ tests:
                 Application: progressing-only-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 App progressing for too long.
+              alert_route_namespace: test_dest_namespace
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-ProgressingArgocdApp.md
 
   - interval: 1m
@@ -182,14 +190,14 @@ tests:
   - interval: 1m
     input_series:
       # App 1: Progressing all of the time, should raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="Progressing_first-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series: 'argocd_app_info{health_status="Progressing", name="Progressing_first-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: 1x19
-      - series: 'argocd_app_info{health_status="Healthy", name="Progressing_first-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series: 'argocd_app_info{health_status="Healthy", name="Progressing_first-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: _x19
       # App 2: Progressing for 17 minutes and then healthy for 3 minutes, should not raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="Progressing_second-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series: 'argocd_app_info{health_status="Progressing", name="Progressing_second-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: 1x16 _ _ _
-      - series: 'argocd_app_info{health_status="Healthy", name="Progressing_second-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series: 'argocd_app_info{health_status="Healthy", name="Progressing_second-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
         values: _x16 1 1 1
     alert_rule_test:
       - eval_time: 20m
@@ -197,6 +205,7 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: warning
+              dest_namespace: test_dest_namespace
               dest_server: https://api.foo.openshiftapps.com:6443
               namespace: argocd
               health_status: Progressing
@@ -209,4 +218,5 @@ tests:
                 Application: Progressing_first-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 App progressing for too long.
+              alert_route_namespace: test_dest_namespace
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-ProgressingArgocdApp.md

--- a/test/promql/tests/data_plane/crashloopbackoff_test.yaml
+++ b/test/promql/tests/data_plane/crashloopbackoff_test.yaml
@@ -56,6 +56,7 @@ tests:
                 Pod test-ns/prod-pod-2 (test-container) is in waiting state
                 (reason: 'CrashLoopBackOff') on cluster cluster01 for more than 15
                 minutes.
+              alert_route_namespace: test-ns
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-crashLoopBackOff.md
           - exp_labels:
               severity: warning
@@ -70,4 +71,5 @@ tests:
                 Pod prod-ns/prod-pod-4 (test-container) is in waiting state
                 (reason: 'CrashLoopBackOff') on cluster cluster02 for more than 15
                 minutes.
+              alert_route_namespace: prod-ns
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-crashLoopBackOff.md

--- a/test/promql/tests/data_plane/gitops_argocd_app_reconcile_test.yaml
+++ b/test/promql/tests/data_plane/gitops_argocd_app_reconcile_test.yaml
@@ -27,6 +27,7 @@ tests:
                 Argo CD in namespace gitops-service-argocd
                 has failed to reconcile at least 99% of applications
                 within 4 seconds over the past 30 minutes
+              alert_route_namespace: "gitops-service-argocd"
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/gitops/argocd-app-reconcile.md
 
 # Test that an alert is raised if only 98.9% of applications are reconciled within 4 seconds
@@ -51,6 +52,7 @@ tests:
                 Argo CD in namespace gitops-service-argocd
                 has failed to reconcile at least 99% of applications
                 within 4 seconds over the past 30 minutes
+              alert_route_namespace: "gitops-service-argocd"
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/gitops/argocd-app-reconcile.md
 
 # Test that no alert is raised if 99% of applications are reconciled within 4 seconds

--- a/test/promql/tests/data_plane/notready_pods_test.yaml
+++ b/test/promql/tests/data_plane/notready_pods_test.yaml
@@ -37,6 +37,7 @@ tests:
               description: >-
                 Pod pod-1 in namespace ns-1 on cluster cluster01 is
                 not ready for more than 15 minutes.
+              alert_route_namespace: ns-1
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-PodNotReady.md
 
   - interval: 1m
@@ -71,6 +72,7 @@ tests:
               description: >-
                 Pod pod-1 in namespace ns-2 on cluster cluster02 is
                 not ready for more than 15 minutes.
+              alert_route_namespace: ns-2
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-PodNotReady.md
 
 
@@ -106,6 +108,7 @@ tests:
               description: >-
                 Pod pod-1 in namespace ns-3 on cluster cluster03 is
                 not ready for more than 15 minutes.
+              alert_route_namespace: ns-3
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-PodNotReady.md
 
   - interval: 1m

--- a/test/promql/tests/data_plane/unschedulable_pods_test.yaml
+++ b/test/promql/tests/data_plane/unschedulable_pods_test.yaml
@@ -49,4 +49,5 @@ tests:
               description: >-
                 Pod prod-pod-2 for namespace prod-test on cluster cluster02 is
                 unscheduled for more than 30 minutes.
+              alert_route_namespace: prod-test
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-unschedualablePods.md


### PR DESCRIPTION
Adds a "namespace" annotation to all `pod alerts` alerts,
and to `rhtap-gitops-argocd-app-reconcile-alert` alert.

This is used to test a future feature that will tag the team
relevant to the alert where the alert is recieved.
Alert recievers doesn't have access to the prometheus labels,
therefor the label has to be added to the alert itself, which
the reciever can access.

Although the "namespace" is available on some alerts as a default
label, adding it as an annotation for uniformity and readability sake.
