### PR TITLE
chore(RHTAPWATCH-734): Alert routing namespace annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ Apply `slo: "true"` under labels section of any alerting rule.
       slo: "true"
   ```
 
+### Alerts Tagging
+
+Teams receive updates on alerts relevant to them through Slack notifications, 
+where the team's handle is tagged in the alert message.
+
+#### Usage Guidelines:
+
+Apply the `alert_route_namespace` annotation to alerts in order to get notified about them.
+  
+#### How to apply the `alert_route_namespace` Annotation:
+
+Apply the `alert_route_namespace` key to the annotations section of any alerting rule,
+with one of the team's namespaces as its value.
+  ```
+  annotations:
+      summary: "PipelineRunFinish to SnapshotInProgress time exceeded"
+      alert_route_namespace: "application-service"
+  ```
+
 ### Updating Alerts
 
 Alert rules for data plane and control plane clusters are being deployed by app-interface 

--- a/rhobs/alerting/data_plane/prometheus.application_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.application_alerts.yaml
@@ -25,6 +25,7 @@ spec:
           Application controller in Pod {{ $labels.pod }} for namespace
           {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
           successfully delete at least 95% of applications over the past hour
+        alert_route_namespace: 'application-service'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-delete-failed.md
     - alert: ApplicationCreationErrors
       expr: |
@@ -42,4 +43,5 @@ spec:
           Application controller in Pod {{ $labels.pod }} for namespace
           {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
           successfully create at least 95% of applications over the past hour
+        alert_route_namespace: 'application-service'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-create-failed.md

--- a/rhobs/alerting/data_plane/prometheus.component_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.component_alerts.yaml
@@ -25,6 +25,7 @@ spec:
           Component controller in Pod {{ $labels.pod }} for namespace
           {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
           successfully delete at least 95% of components over the past hour
+        alert_route_namespace: application-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
     - alert: ComponentCreationErrors
       expr: |
@@ -42,4 +43,5 @@ spec:
           Component controller in Pod {{ $labels.pod }} for namespace
           {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
           successfully create at least 95% of components over the past hour
+        alert_route_namespace: application-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md

--- a/rhobs/alerting/data_plane/prometheus.latency_component_onboarding_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_component_onboarding_alerts.yaml
@@ -31,4 +31,5 @@ spec:
           if PaC provision is requested upon the Component creation, then till the provision finishes has been over
           60s for more than 10% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
+        alert_route_namespace: build-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_component_onboarding.md

--- a/rhobs/alerting/data_plane/prometheus.latency_image_repository_provision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_image_repository_provision_alerts.yaml
@@ -30,4 +30,5 @@ spec:
           Time taken to provision image repository has been over
           30s for more than 5% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
+        alert_route_namespace: image-controller
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/latency_image_repository_provision.md

--- a/rhobs/alerting/data_plane/prometheus.latency_pac_provision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_pac_provision_alerts.yaml
@@ -30,4 +30,5 @@ spec:
           Time taken from PaC provision request till Component is provisioned for PaC builds has been over
           20s for more than 5% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
+        alert_route_namespace: build-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_provision.md

--- a/rhobs/alerting/data_plane/prometheus.latency_pac_unprovision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_pac_unprovision_alerts.yaml
@@ -30,4 +30,5 @@ spec:
           Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
           20s for more than 5% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
+        alert_route_namespace: build-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_unprovision.md

--- a/rhobs/alerting/data_plane/prometheus.latency_release_creation_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_release_creation_alerts.yaml
@@ -30,4 +30,5 @@ spec:
           Time from Snapshot marked as passed to release created has been over
           10s for more than 10% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
+        alert_route_namespace: integration-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md

--- a/rhobs/alerting/data_plane/prometheus.latency_simple_build_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_simple_build_alerts.yaml
@@ -30,4 +30,5 @@ spec:
           Time taken from simple build request till the build pipeline is submitted has been over
           15s for more than 5% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
+        alert_route_namespace: build-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_simple_build.md

--- a/rhobs/alerting/data_plane/prometheus.latency_snapshot_to_static_integration_plr_creation_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_snapshot_to_static_integration_plr_creation_alerts.yaml
@@ -30,4 +30,5 @@ spec:
           Time from Snapshot created to integration PLRs in static envs created has been over
           5s for {{ $value | humanizePercentage }} of requests (tolerance 10%) during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
+        alert_route_namespace: integration-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md

--- a/rhobs/alerting/data_plane/prometheus.oauth_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.oauth_alerts.yaml
@@ -24,4 +24,5 @@ spec:
             description: >-
               The average OAuth login time on cluster {{ $labels.source_cluster }} has
               {{ $value }} sec for the last 5 minutes
+            alert_route_namespace: spi-system
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/oauth_login.md

--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -25,6 +25,7 @@ spec:
             description: >-
               Tekton controller on cluster {{ $labels.source_cluster }} the percentage of time needed to receive PipelineRun creation
               events vs. overall PipelineRun execution time is at {{ $value | humanizePercentage }} instead of less than 5%.
+            alert_route_namespace: plnsvc-tests
             runbook_url: TBD
         - alert: HighExecutionOverhead
           expr: |
@@ -42,4 +43,5 @@ spec:
             description: >-
               Tekton controller on cluster {{ $labels.source_cluster }} the percentage of the time needed to create
               underlying TaskRuns vs. overall PipelineRun execution time is at {{ $value | humanizePercentage }} instead of less than 5%.
+            alert_route_namespace: plnsvc-tests
             runbook_url: TBD

--- a/rhobs/alerting/data_plane/prometheus.pipeline_to_snapshot_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_to_snapshot_alerts.yaml
@@ -30,4 +30,5 @@ spec:
           Time from pipeline run finished to snapshot marked in progress has been over
           30s for more than 10% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
+        alert_route_namespace: plnsvc-tests
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md

--- a/rhobs/alerting/data_plane/prometheus.pv_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pv_alerts.yaml
@@ -20,4 +20,5 @@ spec:
         description: >-
           Persistent Volume {{ $labels.persistentvolume }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }}
           is in {{ $labels.phase }} phase for more than 5 minutes.
+        alert_route_namespace: '{{ $labels.namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-pesistentVolumeIssues.md

--- a/rhobs/alerting/data_plane/prometheus.quota_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.quota_alerts.yaml
@@ -25,4 +25,5 @@ spec:
           Resource {{ $labels.resource }} in namespace {{ $labels.namespace }}
           on cluster {{ $labels.source_cluster }} exceeded quota
           {{ $labels.resourcequota }}.
+        alert_route_namespace: '{{ $labels.namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-QuotaExceeded.md

--- a/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
@@ -45,6 +45,7 @@ spec:
           90% of Releases must be processed under one hour
         description: >-
           Release service is failing to successfully process within the period of one hour for 90% of releases
+        alert_route_namespace: release-service
 
     - alert: ReleaseServicePreProcessingDurationSeconds
       expr: |
@@ -60,6 +61,7 @@ spec:
           90% of Releases must start processing under 10 seconds
         description: >-
           Release service is failing to start processing under 10 seconds for 90% of releases
+        alert_route_namespace: release-service
 
     - alert: ReleaseServiceValidationDurationSeconds
       expr: |
@@ -75,3 +77,4 @@ spec:
           90% of Releases must be validated under 5 seconds
         description: >-
           Release service is failing to run the validations under 5 seconds for 90% of releases
+        alert_route_namespace: release-service

--- a/rhobs/alerting/data_plane/prometheus.seb_created_to_ready_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.seb_created_to_ready_alerts.yaml
@@ -30,4 +30,5 @@ spec:
           Time from Snapshot Environment Binding created to marked as
           ready has been over 120s for more than 10% of requests during
           the last 5 minutes on cluster {{ $labels.source_cluster }}
+        alert_route_namespace: integration-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/seb_created_to_ready.md

--- a/rhobs/alerting/data_plane/prometheus.serviceprovider_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.serviceprovider_alerts.yaml
@@ -28,4 +28,5 @@ spec:
               Application controller in Pod {{ $labels.pod }} for namespace
               {{ $labels.namespace }} on instance {{ $labels.source_cluster }} having a
               {{ $value | humanizePercentage }} of 5xx errors from service provider {{ $labels.sp }} for latest 60 minutes
+            alert_route_namespace: spi-system
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/alert-rule-serviceprovider5xxErrorsRate.md

--- a/rhobs/alerting/data_plane/prometheus.stability_image_repository_provision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_image_repository_provision_alerts.yaml
@@ -30,4 +30,5 @@ spec:
           Time taken to provision image repository has been over
           5 minutes for more than 1% of requests during the last 10 minutes on cluster
           {{ $labels.source_cluster }}
+        alert_route_namespace: image-controller
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision.md

--- a/rhobs/alerting/data_plane/prometheus.stability_image_repository_provision_failures_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_image_repository_provision_failures_alerts.yaml
@@ -22,4 +22,5 @@ spec:
         description: >
           Provision image repository failures occured for more than 5 requests during the last 30 minutes
           {{ $labels.source_cluster }}
+        alert_route_namespace: image-controller
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision_failures.md

--- a/rhobs/alerting/data_plane/prometheus.stability_pac_provision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_pac_provision_alerts.yaml
@@ -30,4 +30,5 @@ spec:
           Time taken from PaC provision request till Component is provisioned for PaC builds has been over
           5 minutes for more than 1% of requests during the last 10 minutes on cluster
           {{ $labels.source_cluster }}
+        alert_route_namespace: build-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_provision.md

--- a/rhobs/alerting/data_plane/prometheus.stability_pac_unprovision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_pac_unprovision_alerts.yaml
@@ -30,4 +30,5 @@ spec:
           Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
           5 minutes for more than 1% of requests during the last 10 minutes on cluster
           {{ $labels.source_cluster }}
+        alert_route_namespace: build-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_unprovision.md

--- a/rhobs/alerting/data_plane/prometheus.stability_simple_build_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_simple_build_alerts.yaml
@@ -30,4 +30,5 @@ spec:
           Time taken from simple build request till the build pipeline is submitted has been over
           5 minutes for more than 1% of requests during the last 10 minutes on cluster
           {{ $labels.source_cluster }}
+        alert_route_namespace: build-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_simple_build.md

--- a/test/promql/tests/data_plane/application_errors_test.yaml
+++ b/test/promql/tests/data_plane/application_errors_test.yaml
@@ -31,6 +31,7 @@ tests:
                 Application controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of applications over the past hour
+              alert_route_namespace: 'application-service'
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-delete-failed.md
 
   - interval: 1m
@@ -59,6 +60,7 @@ tests:
                 Application controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of applications over the past hour
+              alert_route_namespace: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-delete-failed.md
 
   - interval: 1m
@@ -115,6 +117,7 @@ tests:
                 Application controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully create at least 95% of applications over the past hour
+              alert_route_namespace: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-create-failed.md
 
   - interval: 1m
@@ -143,6 +146,7 @@ tests:
                 Application controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully create at least 95% of applications over the past hour
+              alert_route_namespace: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-create-failed.md
 
   - interval: 1m

--- a/test/promql/tests/data_plane/component_errors_test.yaml
+++ b/test/promql/tests/data_plane/component_errors_test.yaml
@@ -41,6 +41,7 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of components over the past hour
+              alert_route_namespace: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
 
   - interval: 1m
@@ -69,6 +70,7 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of components over the past hour
+              alert_route_namespace: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
 
   - interval: 1m
@@ -98,6 +100,7 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of components over the past hour
+              alert_route_namespace: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
 
   - interval: 1m
@@ -164,6 +167,7 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully create at least 95% of components over the past hour
+              alert_route_namespace: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md
 
   - interval: 1m
@@ -192,6 +196,7 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully create at least 95% of components over the past hour
+              alert_route_namespace: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md
 
   - interval: 1m
@@ -221,6 +226,7 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully create at least 95% of components over the past hour
+              alert_route_namespace: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md
 
   - interval: 1m

--- a/test/promql/tests/data_plane/latency_component_onboarding_test.yaml
+++ b/test/promql/tests/data_plane/latency_component_onboarding_test.yaml
@@ -35,6 +35,7 @@ tests:
                 if PaC provision is requested upon the Component creation, then till the provision finishes has been over
                 60s for more than 10% of requests during the last 5 minutes on cluster
                 cluster01
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_component_onboarding.md
 
 # Scenario where both clusters cross the 10% threshold
@@ -68,6 +69,7 @@ tests:
                 if PaC provision is requested upon the Component creation, then till the provision finishes has been over
                 60s for more than 10% of requests during the last 5 minutes on cluster
                 cluster01
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_component_onboarding.md
           - exp_labels:
               severity: warning
@@ -80,6 +82,7 @@ tests:
                 if PaC provision is requested upon the Component creation, then till the provision finishes has been over
                 60s for more than 10% of requests during the last 5 minutes on cluster
                 cluster02
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_component_onboarding.md
 
 # Scenario where neither cluster crosses the 10% threshold

--- a/test/promql/tests/data_plane/latency_image_repository_provision_test.yaml
+++ b/test/promql/tests/data_plane/latency_image_repository_provision_test.yaml
@@ -34,6 +34,7 @@ tests:
                 Time taken to provision image repository has been over
                 30s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
+              alert_route_namespace: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/latency_image_repository_provision.md
 
 # Scenario where both clusters cross the 5% threshold
@@ -66,6 +67,7 @@ tests:
                 Time taken to provision image repository has been over
                 30s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
+              alert_route_namespace: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/latency_image_repository_provision.md
           - exp_labels:
               severity: warning
@@ -77,6 +79,7 @@ tests:
                 Time taken to provision image repository has been over
                 30s for more than 5% of requests during the last 5 minutes on cluster
                 cluster02
+              alert_route_namespace: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/latency_image_repository_provision.md
 
 # Scenario where neither cluster crosses the 5% threshold

--- a/test/promql/tests/data_plane/latency_pac_provision_test.yaml
+++ b/test/promql/tests/data_plane/latency_pac_provision_test.yaml
@@ -34,6 +34,7 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_provision.md
 
 # Scenario where both clusters cross the 5% threshold
@@ -66,6 +67,7 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_provision.md
           - exp_labels:
               severity: warning
@@ -77,6 +79,7 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster02
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_provision.md
 
 # Scenario where neither cluster crosses the 5% threshold

--- a/test/promql/tests/data_plane/latency_pac_unprovision_test.yaml
+++ b/test/promql/tests/data_plane/latency_pac_unprovision_test.yaml
@@ -34,6 +34,7 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_unprovision.md
 
 # Scenario where both clusters cross the 5% threshold
@@ -66,6 +67,7 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_unprovision.md
           - exp_labels:
               severity: warning
@@ -77,6 +79,7 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster02
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_unprovision.md
 
 # Scenario where neither cluster crosses the 5% threshold

--- a/test/promql/tests/data_plane/latency_release_creation_test.yaml
+++ b/test/promql/tests/data_plane/latency_release_creation_test.yaml
@@ -32,6 +32,7 @@ tests:
                 Time from Snapshot marked as passed to release created has been over
                 10s for more than 10% of requests during the last 5 minutes on cluster
                 cluster01
+              alert_route_namespace: integration-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md
 
 # Scenario where both clusters cross the 10% threshold
@@ -64,6 +65,7 @@ tests:
                 Time from Snapshot marked as passed to release created has been over
                 10s for more than 10% of requests during the last 5 minutes on cluster
                 cluster01
+              alert_route_namespace: integration-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md
           - exp_labels:
               severity: warning
@@ -75,6 +77,7 @@ tests:
                 Time from Snapshot marked as passed to release created has been over
                 10s for more than 10% of requests during the last 5 minutes on cluster
                 cluster02
+              alert_route_namespace: integration-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md
 
 # Scenario where neither cluster crosses the 10% threshold

--- a/test/promql/tests/data_plane/latency_simple_build_test.yaml
+++ b/test/promql/tests/data_plane/latency_simple_build_test.yaml
@@ -34,6 +34,7 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 15s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_simple_build.md
 
 # Scenario where both clusters cross the 5% threshold
@@ -66,6 +67,7 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 15s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_simple_build.md
           - exp_labels:
               severity: warning
@@ -77,6 +79,7 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 15s for more than 5% of requests during the last 5 minutes on cluster
                 cluster02
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_simple_build.md
 
 # Scenario where neither cluster crosses the 5% threshold

--- a/test/promql/tests/data_plane/latency_snapshot_to_static_integration_plr_creation_test.yaml
+++ b/test/promql/tests/data_plane/latency_snapshot_to_static_integration_plr_creation_test.yaml
@@ -32,6 +32,7 @@ tests:
                 Time from Snapshot created to integration PLRs in static envs created has been over
                 5s for 90% of requests (tolerance 10%) during the last 5 minutes on cluster
                 cluster01
+              alert_route_namespace: integration-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md
 
 # Scenario where both clusters cross the 10% threshold
@@ -64,6 +65,7 @@ tests:
                 Time from Snapshot created to integration PLRs in static envs created has been over
                 5s for 95% of requests (tolerance 10%) during the last 5 minutes on cluster
                 cluster01
+              alert_route_namespace: integration-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md
           - exp_labels:
               severity: warning
@@ -75,6 +77,7 @@ tests:
                 Time from Snapshot created to integration PLRs in static envs created has been over
                 5s for 95% of requests (tolerance 10%) during the last 5 minutes on cluster
                 cluster02
+              alert_route_namespace: integration-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md
 
 # Scenario where neither cluster crosses the 10% threshold

--- a/test/promql/tests/data_plane/oauth_time_test.yaml
+++ b/test/promql/tests/data_plane/oauth_time_test.yaml
@@ -29,6 +29,7 @@ tests:
                 OAuth login average time is more than 30 sec on cluster01
               description: >-
                 The average OAuth login time on cluster cluster01 has 50 sec for the last 5 minutes
+              alert_route_namespace: spi-system
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/oauth_login.md
 
   - interval: 1m
@@ -60,6 +61,7 @@ tests:
                 OAuth login average time is more than 30 sec on cluster01
               description: >-
                 The average OAuth login time on cluster cluster01 has 50 sec for the last 5 minutes
+              alert_route_namespace: spi-system
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/oauth_login.md
           - exp_labels:
               severity: warning
@@ -73,6 +75,7 @@ tests:
                 OAuth login average time is more than 30 sec on cluster02
               description: >-
                 The average OAuth login time on cluster cluster02 has 60 sec for the last 5 minutes
+              alert_route_namespace: spi-system
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/oauth_login.md
 
 

--- a/test/promql/tests/data_plane/persistentvolumeissues_test.yaml
+++ b/test/promql/tests/data_plane/persistentvolumeissues_test.yaml
@@ -36,6 +36,7 @@ tests:
               description: >-
                 Persistent Volume pv-1 in namespace ns-1 on cluster cluster01
                 is in Pending phase for more than 5 minutes.
+              alert_route_namespace: ns-1
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-pesistentVolumeIssues.md
 
   - interval: 1m
@@ -68,6 +69,7 @@ tests:
               description: >-
                 Persistent Volume pv-2 in namespace ns-2 on cluster cluster02
                 is in Failed phase for more than 5 minutes.
+              alert_route_namespace: ns-2
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-pesistentVolumeIssues.md
 
   # Not Alerted cases:

--- a/test/promql/tests/data_plane/pipeline_overhead_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_overhead_test.yaml
@@ -37,6 +37,7 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 the percentage of time needed to receive PipelineRun creation
                 events vs. overall PipelineRun execution time is at 100% instead of less than 5%.
+              alert_route_namespace: plnsvc-tests
               runbook_url: TBD
 
   - interval: 1m
@@ -71,6 +72,7 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 the percentage of time needed to receive PipelineRun creation
                 events vs. overall PipelineRun execution time is at 50% instead of less than 5%.
+              alert_route_namespace: plnsvc-tests
               runbook_url: TBD
 
   - interval: 1m
@@ -128,6 +130,7 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 the percentage of the time needed to create
                 underlying TaskRuns vs. overall PipelineRun execution time is at 100% instead of less than 5%.
+              alert_route_namespace: plnsvc-tests
               runbook_url: TBD
 
   - interval: 1m
@@ -166,6 +169,7 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 the percentage of the time needed to create
                 underlying TaskRuns vs. overall PipelineRun execution time is at 5.263% instead of less than 5%.
+              alert_route_namespace: plnsvc-tests
               runbook_url: TBD
 
   - interval: 1m

--- a/test/promql/tests/data_plane/pipeline_to_snapshot_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_to_snapshot_test.yaml
@@ -33,6 +33,7 @@ tests:
               Time from pipeline run finished to snapshot marked in progress has been over
               30s for more than 10% of requests during the last 5 minutes on cluster
               cluster01
+            alert_route_namespace: plnsvc-tests
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md
 
 # Scenario where both clusters cross the 10% threshold, alert should trigger for both
@@ -63,6 +64,7 @@ tests:
               Time from pipeline run finished to snapshot marked in progress has been over
               30s for more than 10% of requests during the last 5 minutes on cluster
               cluster01
+            alert_route_namespace: plnsvc-tests
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md
         - exp_labels:
             severity: warning
@@ -75,6 +77,7 @@ tests:
               Time from pipeline run finished to snapshot marked in progress has been over
               30s for more than 10% of requests during the last 5 minutes on cluster
               cluster02
+            alert_route_namespace: plnsvc-tests
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md
 
 # Scenario where no alert is triggered as both clusters stay below the 10% threshold

--- a/test/promql/tests/data_plane/quota_exceeded_test.yaml
+++ b/test/promql/tests/data_plane/quota_exceeded_test.yaml
@@ -41,6 +41,7 @@ tests:
               description: >-
                 Resource example-resource in namespace exceeding-limits on cluster
                 cluster01 exceeded quota test-quota.
+              alert_route_namespace: exceeding-limits
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-QuotaExceeded.md
 
   - interval: 1m

--- a/test/promql/tests/data_plane/release_service_test.yaml
+++ b/test/promql/tests/data_plane/release_service_test.yaml
@@ -6,13 +6,13 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: 'release_processing_duration_seconds_bucket{le="3600", job="release", source_cluster="cluster01"}'
+      - series: 'release_processing_duration_seconds_bucket{le="3600", job="release", namespace="foo", source_cluster="cluster01"}'
         values: '1+8x59'
-      - series: 'release_processing_duration_seconds_count{job="release", source_cluster="cluster01"}'
+      - series: 'release_processing_duration_seconds_count{job="release", namespace="foo", source_cluster="cluster01"}'
         values: '1+9x59'
-      - series: 'release_processing_duration_seconds_bucket{le="3600", job="release", source_cluster="cluster02"}'
+      - series: 'release_processing_duration_seconds_bucket{le="3600", job="release", namespace="foo", source_cluster="cluster02"}'
         values: '1+8x59'
-      - series: 'release_processing_duration_seconds_count{job="release", source_cluster="cluster02"}'
+      - series: 'release_processing_duration_seconds_count{job="release", namespace="foo", source_cluster="cluster02"}'
         values: '1+9x59'
     alert_rule_test:
       - eval_time: 1h
@@ -27,16 +27,17 @@ tests:
                 90% of Releases must be processed under one hour
               description: >-
                 Release service is failing to successfully process within the period of one hour for 90% of releases
+              alert_route_namespace: release-service
 
   - interval: 1m
     input_series:
-      - series: 'release_pre_processing_duration_seconds_bucket{le="10", job="release", source_cluster="cluster01"}'
+      - series: 'release_pre_processing_duration_seconds_bucket{le="10", job="release", namespace="foo", source_cluster="cluster01"}'
         values: '1+8x59'
-      - series: 'release_pre_processing_duration_seconds_count{job="release", source_cluster="cluster01"}'
+      - series: 'release_pre_processing_duration_seconds_count{job="release", namespace="foo", source_cluster="cluster01"}'
         values: '1+9x59'
-      - series: 'release_pre_processing_duration_seconds_bucket{le="10", job="release", source_cluster="cluster02"}'
+      - series: 'release_pre_processing_duration_seconds_bucket{le="10", job="release", namespace="foo", source_cluster="cluster02"}'
         values: '1+8x59'
-      - series: 'release_pre_processing_duration_seconds_count{job="release", source_cluster="cluster02"}'
+      - series: 'release_pre_processing_duration_seconds_count{job="release", namespace="foo", source_cluster="cluster02"}'
         values: '1+9x59'
     alert_rule_test:
       - eval_time: 1h
@@ -51,16 +52,17 @@ tests:
                 90% of Releases must start processing under 10 seconds
               description: >-
                 Release service is failing to start processing under 10 seconds for 90% of releases
+              alert_route_namespace: release-service
 
   - interval: 1m
     input_series:
-      - series: 'release_validation_duration_seconds_bucket{le="5", job="release", source_cluster="cluster01"}'
+      - series: 'release_validation_duration_seconds_bucket{le="5", job="release", namespace="foo", source_cluster="cluster01"}'
         values: '1+8x59'
-      - series: 'release_validation_duration_seconds_count{job="release", source_cluster="cluster01"}'
+      - series: 'release_validation_duration_seconds_count{job="release", namespace="foo", source_cluster="cluster01"}'
         values: '1+9x59'
-      - series: 'release_validation_duration_seconds_bucket{le="5", job="release", source_cluster="cluster02"}'
+      - series: 'release_validation_duration_seconds_bucket{le="5", job="release", namespace="foo", source_cluster="cluster02"}'
         values: '1+8x59'
-      - series: 'release_validation_duration_seconds_count{job="release", source_cluster="cluster02"}'
+      - series: 'release_validation_duration_seconds_count{job="release", namespace="foo", source_cluster="cluster02"}'
         values: '1+9x59'
     alert_rule_test:
       - eval_time: 1h
@@ -75,3 +77,4 @@ tests:
                 90% of Releases must be validated under 5 seconds
               description: >-
                 Release service is failing to run the validations under 5 seconds for 90% of releases
+              alert_route_namespace: release-service

--- a/test/promql/tests/data_plane/seb_created_to_ready_test.yaml
+++ b/test/promql/tests/data_plane/seb_created_to_ready_test.yaml
@@ -27,6 +27,7 @@ tests:
                 Time from Snapshot Environment Binding created to marked as
                 ready has been over 120s for more than 10% of requests during
                 the last 5 minutes on cluster cluster01
+              alert_route_namespace: "integration-service"
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/seb_created_to_ready.md
 
   # Scenario where both clusters exceed the 10% threshold
@@ -57,6 +58,7 @@ tests:
                 Time from Snapshot Environment Binding created to marked as
                 ready has been over 120s for more than 10% of requests during
                 the last 5 minutes on cluster cluster01
+              alert_route_namespace: "integration-service"
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/seb_created_to_ready.md
 
           - exp_labels:
@@ -69,6 +71,7 @@ tests:
                 Time from Snapshot Environment Binding created to marked as
                 ready has been over 120s for more than 10% of requests during
                 the last 5 minutes on cluster cluster02
+              alert_route_namespace: "integration-service"
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/seb_created_to_ready.md
 
   # Scenario where neither cluster crosses the 10% threshold

--- a/test/promql/tests/data_plane/serviceprovider_errors_test.yaml
+++ b/test/promql/tests/data_plane/serviceprovider_errors_test.yaml
@@ -32,6 +32,7 @@ tests:
                 Application controller in Pod spi-controller-manager for namespace
                 spi-system on instance cluster01 having a 50% of 5xx errors
                 from service provider GitHub for latest 60 minutes
+              alert_route_namespace: spi-system
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/alert-rule-serviceprovider5xxErrorsRate.md
 
   - interval: 1m
@@ -64,6 +65,7 @@ tests:
                 Application controller in Pod spi-controller-manager for namespace
                 spi-system on instance cluster01 having a 33.33% of 5xx errors
                 from service provider GitHub for latest 60 minutes
+              alert_route_namespace: spi-system
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/alert-rule-serviceprovider5xxErrorsRate.md
 
 

--- a/test/promql/tests/data_plane/stability_image_repository_provision_failures_test.yaml
+++ b/test/promql/tests/data_plane/stability_image_repository_provision_failures_test.yaml
@@ -29,6 +29,7 @@ tests:
               description: >
                 Provision image repository failures occured for more than 5 requests during the last 30 minutes
                 cluster01
+              alert_route_namespace: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision_failures.md
 
 # Scenario where both clusters cross the 5 threshold
@@ -56,6 +57,7 @@ tests:
               description: >
                 Provision image repository failures occured for more than 5 requests during the last 30 minutes
                 cluster01
+              alert_route_namespace: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision_failures.md
           - exp_labels:
               severity: warning
@@ -66,6 +68,7 @@ tests:
               description: >
                 Provision image repository failures occured for more than 5 requests during the last 30 minutes
                 cluster02
+              alert_route_namespace: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision_failures.md
 
 # Scenario where neither cluster crosses the 5 threshold

--- a/test/promql/tests/data_plane/stability_image_repository_provision_test.yaml
+++ b/test/promql/tests/data_plane/stability_image_repository_provision_test.yaml
@@ -34,6 +34,7 @@ tests:
                 Time taken to provision image repository has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
+              alert_route_namespace: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision.md
 
 # Scenario where both clusters cross the 1% threshold
@@ -66,6 +67,7 @@ tests:
                 Time taken to provision image repository has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
+              alert_route_namespace: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision.md
           - exp_labels:
               severity: warning
@@ -77,6 +79,7 @@ tests:
                 Time taken to provision image repository has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster02
+              alert_route_namespace: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision.md
 
 # Scenario where neither cluster crosses the 1% threshold

--- a/test/promql/tests/data_plane/stability_pac_provision_test.yaml
+++ b/test/promql/tests/data_plane/stability_pac_provision_test.yaml
@@ -34,6 +34,7 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_provision.md
 
 # Scenario where both clusters cross the 1% threshold
@@ -66,6 +67,7 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_provision.md
           - exp_labels:
               severity: warning
@@ -77,6 +79,7 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster02
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_provision.md
 
 # Scenario where neither cluster crosses the 1% threshold

--- a/test/promql/tests/data_plane/stability_pac_unprovision_test.yaml
+++ b/test/promql/tests/data_plane/stability_pac_unprovision_test.yaml
@@ -34,6 +34,7 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_unprovision.md
 
 # Scenario where both clusters cross the 1% threshold
@@ -66,6 +67,7 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_unprovision.md
           - exp_labels:
               severity: warning
@@ -77,6 +79,7 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster02
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_unprovision.md
 
 # Scenario where neither cluster crosses the 1% threshold

--- a/test/promql/tests/data_plane/stability_simple_build_test.yaml
+++ b/test/promql/tests/data_plane/stability_simple_build_test.yaml
@@ -34,6 +34,7 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_simple_build.md
 
 # Scenario where both clusters cross the 1% threshold
@@ -66,6 +67,7 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_simple_build.md
           - exp_labels:
               severity: warning
@@ -77,6 +79,7 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster02
+              alert_route_namespace: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_simple_build.md
 
 # Scenario where neither cluster crosses the 1% threshold


### PR DESCRIPTION
Adds an "alert_routing_namespace" annotation on all available alerts and tests to allow for alert-tagging in Slack.

Alerts which belongs to a specific team have an hard-coded value for this annotation, while non-specific alerts derive it from the namespace label.