### PR TITLE
feat(RHTAPWATCH-692): Add BackupFailed alerting rule

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.backup_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.backup_alerts.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-backup-alerting-rules
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: backup-alerts
+    interval: 1m
+    rules:
+    - alert: BackupFailed
+      annotations:
+        summary: OADP experienced backup failures for schedule {{ $labels.schedule }}
+        description: OADP had {{ $value | humanize }} backup failure(s) over the last hour for schedule {{ $labels.schedule }}.
+        alert_routing_key: '{{ $labels.namespace }}'
+        runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/backup/backup-failed.md
+      expr: increase(velero_backup_failure_total[1h]) > 0
+      for: 5m
+      labels:
+        severity: warning

--- a/test/promql/tests/data_plane/backup_failed_test.yaml
+++ b/test/promql/tests/data_plane/backup_failed_test.yaml
@@ -1,0 +1,30 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.backup_alerts.yaml
+
+tests:
+  - interval: 1m
+    input_series:
+      # No backup failures
+      - series: velero_backup_failure_total{namespace="openshift-adp", schedule="backup-toolchain-member", source_cluster="cluster01"}
+        values: '0x60'
+
+      # A backup failure at every interval for 1h
+      - series: velero_backup_failure_total{namespace="openshift-adp", schedule="backup-tenants", source_cluster="cluster01"}
+        values: '0+1x60'
+
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: BackupFailed
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              namespace: openshift-adp
+              source_cluster: cluster01
+              schedule: backup-tenants
+            exp_annotations:
+              summary: OADP experienced backup failures for schedule backup-tenants
+              description: OADP had 60 backup failure(s) over the last hour for schedule backup-tenants.
+              alert_routing_key: openshift-adp
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/backup/backup-failed.md


### PR DESCRIPTION
The `runbook_url` doesn't exist yet but will be created separately as part of [RHTAPSRE-320](https://issues.redhat.com/browse/RHTAPSRE-320).