### PR TITLE
chore(RHTAPWATCH-675): Update annotations for control_plane alerts

### DIFF
--- a/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
+++ b/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
@@ -19,7 +19,8 @@ spec:
         severity: warning
         team: rhtap
       annotations:
-        message: |
+        summary: Argocd App '{{ $labels.name }}' is degraded
+        description: |
           Environment: {{ $labels.source_environment }}
           Application: {{ $labels.name }}
           Cluster: {{ $labels.dest_server }}
@@ -39,7 +40,8 @@ spec:
         severity: warning
         team: rhtap
       annotations:
-        message: |-
+        summary: Argocd App '{{ $labels.name }}' is progressing for too long
+        description: |-
           Environment: {{ $labels.source_environment }}
           Application: {{ $labels.name }}
           Cluster: {{ $labels.dest_server }}

--- a/test/promql/tests/control_plane/argocd_test.yaml
+++ b/test/promql/tests/control_plane/argocd_test.yaml
@@ -54,7 +54,8 @@ tests:
               source_environment: staging-cluster
               team: rhtap
             exp_annotations:
-              message: |
+              summary: Argocd App 'degraded-app' is degraded
+              description: |
                 Environment: staging-cluster
                 Application: degraded-app
                 Cluster: https://api.foo.openshiftapps.com:6443
@@ -70,7 +71,8 @@ tests:
               source_environment: production-cluster
               team: rhtap
             exp_annotations:
-              message: |
+              summary: Argocd App 'flapping-1m-app' is degraded
+              description: |
                 Environment: production-cluster
                 Application: flapping-1m-app
                 Cluster: https://api.foo.openshiftapps.com:6443
@@ -86,7 +88,8 @@ tests:
               source_environment: production-cluster
               team: rhtap
             exp_annotations:
-              message: |
+              summary: Argocd App 'flapping-2m-app' is degraded
+              description: |
                 Environment: production-cluster
                 Application: flapping-2m-app
                 Cluster: https://api.foo.openshiftapps.com:6443
@@ -124,7 +127,8 @@ tests:
               source_environment: staging-cluster
               team: rhtap
             exp_annotations:
-              message: |-
+              summary: Argocd App 'progressing-only-app' is progressing for too long
+              description: |-
                 Environment: staging-cluster
                 Application: progressing-only-app
                 Cluster: https://api.foo.openshiftapps.com:6443
@@ -204,7 +208,8 @@ tests:
               source_environment: production-cluster
               team: rhtap
             exp_annotations:
-              message: |-
+              summary: Argocd App 'Progressing_first-app' is progressing for too long
+              description: |-
                 Environment: production-cluster
                 Application: Progressing_first-app
                 Cluster: https://api.foo.openshiftapps.com:6443


### PR DESCRIPTION
Adding a `summary` annotation and rename the `message` annotation to `description` to be alligned with all the alerts in `o11y` and to make it easier to extract these values when we route the alerts.