### PR TITLE
chore(RHTAPWATCH-734): annotate `alert_routing_key` instead of namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,21 @@ where the team's handle is tagged in the alert message.
 
 #### Usage Guidelines:
 
-Apply the `alert_route_namespace` annotation to alerts in order to get notified about them.
+Apply the `alert_routing_key` annotation to alerts in order to get notified about them.
   
-#### How to apply the `alert_route_namespace` Annotation:
+#### How to apply the `alert_routing_key` Annotation:
 
-Apply the `alert_route_namespace` key to the annotations section of any alerting rule,
-with one of the team's namespaces as its value.
+Apply the `alert_routing_key` key to the annotations section of any alerting rule,
+with one of the team's namespaces as its value, or the team's name.
   ```
   annotations:
       summary: "PipelineRunFinish to SnapshotInProgress time exceeded"
-      alert_route_namespace: "application-service"
+      alert_routing_key: "application-service"
   ```
+
+make sure that the team's name is aligned with the one mentioned in 
+[app-interface's logic](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/resources/rhobs/stage/alertmanager-routes-mst.secret.yaml?ref_type=heads#L75). 
+if the team is missing from the conditional statement in that file, make sure to add it.
 
 ### Updating Alerts
 

--- a/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
+++ b/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
@@ -25,7 +25,7 @@ spec:
           Application: {{ $labels.name }}
           Cluster: {{ $labels.dest_server }}
           Health status Degraded.
-        alert_route_namespace: '{{ $labels.dest_namespace }}'
+        alert_routing_key: '{{ $labels.dest_namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
     - alert: ProgressingArgocdApp
       expr: |
@@ -47,5 +47,5 @@ spec:
           Application: {{ $labels.name }}
           Cluster: {{ $labels.dest_server }}
           App progressing for too long.
-        alert_route_namespace: '{{ $labels.dest_namespace }}'
+        alert_routing_key: '{{ $labels.dest_namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-ProgressingArgocdApp.md

--- a/rhobs/alerting/data_plane/prometheus.application_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.application_alerts.yaml
@@ -25,7 +25,7 @@ spec:
           Application controller in Pod {{ $labels.pod }} for namespace
           {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
           successfully delete at least 95% of applications over the past hour
-        alert_route_namespace: 'application-service'
+        alert_routing_key: 'application-service'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-delete-failed.md
     - alert: ApplicationCreationErrors
       expr: |
@@ -43,5 +43,5 @@ spec:
           Application controller in Pod {{ $labels.pod }} for namespace
           {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
           successfully create at least 95% of applications over the past hour
-        alert_route_namespace: 'application-service'
+        alert_routing_key: 'application-service'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-create-failed.md

--- a/rhobs/alerting/data_plane/prometheus.component_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.component_alerts.yaml
@@ -25,7 +25,7 @@ spec:
           Component controller in Pod {{ $labels.pod }} for namespace
           {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
           successfully delete at least 95% of components over the past hour
-        alert_route_namespace: application-service
+        alert_routing_key: application-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
     - alert: ComponentCreationErrors
       expr: |
@@ -43,5 +43,5 @@ spec:
           Component controller in Pod {{ $labels.pod }} for namespace
           {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
           successfully create at least 95% of components over the past hour
-        alert_route_namespace: application-service
+        alert_routing_key: application-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md

--- a/rhobs/alerting/data_plane/prometheus.latency_component_onboarding_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_component_onboarding_alerts.yaml
@@ -31,5 +31,5 @@ spec:
           if PaC provision is requested upon the Component creation, then till the provision finishes has been over
           60s for more than 10% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_route_namespace: build-service
+        alert_routing_key: build-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_component_onboarding.md

--- a/rhobs/alerting/data_plane/prometheus.latency_image_repository_provision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_image_repository_provision_alerts.yaml
@@ -30,5 +30,5 @@ spec:
           Time taken to provision image repository has been over
           30s for more than 5% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_route_namespace: image-controller
+        alert_routing_key: image-controller
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/latency_image_repository_provision.md

--- a/rhobs/alerting/data_plane/prometheus.latency_pac_provision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_pac_provision_alerts.yaml
@@ -30,5 +30,5 @@ spec:
           Time taken from PaC provision request till Component is provisioned for PaC builds has been over
           20s for more than 5% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_route_namespace: build-service
+        alert_routing_key: build-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_provision.md

--- a/rhobs/alerting/data_plane/prometheus.latency_pac_unprovision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_pac_unprovision_alerts.yaml
@@ -30,5 +30,5 @@ spec:
           Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
           20s for more than 5% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_route_namespace: build-service
+        alert_routing_key: build-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_unprovision.md

--- a/rhobs/alerting/data_plane/prometheus.latency_release_creation_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_release_creation_alerts.yaml
@@ -30,5 +30,5 @@ spec:
           Time from Snapshot marked as passed to release created has been over
           10s for more than 10% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_route_namespace: integration-service
+        alert_routing_key: integration-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md

--- a/rhobs/alerting/data_plane/prometheus.latency_simple_build_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_simple_build_alerts.yaml
@@ -30,5 +30,5 @@ spec:
           Time taken from simple build request till the build pipeline is submitted has been over
           15s for more than 5% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_route_namespace: build-service
+        alert_routing_key: build-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_simple_build.md

--- a/rhobs/alerting/data_plane/prometheus.latency_snapshot_to_static_integration_plr_creation_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_snapshot_to_static_integration_plr_creation_alerts.yaml
@@ -30,5 +30,5 @@ spec:
           Time from Snapshot created to integration PLRs in static envs created has been over
           5s for {{ $value | humanizePercentage }} of requests (tolerance 10%) during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_route_namespace: integration-service
+        alert_routing_key: integration-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md

--- a/rhobs/alerting/data_plane/prometheus.oauth_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.oauth_alerts.yaml
@@ -24,5 +24,5 @@ spec:
             description: >-
               The average OAuth login time on cluster {{ $labels.source_cluster }} has
               {{ $value }} sec for the last 5 minutes
-            alert_route_namespace: spi-system
+            alert_routing_key: spi-system
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/oauth_login.md

--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -25,7 +25,7 @@ spec:
             description: >-
               Tekton controller on cluster {{ $labels.source_cluster }} the percentage of time needed to receive PipelineRun creation
               events vs. overall PipelineRun execution time is at {{ $value | humanizePercentage }} instead of less than 5%.
-            alert_route_namespace: plnsvc-tests
+            alert_routing_key: pipelines
             runbook_url: TBD
         - alert: HighExecutionOverhead
           expr: |
@@ -43,5 +43,5 @@ spec:
             description: >-
               Tekton controller on cluster {{ $labels.source_cluster }} the percentage of the time needed to create
               underlying TaskRuns vs. overall PipelineRun execution time is at {{ $value | humanizePercentage }} instead of less than 5%.
-            alert_route_namespace: plnsvc-tests
+            alert_routing_key: pipelines
             runbook_url: TBD

--- a/rhobs/alerting/data_plane/prometheus.pipeline_to_snapshot_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_to_snapshot_alerts.yaml
@@ -30,5 +30,5 @@ spec:
           Time from pipeline run finished to snapshot marked in progress has been over
           30s for more than 10% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_route_namespace: plnsvc-tests
+        alert_routing_key: integration-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md

--- a/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
@@ -19,7 +19,7 @@ spec:
         description: >-
           Pod {{ $labels.pod }} for namespace {{ $labels.namespace }} on cluster
           {{ $labels.source_cluster }} is unscheduled for more than 30 minutes.
-        alert_route_namespace: '{{ $labels.namespace }}'
+        alert_routing_key: '{{ $labels.namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-unschedualablePods.md
     - alert: CrashLoopBackOff
       expr: max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e)"}[5m]) >= 1
@@ -32,7 +32,7 @@ spec:
           Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is in
           waiting state (reason: 'CrashLoopBackOff') on cluster
           {{ $labels.source_cluster }} for more than 15 minutes.
-        alert_route_namespace: '{{ $labels.namespace }}'
+        alert_routing_key: '{{ $labels.namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-crashLoopBackOff.md
     - alert: PodNotReady
       expr: |
@@ -47,5 +47,5 @@ spec:
         description: >-
           Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster
           {{ $labels.source_cluster }} is not ready for more than 15 minutes.
-        alert_route_namespace: '{{ $labels.namespace }}'
+        alert_routing_key: '{{ $labels.namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-PodNotReady.md

--- a/rhobs/alerting/data_plane/prometheus.pv_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pv_alerts.yaml
@@ -20,5 +20,5 @@ spec:
         description: >-
           Persistent Volume {{ $labels.persistentvolume }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }}
           is in {{ $labels.phase }} phase for more than 5 minutes.
-        alert_route_namespace: '{{ $labels.namespace }}'
+        alert_routing_key: '{{ $labels.namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-pesistentVolumeIssues.md

--- a/rhobs/alerting/data_plane/prometheus.quota_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.quota_alerts.yaml
@@ -25,5 +25,5 @@ spec:
           Resource {{ $labels.resource }} in namespace {{ $labels.namespace }}
           on cluster {{ $labels.source_cluster }} exceeded quota
           {{ $labels.resourcequota }}.
-        alert_route_namespace: '{{ $labels.namespace }}'
+        alert_routing_key: '{{ $labels.namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-QuotaExceeded.md

--- a/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
@@ -45,7 +45,7 @@ spec:
           90% of Releases must be processed under one hour
         description: >-
           Release service is failing to successfully process within the period of one hour for 90% of releases
-        alert_route_namespace: release-service
+        alert_routing_key: release-service
 
     - alert: ReleaseServicePreProcessingDurationSeconds
       expr: |
@@ -61,7 +61,7 @@ spec:
           90% of Releases must start processing under 10 seconds
         description: >-
           Release service is failing to start processing under 10 seconds for 90% of releases
-        alert_route_namespace: release-service
+        alert_routing_key: release-service
 
     - alert: ReleaseServiceValidationDurationSeconds
       expr: |
@@ -77,4 +77,4 @@ spec:
           90% of Releases must be validated under 5 seconds
         description: >-
           Release service is failing to run the validations under 5 seconds for 90% of releases
-        alert_route_namespace: release-service
+        alert_routing_key: release-service

--- a/rhobs/alerting/data_plane/prometheus.seb_created_to_ready_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.seb_created_to_ready_alerts.yaml
@@ -30,5 +30,5 @@ spec:
           Time from Snapshot Environment Binding created to marked as
           ready has been over 120s for more than 10% of requests during
           the last 5 minutes on cluster {{ $labels.source_cluster }}
-        alert_route_namespace: integration-service
+        alert_routing_key: integration-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/seb_created_to_ready.md

--- a/rhobs/alerting/data_plane/prometheus.serviceprovider_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.serviceprovider_alerts.yaml
@@ -28,5 +28,5 @@ spec:
               Application controller in Pod {{ $labels.pod }} for namespace
               {{ $labels.namespace }} on instance {{ $labels.source_cluster }} having a
               {{ $value | humanizePercentage }} of 5xx errors from service provider {{ $labels.sp }} for latest 60 minutes
-            alert_route_namespace: spi-system
+            alert_routing_key: spi-system
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/alert-rule-serviceprovider5xxErrorsRate.md

--- a/rhobs/alerting/data_plane/prometheus.stability_image_repository_provision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_image_repository_provision_alerts.yaml
@@ -30,5 +30,5 @@ spec:
           Time taken to provision image repository has been over
           5 minutes for more than 1% of requests during the last 10 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_route_namespace: image-controller
+        alert_routing_key: image-controller
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision.md

--- a/rhobs/alerting/data_plane/prometheus.stability_image_repository_provision_failures_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_image_repository_provision_failures_alerts.yaml
@@ -22,5 +22,5 @@ spec:
         description: >
           Provision image repository failures occured for more than 5 requests during the last 30 minutes
           {{ $labels.source_cluster }}
-        alert_route_namespace: image-controller
+        alert_routing_key: image-controller
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision_failures.md

--- a/rhobs/alerting/data_plane/prometheus.stability_pac_provision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_pac_provision_alerts.yaml
@@ -30,5 +30,5 @@ spec:
           Time taken from PaC provision request till Component is provisioned for PaC builds has been over
           5 minutes for more than 1% of requests during the last 10 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_route_namespace: build-service
+        alert_routing_key: build-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_provision.md

--- a/rhobs/alerting/data_plane/prometheus.stability_pac_unprovision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_pac_unprovision_alerts.yaml
@@ -30,5 +30,5 @@ spec:
           Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
           5 minutes for more than 1% of requests during the last 10 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_route_namespace: build-service
+        alert_routing_key: build-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_unprovision.md

--- a/rhobs/alerting/data_plane/prometheus.stability_simple_build_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_simple_build_alerts.yaml
@@ -30,5 +30,5 @@ spec:
           Time taken from simple build request till the build pipeline is submitted has been over
           5 minutes for more than 1% of requests during the last 10 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_route_namespace: build-service
+        alert_routing_key: build-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_simple_build.md

--- a/test/promql/tests/control_plane/argocd_test.yaml
+++ b/test/promql/tests/control_plane/argocd_test.yaml
@@ -61,7 +61,7 @@ tests:
                 Application: degraded-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 Health status Degraded.
-              alert_route_namespace: test_dest_namespace
+              alert_routing_key: test_dest_namespace
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
 
           - exp_labels:
@@ -80,7 +80,7 @@ tests:
                 Application: flapping-1m-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 Health status Degraded.
-              alert_route_namespace: test_dest_namespace
+              alert_routing_key: test_dest_namespace
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
 
           - exp_labels:
@@ -99,7 +99,7 @@ tests:
                 Application: flapping-2m-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 Health status Degraded.
-              alert_route_namespace: test_dest_namespace
+              alert_routing_key: test_dest_namespace
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
 
   # ProgressingArgocdApp alert
@@ -140,7 +140,7 @@ tests:
                 Application: progressing-only-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 App progressing for too long.
-              alert_route_namespace: test_dest_namespace
+              alert_routing_key: test_dest_namespace
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-ProgressingArgocdApp.md
 
   - interval: 1m
@@ -223,5 +223,5 @@ tests:
                 Application: Progressing_first-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 App progressing for too long.
-              alert_route_namespace: test_dest_namespace
+              alert_routing_key: test_dest_namespace
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-ProgressingArgocdApp.md

--- a/test/promql/tests/data_plane/application_errors_test.yaml
+++ b/test/promql/tests/data_plane/application_errors_test.yaml
@@ -31,7 +31,7 @@ tests:
                 Application controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of applications over the past hour
-              alert_route_namespace: 'application-service'
+              alert_routing_key: 'application-service'
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-delete-failed.md
 
   - interval: 1m
@@ -60,7 +60,7 @@ tests:
                 Application controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of applications over the past hour
-              alert_route_namespace: application-service
+              alert_routing_key: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-delete-failed.md
 
   - interval: 1m
@@ -117,7 +117,7 @@ tests:
                 Application controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully create at least 95% of applications over the past hour
-              alert_route_namespace: application-service
+              alert_routing_key: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-create-failed.md
 
   - interval: 1m
@@ -146,7 +146,7 @@ tests:
                 Application controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully create at least 95% of applications over the past hour
-              alert_route_namespace: application-service
+              alert_routing_key: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-create-failed.md
 
   - interval: 1m

--- a/test/promql/tests/data_plane/component_errors_test.yaml
+++ b/test/promql/tests/data_plane/component_errors_test.yaml
@@ -41,7 +41,7 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of components over the past hour
-              alert_route_namespace: application-service
+              alert_routing_key: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
 
   - interval: 1m
@@ -70,7 +70,7 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of components over the past hour
-              alert_route_namespace: application-service
+              alert_routing_key: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
 
   - interval: 1m
@@ -100,7 +100,7 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of components over the past hour
-              alert_route_namespace: application-service
+              alert_routing_key: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
 
   - interval: 1m
@@ -167,7 +167,7 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully create at least 95% of components over the past hour
-              alert_route_namespace: application-service
+              alert_routing_key: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md
 
   - interval: 1m
@@ -196,7 +196,7 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully create at least 95% of components over the past hour
-              alert_route_namespace: application-service
+              alert_routing_key: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md
 
   - interval: 1m
@@ -226,7 +226,7 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully create at least 95% of components over the past hour
-              alert_route_namespace: application-service
+              alert_routing_key: application-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md
 
   - interval: 1m

--- a/test/promql/tests/data_plane/crashloopbackoff_test.yaml
+++ b/test/promql/tests/data_plane/crashloopbackoff_test.yaml
@@ -68,7 +68,7 @@ tests:
                 Pod test-ns/prod-pod-2 (test-container) is in waiting state
                 (reason: 'CrashLoopBackOff') on cluster cluster01 for more than 15
                 minutes.
-              alert_route_namespace: test-ns
+              alert_routing_key: test-ns
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-crashLoopBackOff.md
           - exp_labels:
               severity: warning
@@ -83,5 +83,5 @@ tests:
                 Pod prod-ns/prod-pod-4 (test-container) is in waiting state
                 (reason: 'CrashLoopBackOff') on cluster cluster02 for more than 15
                 minutes.
-              alert_route_namespace: prod-ns
+              alert_routing_key: prod-ns
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-crashLoopBackOff.md

--- a/test/promql/tests/data_plane/latency_component_onboarding_test.yaml
+++ b/test/promql/tests/data_plane/latency_component_onboarding_test.yaml
@@ -35,7 +35,7 @@ tests:
                 if PaC provision is requested upon the Component creation, then till the provision finishes has been over
                 60s for more than 10% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_component_onboarding.md
 
 # Scenario where both clusters cross the 10% threshold
@@ -69,7 +69,7 @@ tests:
                 if PaC provision is requested upon the Component creation, then till the provision finishes has been over
                 60s for more than 10% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_component_onboarding.md
           - exp_labels:
               severity: warning
@@ -82,7 +82,7 @@ tests:
                 if PaC provision is requested upon the Component creation, then till the provision finishes has been over
                 60s for more than 10% of requests during the last 5 minutes on cluster
                 cluster02
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_component_onboarding.md
 
 # Scenario where neither cluster crosses the 10% threshold

--- a/test/promql/tests/data_plane/latency_image_repository_provision_test.yaml
+++ b/test/promql/tests/data_plane/latency_image_repository_provision_test.yaml
@@ -34,7 +34,7 @@ tests:
                 Time taken to provision image repository has been over
                 30s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_route_namespace: image-controller
+              alert_routing_key: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/latency_image_repository_provision.md
 
 # Scenario where both clusters cross the 5% threshold
@@ -67,7 +67,7 @@ tests:
                 Time taken to provision image repository has been over
                 30s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_route_namespace: image-controller
+              alert_routing_key: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/latency_image_repository_provision.md
           - exp_labels:
               severity: warning
@@ -79,7 +79,7 @@ tests:
                 Time taken to provision image repository has been over
                 30s for more than 5% of requests during the last 5 minutes on cluster
                 cluster02
-              alert_route_namespace: image-controller
+              alert_routing_key: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/latency_image_repository_provision.md
 
 # Scenario where neither cluster crosses the 5% threshold

--- a/test/promql/tests/data_plane/latency_pac_provision_test.yaml
+++ b/test/promql/tests/data_plane/latency_pac_provision_test.yaml
@@ -34,7 +34,7 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_provision.md
 
 # Scenario where both clusters cross the 5% threshold
@@ -67,7 +67,7 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_provision.md
           - exp_labels:
               severity: warning
@@ -79,7 +79,7 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster02
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_provision.md
 
 # Scenario where neither cluster crosses the 5% threshold

--- a/test/promql/tests/data_plane/latency_pac_unprovision_test.yaml
+++ b/test/promql/tests/data_plane/latency_pac_unprovision_test.yaml
@@ -34,7 +34,7 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_unprovision.md
 
 # Scenario where both clusters cross the 5% threshold
@@ -67,7 +67,7 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_unprovision.md
           - exp_labels:
               severity: warning
@@ -79,7 +79,7 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster02
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_unprovision.md
 
 # Scenario where neither cluster crosses the 5% threshold

--- a/test/promql/tests/data_plane/latency_release_creation_test.yaml
+++ b/test/promql/tests/data_plane/latency_release_creation_test.yaml
@@ -32,7 +32,7 @@ tests:
                 Time from Snapshot marked as passed to release created has been over
                 10s for more than 10% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_route_namespace: integration-service
+              alert_routing_key: integration-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md
 
 # Scenario where both clusters cross the 10% threshold
@@ -65,7 +65,7 @@ tests:
                 Time from Snapshot marked as passed to release created has been over
                 10s for more than 10% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_route_namespace: integration-service
+              alert_routing_key: integration-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md
           - exp_labels:
               severity: warning
@@ -77,7 +77,7 @@ tests:
                 Time from Snapshot marked as passed to release created has been over
                 10s for more than 10% of requests during the last 5 minutes on cluster
                 cluster02
-              alert_route_namespace: integration-service
+              alert_routing_key: integration-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md
 
 # Scenario where neither cluster crosses the 10% threshold

--- a/test/promql/tests/data_plane/latency_simple_build_test.yaml
+++ b/test/promql/tests/data_plane/latency_simple_build_test.yaml
@@ -34,7 +34,7 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 15s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_simple_build.md
 
 # Scenario where both clusters cross the 5% threshold
@@ -67,7 +67,7 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 15s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_simple_build.md
           - exp_labels:
               severity: warning
@@ -79,7 +79,7 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 15s for more than 5% of requests during the last 5 minutes on cluster
                 cluster02
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_simple_build.md
 
 # Scenario where neither cluster crosses the 5% threshold

--- a/test/promql/tests/data_plane/latency_snapshot_to_static_integration_plr_creation_test.yaml
+++ b/test/promql/tests/data_plane/latency_snapshot_to_static_integration_plr_creation_test.yaml
@@ -32,7 +32,7 @@ tests:
                 Time from Snapshot created to integration PLRs in static envs created has been over
                 5s for 90% of requests (tolerance 10%) during the last 5 minutes on cluster
                 cluster01
-              alert_route_namespace: integration-service
+              alert_routing_key: integration-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md
 
 # Scenario where both clusters cross the 10% threshold
@@ -65,7 +65,7 @@ tests:
                 Time from Snapshot created to integration PLRs in static envs created has been over
                 5s for 95% of requests (tolerance 10%) during the last 5 minutes on cluster
                 cluster01
-              alert_route_namespace: integration-service
+              alert_routing_key: integration-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md
           - exp_labels:
               severity: warning
@@ -77,7 +77,7 @@ tests:
                 Time from Snapshot created to integration PLRs in static envs created has been over
                 5s for 95% of requests (tolerance 10%) during the last 5 minutes on cluster
                 cluster02
-              alert_route_namespace: integration-service
+              alert_routing_key: integration-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md
 
 # Scenario where neither cluster crosses the 10% threshold

--- a/test/promql/tests/data_plane/notready_pods_test.yaml
+++ b/test/promql/tests/data_plane/notready_pods_test.yaml
@@ -37,7 +37,7 @@ tests:
               description: >-
                 Pod pod-1 in namespace ns-1 on cluster cluster01 is
                 not ready for more than 15 minutes.
-              alert_route_namespace: ns-1
+              alert_routing_key: ns-1
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-PodNotReady.md
 
   - interval: 1m
@@ -72,7 +72,7 @@ tests:
               description: >-
                 Pod pod-1 in namespace ns-2 on cluster cluster02 is
                 not ready for more than 15 minutes.
-              alert_route_namespace: ns-2
+              alert_routing_key: ns-2
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-PodNotReady.md
 
 
@@ -108,7 +108,7 @@ tests:
               description: >-
                 Pod pod-1 in namespace ns-3 on cluster cluster03 is
                 not ready for more than 15 minutes.
-              alert_route_namespace: ns-3
+              alert_routing_key: ns-3
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-PodNotReady.md
 
   - interval: 1m

--- a/test/promql/tests/data_plane/oauth_time_test.yaml
+++ b/test/promql/tests/data_plane/oauth_time_test.yaml
@@ -29,7 +29,7 @@ tests:
                 OAuth login average time is more than 30 sec on cluster01
               description: >-
                 The average OAuth login time on cluster cluster01 has 50 sec for the last 5 minutes
-              alert_route_namespace: spi-system
+              alert_routing_key: spi-system
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/oauth_login.md
 
   - interval: 1m
@@ -61,7 +61,7 @@ tests:
                 OAuth login average time is more than 30 sec on cluster01
               description: >-
                 The average OAuth login time on cluster cluster01 has 50 sec for the last 5 minutes
-              alert_route_namespace: spi-system
+              alert_routing_key: spi-system
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/oauth_login.md
           - exp_labels:
               severity: warning
@@ -75,7 +75,7 @@ tests:
                 OAuth login average time is more than 30 sec on cluster02
               description: >-
                 The average OAuth login time on cluster cluster02 has 60 sec for the last 5 minutes
-              alert_route_namespace: spi-system
+              alert_routing_key: spi-system
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/oauth_login.md
 
 

--- a/test/promql/tests/data_plane/persistentvolumeissues_test.yaml
+++ b/test/promql/tests/data_plane/persistentvolumeissues_test.yaml
@@ -36,7 +36,7 @@ tests:
               description: >-
                 Persistent Volume pv-1 in namespace ns-1 on cluster cluster01
                 is in Pending phase for more than 5 minutes.
-              alert_route_namespace: ns-1
+              alert_routing_key: ns-1
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-pesistentVolumeIssues.md
 
   - interval: 1m
@@ -69,7 +69,7 @@ tests:
               description: >-
                 Persistent Volume pv-2 in namespace ns-2 on cluster cluster02
                 is in Failed phase for more than 5 minutes.
-              alert_route_namespace: ns-2
+              alert_routing_key: ns-2
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-pesistentVolumeIssues.md
 
   # Not Alerted cases:

--- a/test/promql/tests/data_plane/pipeline_overhead_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_overhead_test.yaml
@@ -37,7 +37,7 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 the percentage of time needed to receive PipelineRun creation
                 events vs. overall PipelineRun execution time is at 100% instead of less than 5%.
-              alert_route_namespace: plnsvc-tests
+              alert_routing_key: pipelines
               runbook_url: TBD
 
   - interval: 1m
@@ -72,7 +72,7 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 the percentage of time needed to receive PipelineRun creation
                 events vs. overall PipelineRun execution time is at 50% instead of less than 5%.
-              alert_route_namespace: plnsvc-tests
+              alert_routing_key: pipelines
               runbook_url: TBD
 
   - interval: 1m
@@ -130,7 +130,7 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 the percentage of the time needed to create
                 underlying TaskRuns vs. overall PipelineRun execution time is at 100% instead of less than 5%.
-              alert_route_namespace: plnsvc-tests
+              alert_routing_key: pipelines
               runbook_url: TBD
 
   - interval: 1m
@@ -169,7 +169,7 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 the percentage of the time needed to create
                 underlying TaskRuns vs. overall PipelineRun execution time is at 5.263% instead of less than 5%.
-              alert_route_namespace: plnsvc-tests
+              alert_routing_key: pipelines
               runbook_url: TBD
 
   - interval: 1m

--- a/test/promql/tests/data_plane/pipeline_to_snapshot_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_to_snapshot_test.yaml
@@ -33,7 +33,7 @@ tests:
               Time from pipeline run finished to snapshot marked in progress has been over
               30s for more than 10% of requests during the last 5 minutes on cluster
               cluster01
-            alert_route_namespace: plnsvc-tests
+            alert_routing_key: integration-service
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md
 
 # Scenario where both clusters cross the 10% threshold, alert should trigger for both
@@ -64,7 +64,7 @@ tests:
               Time from pipeline run finished to snapshot marked in progress has been over
               30s for more than 10% of requests during the last 5 minutes on cluster
               cluster01
-            alert_route_namespace: plnsvc-tests
+            alert_routing_key: integration-service
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md
         - exp_labels:
             severity: warning
@@ -77,7 +77,7 @@ tests:
               Time from pipeline run finished to snapshot marked in progress has been over
               30s for more than 10% of requests during the last 5 minutes on cluster
               cluster02
-            alert_route_namespace: plnsvc-tests
+            alert_routing_key: integration-service
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md
 
 # Scenario where no alert is triggered as both clusters stay below the 10% threshold

--- a/test/promql/tests/data_plane/quota_exceeded_test.yaml
+++ b/test/promql/tests/data_plane/quota_exceeded_test.yaml
@@ -41,7 +41,7 @@ tests:
               description: >-
                 Resource example-resource in namespace exceeding-limits on cluster
                 cluster01 exceeded quota test-quota.
-              alert_route_namespace: exceeding-limits
+              alert_routing_key: exceeding-limits
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-QuotaExceeded.md
 
   - interval: 1m

--- a/test/promql/tests/data_plane/release_service_test.yaml
+++ b/test/promql/tests/data_plane/release_service_test.yaml
@@ -27,7 +27,7 @@ tests:
                 90% of Releases must be processed under one hour
               description: >-
                 Release service is failing to successfully process within the period of one hour for 90% of releases
-              alert_route_namespace: release-service
+              alert_routing_key: release-service
 
   - interval: 1m
     input_series:
@@ -52,7 +52,7 @@ tests:
                 90% of Releases must start processing under 10 seconds
               description: >-
                 Release service is failing to start processing under 10 seconds for 90% of releases
-              alert_route_namespace: release-service
+              alert_routing_key: release-service
 
   - interval: 1m
     input_series:
@@ -77,4 +77,4 @@ tests:
                 90% of Releases must be validated under 5 seconds
               description: >-
                 Release service is failing to run the validations under 5 seconds for 90% of releases
-              alert_route_namespace: release-service
+              alert_routing_key: release-service

--- a/test/promql/tests/data_plane/seb_created_to_ready_test.yaml
+++ b/test/promql/tests/data_plane/seb_created_to_ready_test.yaml
@@ -27,7 +27,7 @@ tests:
                 Time from Snapshot Environment Binding created to marked as
                 ready has been over 120s for more than 10% of requests during
                 the last 5 minutes on cluster cluster01
-              alert_route_namespace: "integration-service"
+              alert_routing_key: "integration-service"
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/seb_created_to_ready.md
 
   # Scenario where both clusters exceed the 10% threshold
@@ -58,7 +58,7 @@ tests:
                 Time from Snapshot Environment Binding created to marked as
                 ready has been over 120s for more than 10% of requests during
                 the last 5 minutes on cluster cluster01
-              alert_route_namespace: "integration-service"
+              alert_routing_key: "integration-service"
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/seb_created_to_ready.md
 
           - exp_labels:
@@ -71,7 +71,7 @@ tests:
                 Time from Snapshot Environment Binding created to marked as
                 ready has been over 120s for more than 10% of requests during
                 the last 5 minutes on cluster cluster02
-              alert_route_namespace: "integration-service"
+              alert_routing_key: "integration-service"
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/seb_created_to_ready.md
 
   # Scenario where neither cluster crosses the 10% threshold

--- a/test/promql/tests/data_plane/serviceprovider_errors_test.yaml
+++ b/test/promql/tests/data_plane/serviceprovider_errors_test.yaml
@@ -32,7 +32,7 @@ tests:
                 Application controller in Pod spi-controller-manager for namespace
                 spi-system on instance cluster01 having a 50% of 5xx errors
                 from service provider GitHub for latest 60 minutes
-              alert_route_namespace: spi-system
+              alert_routing_key: spi-system
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/alert-rule-serviceprovider5xxErrorsRate.md
 
   - interval: 1m
@@ -65,7 +65,7 @@ tests:
                 Application controller in Pod spi-controller-manager for namespace
                 spi-system on instance cluster01 having a 33.33% of 5xx errors
                 from service provider GitHub for latest 60 minutes
-              alert_route_namespace: spi-system
+              alert_routing_key: spi-system
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/alert-rule-serviceprovider5xxErrorsRate.md
 
 

--- a/test/promql/tests/data_plane/stability_image_repository_provision_failures_test.yaml
+++ b/test/promql/tests/data_plane/stability_image_repository_provision_failures_test.yaml
@@ -29,7 +29,7 @@ tests:
               description: >
                 Provision image repository failures occured for more than 5 requests during the last 30 minutes
                 cluster01
-              alert_route_namespace: image-controller
+              alert_routing_key: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision_failures.md
 
 # Scenario where both clusters cross the 5 threshold
@@ -57,7 +57,7 @@ tests:
               description: >
                 Provision image repository failures occured for more than 5 requests during the last 30 minutes
                 cluster01
-              alert_route_namespace: image-controller
+              alert_routing_key: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision_failures.md
           - exp_labels:
               severity: warning
@@ -68,7 +68,7 @@ tests:
               description: >
                 Provision image repository failures occured for more than 5 requests during the last 30 minutes
                 cluster02
-              alert_route_namespace: image-controller
+              alert_routing_key: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision_failures.md
 
 # Scenario where neither cluster crosses the 5 threshold

--- a/test/promql/tests/data_plane/stability_image_repository_provision_test.yaml
+++ b/test/promql/tests/data_plane/stability_image_repository_provision_test.yaml
@@ -34,7 +34,7 @@ tests:
                 Time taken to provision image repository has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_route_namespace: image-controller
+              alert_routing_key: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision.md
 
 # Scenario where both clusters cross the 1% threshold
@@ -67,7 +67,7 @@ tests:
                 Time taken to provision image repository has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_route_namespace: image-controller
+              alert_routing_key: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision.md
           - exp_labels:
               severity: warning
@@ -79,7 +79,7 @@ tests:
                 Time taken to provision image repository has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster02
-              alert_route_namespace: image-controller
+              alert_routing_key: image-controller
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision.md
 
 # Scenario where neither cluster crosses the 1% threshold

--- a/test/promql/tests/data_plane/stability_pac_provision_test.yaml
+++ b/test/promql/tests/data_plane/stability_pac_provision_test.yaml
@@ -34,7 +34,7 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_provision.md
 
 # Scenario where both clusters cross the 1% threshold
@@ -67,7 +67,7 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_provision.md
           - exp_labels:
               severity: warning
@@ -79,7 +79,7 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster02
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_provision.md
 
 # Scenario where neither cluster crosses the 1% threshold

--- a/test/promql/tests/data_plane/stability_pac_unprovision_test.yaml
+++ b/test/promql/tests/data_plane/stability_pac_unprovision_test.yaml
@@ -34,7 +34,7 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_unprovision.md
 
 # Scenario where both clusters cross the 1% threshold
@@ -67,7 +67,7 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_unprovision.md
           - exp_labels:
               severity: warning
@@ -79,7 +79,7 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster02
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_unprovision.md
 
 # Scenario where neither cluster crosses the 1% threshold

--- a/test/promql/tests/data_plane/stability_simple_build_test.yaml
+++ b/test/promql/tests/data_plane/stability_simple_build_test.yaml
@@ -34,7 +34,7 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_simple_build.md
 
 # Scenario where both clusters cross the 1% threshold
@@ -67,7 +67,7 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_simple_build.md
           - exp_labels:
               severity: warning
@@ -79,7 +79,7 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster02
-              alert_route_namespace: build-service
+              alert_routing_key: build-service
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_simple_build.md
 
 # Scenario where neither cluster crosses the 1% threshold

--- a/test/promql/tests/data_plane/unschedulable_pods_test.yaml
+++ b/test/promql/tests/data_plane/unschedulable_pods_test.yaml
@@ -61,5 +61,5 @@ tests:
               description: >-
                 Pod prod-pod-2 for namespace prod-test on cluster cluster02 is
                 unscheduled for more than 30 minutes.
-              alert_route_namespace: prod-test
+              alert_routing_key: prod-test
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-unschedualablePods.md


### PR DESCRIPTION
Change `alert_routing_namespace` to `alert_routing_key`, to better
represent the fact the value for it can be a team's name instead
of a namespace name, as a team's specific alert can fire from
multiple namespaces.
    
similar change been applied in app-interface logic and both
should be merged around the same time to allow for consistent
alert tagging.
    
Signed-off-by: Omer <oamsalem@redhat.com>

depends on #183 
