### PR TITLE
chore: Add time frame for HAS Component Create SLO Panel

### DIFF
--- a/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
+++ b/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
@@ -810,6 +810,7 @@ data:
               "refId": "A"
             }
           ],
+          "timeFrom": "1h",
           "title": "Measured",
           "type": "gauge"
         },


### PR DESCRIPTION
Updates the HAS Component Create SLO Panel to include a 1hr time window. The alerts are over a 1h period as well.

This is how it looks in the dashboard. I copy pasted the property from the JSON:
<img width="1286" alt="Screenshot 2024-01-29 at 3 15 44 PM" src="https://github.com/redhat-appstudio/o11y/assets/31771087/e900edfd-1019-43b1-b15a-5982c2f7e6b3">
