### PR TITLE
fix(STONEINTG-777): extend the window for PipelineRunToSnapshotExceeded

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pipeline_to_snapshot_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_to_snapshot_alerts.yaml
@@ -13,13 +13,13 @@ spec:
       expr: |
        (
         (
-         increase(integration_svc_response_seconds_bucket{le="+Inf"}[5m])
+         increase(integration_svc_response_seconds_bucket{le="+Inf"}[10m])
          - ignoring(le)
-         increase(integration_svc_response_seconds_bucket{le="30"}[5m])
+         increase(integration_svc_response_seconds_bucket{le="30"}[10m])
         ) / ignoring(le)
-        increase(integration_svc_response_seconds_bucket{le="+Inf"}[5m])
+        increase(integration_svc_response_seconds_bucket{le="+Inf"}[10m])
        ) > 0.10
-      for: 1m
+      for: 10m
       labels:
         severity: critical
         slo: "true"
@@ -28,7 +28,7 @@ spec:
           PipelineRunFinish to SnapshotInProgress time exceeded
         description: >
           Time from pipeline run finished to snapshot marked in progress has been over
-          30s for more than 10% of requests during the last 5 minutes on cluster
-          {{ $labels.source_cluster }}
+          30s for more than 10% of requests during the last 10 minutes and has not improved for 10 minutes
+          on cluster {{ $labels.source_cluster }}
         alert_routing_key: integration-service
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md

--- a/test/promql/tests/data_plane/pipeline_to_snapshot_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_to_snapshot_test.yaml
@@ -10,16 +10,16 @@ tests:
   input_series:
     # Simulating data from Cluster 1
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service",  source_cluster="cluster01"}'
-      values: '0+10x10'  # 10 requests took less than 30s
+      values: '0+10x15'  # 10 requests took less than 30s
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster01"}'
-      values: '0+100x10'  # 100 total occurrences in cluster1
+      values: '0+100x15'  # 100 total occurrences in cluster1
     # Simulating data from Cluster 2
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+95x10'  # 95 requests took less than 30s
+      values: '0+95x15'  # 95 requests took less than 30s
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+100x10'  # 100 total occurrences in cluster2
+      values: '0+100x15'  # 100 total occurrences in cluster2
   alert_rule_test:
-    - eval_time: 10m
+    - eval_time: 15m
       alertname: PipelineRunToSnapshotExceeded
       exp_alerts:
         - exp_labels:
@@ -31,8 +31,39 @@ tests:
             summary: PipelineRunFinish to SnapshotInProgress time exceeded
             description: >
               Time from pipeline run finished to snapshot marked in progress has been over
-              30s for more than 10% of requests during the last 5 minutes on cluster
-              cluster01
+              30s for more than 10% of requests during the last 10 minutes and has not improved for 10 minutes
+              on cluster cluster01
+            alert_routing_key: integration-service
+            runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md
+
+# Scenario where one cluster crosses the 10% threshold after 7 minutes and another does not
+- interval: 1m
+  input_series:
+    # Simulating data from Cluster 1
+    - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service",  source_cluster="cluster01"}'
+      values: '7+10x20'  # 10 requests took less than 30s
+    - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster01"}'
+      values: '7+100x20'  # 100 total occurrences in cluster1
+    # Simulating data from Cluster 2
+    - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster02"}'
+      values: '0+95x20'  # 95 requests took less than 30s
+    - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster02"}'
+      values: '0+100x20'  # 100 total occurrences in cluster2
+  alert_rule_test:
+    - eval_time: 21m
+      alertname: PipelineRunToSnapshotExceeded
+      exp_alerts:
+        - exp_labels:
+            severity: critical
+            slo: "true"
+            namespace: integration-service
+            source_cluster: cluster01
+          exp_annotations:
+            summary: PipelineRunFinish to SnapshotInProgress time exceeded
+            description: >
+              Time from pipeline run finished to snapshot marked in progress has been over
+              30s for more than 10% of requests during the last 10 minutes and has not improved for 10 minutes
+              on cluster cluster01
             alert_routing_key: integration-service
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md
 
@@ -41,16 +72,16 @@ tests:
   input_series:
     # Simulating data from Cluster 01
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster01"}'
-      values: '0+10x10'  # 10 requests took less than 30s
+      values: '0+10x15'  # 10 requests took less than 30s
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster01"}'
-      values: '0+100x10'  # 100 total occurrences in cluster1
+      values: '0+100x15'  # 100 total occurrences in cluster1
     # Simulating data from Cluster 2
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+10x10'  # 10 requests took less than 30s
+      values: '0+10x15'  # 10 requests took less than 30s
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+100x10'  # 100 total occurrences in cluster2
+      values: '0+100x15'  # 100 total occurrences in cluster2
   alert_rule_test:
-    - eval_time: 10m
+    - eval_time: 15m
       alertname: PipelineRunToSnapshotExceeded
       exp_alerts:
         - exp_labels:
@@ -62,8 +93,8 @@ tests:
             summary: PipelineRunFinish to SnapshotInProgress time exceeded
             description: >
               Time from pipeline run finished to snapshot marked in progress has been over
-              30s for more than 10% of requests during the last 5 minutes on cluster
-              cluster01
+              30s for more than 10% of requests during the last 10 minutes and has not improved for 10 minutes
+              on cluster cluster01
             alert_routing_key: integration-service
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md
         - exp_labels:
@@ -75,8 +106,8 @@ tests:
             summary: PipelineRunFinish to SnapshotInProgress time exceeded
             description: >
               Time from pipeline run finished to snapshot marked in progress has been over
-              30s for more than 10% of requests during the last 5 minutes on cluster
-              cluster02
+              30s for more than 10% of requests during the last 10 minutes and has not improved for 10 minutes
+              on cluster cluster02
             alert_routing_key: integration-service
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md
 
@@ -85,16 +116,16 @@ tests:
   input_series:
     # Simulating data from Cluster 1 for 9.99% above 30s
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster01"}'
-      values: '0+99x10'  # 99 requests took less than 30s
+      values: '0+99x15'  # 99 requests took less than 30s
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster01"}'
-      values: '0+100x10'  # 100 total occurrences in cluster1
+      values: '0+100x15'  # 100 total occurrences in cluster1
 
     # Simulating data from Cluster 2 for 4% above 30s, alert should not trigger
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+96x10'  # 96 requests took less than 30s
+      values: '0+96x15'  # 96 requests took less than 30s
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+100x10'  # 100 total occurrences in cluster2
+      values: '0+100x15'  # 100 total occurrences in cluster2
   alert_rule_test:
-    - eval_time: 10m
+    - eval_time: 15m
       alertname: PipelineRunToSnapshotExceeded
       exp_alerts: []  # No alerts are expected in this scenario


### PR DESCRIPTION
* The alert is currently flaky and flapping because of different services taking longer to finalize the build pipelineRuns
* See also [KFLUXBUGS-24](https://issues.redhat.com/browse/KFLUXBUGS-24)