### PR TITLE
chore(RHTAPWATCH-823): SLO alerts uses team handles for routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,21 +63,22 @@ where the team's handle is tagged in the alert message.
 
 #### Usage Guidelines:
 
-Apply the `alert_routing_key` annotation to alerts in order to get notified about them.
+Apply the `alert_team_handle` and `team` annotations to SLO alerts in order to get notified about them.
   
-#### How to apply the `alert_routing_key` Annotation:
+#### How to apply the `alert_team_handle` Annotation:
 
-Apply the `alert_routing_key` key to the annotations section of any alerting rule,
-with one of the team's namespaces as its value, or the team's name.
+Apply the `alert_team_handle` key to the annotations section of any alerting rule,
+with the relevant team's Slack group handle.
+The format of the Slack handle is: `<!subteam^-slack_group_id->` (e.g: `<!subteam^S041261DDEW>`);
+To obtain the Slack group ID, click on the team's group handle, then click the three dots, and select "Copy group ID."
+
+make sure to also add the `team` annotation with the name of the relevant team for readability.
   ```
   annotations:
       summary: "PipelineRunFinish to SnapshotInProgress time exceeded"
-      alert_routing_key: "application-service"
+      alert_team_handle: <!subteam^S04S21ECL8K>
+      team: o11y
   ```
-
-make sure that the team's name is aligned with the one mentioned in 
-[app-interface's logic](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/resources/rhobs/stage/alertmanager-routes-mst.secret.yaml?ref_type=heads#L75). 
-if the team is missing from the conditional statement in that file, make sure to add it.
 
 ### Updating Alerts
 

--- a/rhobs/alerting/data_plane/prometheus.application_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.application_alerts.yaml
@@ -25,7 +25,8 @@ spec:
           Application controller in Pod {{ $labels.pod }} for namespace
           {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
           successfully delete at least 95% of applications over the past hour
-        alert_routing_key: 'application-service'
+        alert_team_handle: <!subteam^S04MSCVRF4Z>
+        team: has
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-delete-failed.md
     - alert: ApplicationCreationErrors
       expr: |
@@ -43,5 +44,6 @@ spec:
           Application controller in Pod {{ $labels.pod }} for namespace
           {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
           successfully create at least 95% of applications over the past hour
-        alert_routing_key: 'application-service'
+        alert_team_handle: <!subteam^S04MSCVRF4Z>
+        team: has
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-create-failed.md

--- a/rhobs/alerting/data_plane/prometheus.component_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.component_alerts.yaml
@@ -25,7 +25,8 @@ spec:
           Component controller in Pod {{ $labels.pod }} for namespace
           {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
           successfully delete at least 95% of components over the past hour
-        alert_routing_key: application-service
+        alert_team_handle: <!subteam^S04MSCVRF4Z>
+        team: has
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
     - alert: ComponentCreationErrors
       expr: |
@@ -43,5 +44,6 @@ spec:
           Component controller in Pod {{ $labels.pod }} for namespace
           {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is failing to
           successfully create at least 95% of components over the past hour
-        alert_routing_key: application-service
+        alert_team_handle: <!subteam^S04MSCVRF4Z>
+        team: has
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md

--- a/rhobs/alerting/data_plane/prometheus.latency_component_onboarding_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_component_onboarding_alerts.yaml
@@ -31,5 +31,6 @@ spec:
           if PaC provision is requested upon the Component creation, then till the provision finishes has been over
           60s for more than 10% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_routing_key: build-service
+        alert_team_handle: <!subteam^S0500D143S8>
+        team: build
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_component_onboarding.md

--- a/rhobs/alerting/data_plane/prometheus.latency_image_repository_provision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_image_repository_provision_alerts.yaml
@@ -30,5 +30,6 @@ spec:
           Time taken to provision image repository has been over
           30s for more than 5% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_routing_key: image-controller
+        alert_team_handle: <!subteam^S0500D143S8>
+        team: build
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/latency_image_repository_provision.md

--- a/rhobs/alerting/data_plane/prometheus.latency_pac_provision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_pac_provision_alerts.yaml
@@ -30,5 +30,6 @@ spec:
           Time taken from PaC provision request till Component is provisioned for PaC builds has been over
           20s for more than 5% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_routing_key: build-service
+        alert_team_handle: <!subteam^S0500D143S8>
+        team: build
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_provision.md

--- a/rhobs/alerting/data_plane/prometheus.latency_pac_unprovision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_pac_unprovision_alerts.yaml
@@ -30,5 +30,6 @@ spec:
           Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
           20s for more than 5% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_routing_key: build-service
+        alert_team_handle: <!subteam^S0500D143S8>
+        team: build
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_unprovision.md

--- a/rhobs/alerting/data_plane/prometheus.latency_release_creation_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_release_creation_alerts.yaml
@@ -30,5 +30,6 @@ spec:
           Time from Snapshot marked as passed to release created has been over
           10s for more than 10% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_routing_key: integration-service
+        alert_team_handle: <!subteam^S041261DDEW>
+        team: integration
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md

--- a/rhobs/alerting/data_plane/prometheus.latency_simple_build_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_simple_build_alerts.yaml
@@ -30,5 +30,6 @@ spec:
           Time taken from simple build request till the build pipeline is submitted has been over
           15s for more than 5% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_routing_key: build-service
+        alert_team_handle: <!subteam^S0500D143S8>
+        team: build
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_simple_build.md

--- a/rhobs/alerting/data_plane/prometheus.latency_snapshot_to_static_integration_plr_creation_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_snapshot_to_static_integration_plr_creation_alerts.yaml
@@ -30,5 +30,6 @@ spec:
           Time from Snapshot created to integration PLRs in static envs created has been over
           5s for {{ $value | humanizePercentage }} of requests (tolerance 10%) during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_routing_key: integration-service
+        alert_team_handle: <!subteam^S041261DDEW>
+        team: integration
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md

--- a/rhobs/alerting/data_plane/prometheus.oauth_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.oauth_alerts.yaml
@@ -24,5 +24,6 @@ spec:
             description: >-
               The average OAuth login time on cluster {{ $labels.source_cluster }} has
               {{ $value }} sec for the last 5 minutes
-            alert_routing_key: spi-system
+            alert_team_handle: <!subteam^SLRSHSU1K>
+            team: spi
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/oauth_login.md

--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -25,7 +25,8 @@ spec:
             description: >-
               Tekton controller on cluster {{ $labels.source_cluster }} the percentage of time needed to receive PipelineRun creation
               events vs. overall PipelineRun execution time is at {{ $value | humanizePercentage }} instead of less than 5%.
-            alert_routing_key: pipelines
+            alert_team_handle: <!subteam^S03GF42RBE2>
+            team: pipelines
             runbook_url: TBD
         - alert: HighExecutionOverhead
           expr: |
@@ -43,5 +44,6 @@ spec:
             description: >-
               Tekton controller on cluster {{ $labels.source_cluster }} the percentage of the time needed to create
               underlying TaskRuns vs. overall PipelineRun execution time is at {{ $value | humanizePercentage }} instead of less than 5%.
-            alert_routing_key: pipelines
+            alert_team_handle: <!subteam^S03GF42RBE2>
+            team: pipelines
             runbook_url: TBD

--- a/rhobs/alerting/data_plane/prometheus.pipeline_to_snapshot_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_to_snapshot_alerts.yaml
@@ -30,5 +30,6 @@ spec:
           Time from pipeline run finished to snapshot marked in progress has been over
           30s for more than 10% of requests during the last 10 minutes and has not improved for 10 minutes
           on cluster {{ $labels.source_cluster }}
-        alert_routing_key: integration-service
+        alert_team_handle: <!subteam^S041261DDEW>
+        team: integration
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md

--- a/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
@@ -45,7 +45,8 @@ spec:
           90% of Releases must be processed under one hour
         description: >-
           Release service is failing to successfully process within the period of one hour for 90% of releases
-        alert_routing_key: release-service
+        alert_team_handle: <!subteam^S03SVBS426R>
+        team: release
 
     - alert: ReleaseServicePreProcessingDurationSeconds
       expr: |
@@ -61,7 +62,8 @@ spec:
           90% of Releases must start processing under 10 seconds
         description: >-
           Release service is failing to start processing under 10 seconds for 90% of releases
-        alert_routing_key: release-service
+        alert_team_handle: <!subteam^S03SVBS426R>
+        team: release
 
     - alert: ReleaseServiceValidationDurationSeconds
       expr: |
@@ -77,4 +79,5 @@ spec:
           90% of Releases must be validated under 5 seconds
         description: >-
           Release service is failing to run the validations under 5 seconds for 90% of releases
-        alert_routing_key: release-service
+        alert_team_handle: <!subteam^S03SVBS426R>
+        team: release

--- a/rhobs/alerting/data_plane/prometheus.seb_created_to_ready_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.seb_created_to_ready_alerts.yaml
@@ -30,5 +30,6 @@ spec:
           Time from Snapshot Environment Binding created to marked as
           ready has been over 120s for more than 10% of requests during
           the last 5 minutes on cluster {{ $labels.source_cluster }}
-        alert_routing_key: integration-service
+        alert_team_handle: <!subteam^S041261DDEW>
+        team: integration
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/seb_created_to_ready.md

--- a/rhobs/alerting/data_plane/prometheus.serviceprovider_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.serviceprovider_alerts.yaml
@@ -28,5 +28,6 @@ spec:
               Application controller in Pod {{ $labels.pod }} for namespace
               {{ $labels.namespace }} on instance {{ $labels.source_cluster }} having a
               {{ $value | humanizePercentage }} of 5xx errors from service provider {{ $labels.sp }} for latest 60 minutes
-            alert_routing_key: spi-system
+            alert_team_handle: <!subteam^SLRSHSU1K>
+            team: spi
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/alert-rule-serviceprovider5xxErrorsRate.md

--- a/rhobs/alerting/data_plane/prometheus.stability_image_repository_provision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_image_repository_provision_alerts.yaml
@@ -30,5 +30,6 @@ spec:
           Time taken to provision image repository has been over
           5 minutes for more than 1% of requests during the last 10 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_routing_key: image-controller
+        alert_team_handle: <!subteam^S0500D143S8>
+        team: build
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision.md

--- a/rhobs/alerting/data_plane/prometheus.stability_image_repository_provision_failures_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_image_repository_provision_failures_alerts.yaml
@@ -22,5 +22,6 @@ spec:
         description: >
           Provision image repository failures occured for more than 5 requests during the last 30 minutes
           {{ $labels.source_cluster }}
-        alert_routing_key: image-controller
+        alert_team_handle: <!subteam^S0500D143S8>
+        team: build
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision_failures.md

--- a/rhobs/alerting/data_plane/prometheus.stability_pac_provision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_pac_provision_alerts.yaml
@@ -30,5 +30,6 @@ spec:
           Time taken from PaC provision request till Component is provisioned for PaC builds has been over
           5 minutes for more than 1% of requests during the last 10 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_routing_key: build-service
+        alert_team_handle: <!subteam^S0500D143S8>
+        team: build
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_provision.md

--- a/rhobs/alerting/data_plane/prometheus.stability_pac_unprovision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_pac_unprovision_alerts.yaml
@@ -30,5 +30,6 @@ spec:
           Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
           5 minutes for more than 1% of requests during the last 10 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_routing_key: build-service
+        alert_team_handle: <!subteam^S0500D143S8>
+        team: build
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_unprovision.md

--- a/rhobs/alerting/data_plane/prometheus.stability_simple_build_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_simple_build_alerts.yaml
@@ -30,5 +30,6 @@ spec:
           Time taken from simple build request till the build pipeline is submitted has been over
           5 minutes for more than 1% of requests during the last 10 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_routing_key: build-service
+        alert_team_handle: <!subteam^S0500D143S8>
+        team: build
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_simple_build.md

--- a/test/promql/tests/data_plane/application_errors_test.yaml
+++ b/test/promql/tests/data_plane/application_errors_test.yaml
@@ -31,7 +31,8 @@ tests:
                 Application controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of applications over the past hour
-              alert_routing_key: 'application-service'
+              alert_team_handle: <!subteam^S04MSCVRF4Z>
+              team: has
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-delete-failed.md
 
   - interval: 1m
@@ -60,7 +61,8 @@ tests:
                 Application controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of applications over the past hour
-              alert_routing_key: application-service
+              alert_team_handle: <!subteam^S04MSCVRF4Z>
+              team: has
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-delete-failed.md
 
   - interval: 1m
@@ -117,7 +119,8 @@ tests:
                 Application controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully create at least 95% of applications over the past hour
-              alert_routing_key: application-service
+              alert_team_handle: <!subteam^S04MSCVRF4Z>
+              team: has
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-create-failed.md
 
   - interval: 1m
@@ -146,7 +149,8 @@ tests:
                 Application controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully create at least 95% of applications over the past hour
-              alert_routing_key: application-service
+              alert_team_handle: <!subteam^S04MSCVRF4Z>
+              team: has
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/application-create-failed.md
 
   - interval: 1m

--- a/test/promql/tests/data_plane/component_errors_test.yaml
+++ b/test/promql/tests/data_plane/component_errors_test.yaml
@@ -41,7 +41,8 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of components over the past hour
-              alert_routing_key: application-service
+              alert_team_handle: <!subteam^S04MSCVRF4Z>
+              team: has
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
 
   - interval: 1m
@@ -70,7 +71,8 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of components over the past hour
-              alert_routing_key: application-service
+              alert_team_handle: <!subteam^S04MSCVRF4Z>
+              team: has
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
 
   - interval: 1m
@@ -100,7 +102,8 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully delete at least 95% of components over the past hour
-              alert_routing_key: application-service
+              alert_team_handle: <!subteam^S04MSCVRF4Z>
+              team: has
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-delete-failed.md
 
   - interval: 1m
@@ -167,7 +170,8 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully create at least 95% of components over the past hour
-              alert_routing_key: application-service
+              alert_team_handle: <!subteam^S04MSCVRF4Z>
+              team: has
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md
 
   - interval: 1m
@@ -196,7 +200,8 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully create at least 95% of components over the past hour
-              alert_routing_key: application-service
+              alert_team_handle: <!subteam^S04MSCVRF4Z>
+              team: has
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md
 
   - interval: 1m
@@ -226,7 +231,8 @@ tests:
                 Component controller in Pod has for namespace
                 application-service on cluster cluster01 is failing to
                 successfully create at least 95% of components over the past hour
-              alert_routing_key: application-service
+              alert_team_handle: <!subteam^S04MSCVRF4Z>
+              team: has
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/has/component-create-failed.md
 
   - interval: 1m

--- a/test/promql/tests/data_plane/latency_component_onboarding_test.yaml
+++ b/test/promql/tests/data_plane/latency_component_onboarding_test.yaml
@@ -35,7 +35,8 @@ tests:
                 if PaC provision is requested upon the Component creation, then till the provision finishes has been over
                 60s for more than 10% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_component_onboarding.md
 
   # Scenario where both clusters cross the 10% threshold
@@ -69,7 +70,8 @@ tests:
                 if PaC provision is requested upon the Component creation, then till the provision finishes has been over
                 60s for more than 10% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_component_onboarding.md
           - exp_labels:
               severity: critical
@@ -82,7 +84,8 @@ tests:
                 if PaC provision is requested upon the Component creation, then till the provision finishes has been over
                 60s for more than 10% of requests during the last 5 minutes on cluster
                 cluster02
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_component_onboarding.md
 
   # Scenario where neither cluster crosses the 10% threshold

--- a/test/promql/tests/data_plane/latency_image_repository_provision_test.yaml
+++ b/test/promql/tests/data_plane/latency_image_repository_provision_test.yaml
@@ -34,7 +34,8 @@ tests:
                 Time taken to provision image repository has been over
                 30s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_routing_key: image-controller
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/latency_image_repository_provision.md
 
   # Scenario where both clusters cross the 5% threshold
@@ -67,7 +68,8 @@ tests:
                 Time taken to provision image repository has been over
                 30s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_routing_key: image-controller
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/latency_image_repository_provision.md
           - exp_labels:
               severity: critical
@@ -79,7 +81,8 @@ tests:
                 Time taken to provision image repository has been over
                 30s for more than 5% of requests during the last 5 minutes on cluster
                 cluster02
-              alert_routing_key: image-controller
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/latency_image_repository_provision.md
 
   # Scenario where neither cluster crosses the 5% threshold

--- a/test/promql/tests/data_plane/latency_pac_provision_test.yaml
+++ b/test/promql/tests/data_plane/latency_pac_provision_test.yaml
@@ -34,7 +34,8 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_provision.md
 
   # Scenario where both clusters cross the 5% threshold
@@ -67,7 +68,8 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_provision.md
           - exp_labels:
               severity: critical
@@ -79,7 +81,8 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster02
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_provision.md
 
   # Scenario where neither cluster crosses the 5% threshold

--- a/test/promql/tests/data_plane/latency_pac_unprovision_test.yaml
+++ b/test/promql/tests/data_plane/latency_pac_unprovision_test.yaml
@@ -34,7 +34,8 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_unprovision.md
 
   # Scenario where both clusters cross the 5% threshold
@@ -67,7 +68,8 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_unprovision.md
           - exp_labels:
               severity: critical
@@ -79,7 +81,8 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 20s for more than 5% of requests during the last 5 minutes on cluster
                 cluster02
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_pac_unprovision.md
 
   # Scenario where neither cluster crosses the 5% threshold

--- a/test/promql/tests/data_plane/latency_release_creation_test.yaml
+++ b/test/promql/tests/data_plane/latency_release_creation_test.yaml
@@ -32,7 +32,8 @@ tests:
                 Time from Snapshot marked as passed to release created has been over
                 10s for more than 10% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_routing_key: integration-service
+              alert_team_handle: <!subteam^S041261DDEW>
+              team: integration
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md
 
   # Scenario where both clusters cross the 10% threshold
@@ -65,7 +66,8 @@ tests:
                 Time from Snapshot marked as passed to release created has been over
                 10s for more than 10% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_routing_key: integration-service
+              alert_team_handle: <!subteam^S041261DDEW>
+              team: integration
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md
           - exp_labels:
               severity: critical
@@ -77,7 +79,8 @@ tests:
                 Time from Snapshot marked as passed to release created has been over
                 10s for more than 10% of requests during the last 5 minutes on cluster
                 cluster02
-              alert_routing_key: integration-service
+              alert_team_handle: <!subteam^S041261DDEW>
+              team: integration
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md
 
   # Scenario where neither cluster crosses the 10% threshold

--- a/test/promql/tests/data_plane/latency_simple_build_test.yaml
+++ b/test/promql/tests/data_plane/latency_simple_build_test.yaml
@@ -34,7 +34,8 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 15s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_simple_build.md
 
   # Scenario where both clusters cross the 5% threshold
@@ -67,7 +68,8 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 15s for more than 5% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_simple_build.md
           - exp_labels:
               severity: critical
@@ -79,7 +81,8 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 15s for more than 5% of requests during the last 5 minutes on cluster
                 cluster02
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/latency_simple_build.md
 
   # Scenario where neither cluster crosses the 5% threshold

--- a/test/promql/tests/data_plane/latency_snapshot_to_static_integration_plr_creation_test.yaml
+++ b/test/promql/tests/data_plane/latency_snapshot_to_static_integration_plr_creation_test.yaml
@@ -32,7 +32,8 @@ tests:
                 Time from Snapshot created to integration PLRs in static envs created has been over
                 5s for 90% of requests (tolerance 10%) during the last 5 minutes on cluster
                 cluster01
-              alert_routing_key: integration-service
+              alert_team_handle: <!subteam^S041261DDEW>
+              team: integration
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md
 
   # Scenario where both clusters cross the 10% threshold
@@ -65,7 +66,8 @@ tests:
                 Time from Snapshot created to integration PLRs in static envs created has been over
                 5s for 95% of requests (tolerance 10%) during the last 5 minutes on cluster
                 cluster01
-              alert_routing_key: integration-service
+              alert_team_handle: <!subteam^S041261DDEW>
+              team: integration
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md
           - exp_labels:
               severity: critical
@@ -77,7 +79,8 @@ tests:
                 Time from Snapshot created to integration PLRs in static envs created has been over
                 5s for 95% of requests (tolerance 10%) during the last 5 minutes on cluster
                 cluster02
-              alert_routing_key: integration-service
+              alert_team_handle: <!subteam^S041261DDEW>
+              team: integration
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md
 
   # Scenario where neither cluster crosses the 10% threshold

--- a/test/promql/tests/data_plane/oauth_time_test.yaml
+++ b/test/promql/tests/data_plane/oauth_time_test.yaml
@@ -29,7 +29,8 @@ tests:
                 OAuth login average time is more than 30 sec on cluster01
               description: >-
                 The average OAuth login time on cluster cluster01 has 50 sec for the last 5 minutes
-              alert_routing_key: spi-system
+              alert_team_handle: <!subteam^SLRSHSU1K>
+              team: spi
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/oauth_login.md
 
   - interval: 1m
@@ -61,7 +62,8 @@ tests:
                 OAuth login average time is more than 30 sec on cluster01
               description: >-
                 The average OAuth login time on cluster cluster01 has 50 sec for the last 5 minutes
-              alert_routing_key: spi-system
+              alert_team_handle: <!subteam^SLRSHSU1K>
+              team: spi
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/oauth_login.md
           - exp_labels:
               severity: critical
@@ -75,7 +77,8 @@ tests:
                 OAuth login average time is more than 30 sec on cluster02
               description: >-
                 The average OAuth login time on cluster cluster02 has 60 sec for the last 5 minutes
-              alert_routing_key: spi-system
+              alert_team_handle: <!subteam^SLRSHSU1K>
+              team: spi
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/oauth_login.md
 
 

--- a/test/promql/tests/data_plane/pipeline_overhead_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_overhead_test.yaml
@@ -37,7 +37,8 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 the percentage of time needed to receive PipelineRun creation
                 events vs. overall PipelineRun execution time is at 100% instead of less than 5%.
-              alert_routing_key: pipelines
+              alert_team_handle: <!subteam^S03GF42RBE2>
+              team: pipelines
               runbook_url: TBD
 
   - interval: 1m
@@ -72,7 +73,8 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 the percentage of time needed to receive PipelineRun creation
                 events vs. overall PipelineRun execution time is at 50% instead of less than 5%.
-              alert_routing_key: pipelines
+              alert_team_handle: <!subteam^S03GF42RBE2>
+              team: pipelines
               runbook_url: TBD
 
   - interval: 1m
@@ -130,7 +132,8 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 the percentage of the time needed to create
                 underlying TaskRuns vs. overall PipelineRun execution time is at 100% instead of less than 5%.
-              alert_routing_key: pipelines
+              alert_team_handle: <!subteam^S03GF42RBE2>
+              team: pipelines
               runbook_url: TBD
 
   - interval: 1m
@@ -169,7 +172,8 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 the percentage of the time needed to create
                 underlying TaskRuns vs. overall PipelineRun execution time is at 5.263% instead of less than 5%.
-              alert_routing_key: pipelines
+              alert_team_handle: <!subteam^S03GF42RBE2>
+              team: pipelines
               runbook_url: TBD
 
   - interval: 1m

--- a/test/promql/tests/data_plane/pipeline_to_snapshot_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_to_snapshot_test.yaml
@@ -33,7 +33,8 @@ tests:
               Time from pipeline run finished to snapshot marked in progress has been over
               30s for more than 10% of requests during the last 10 minutes and has not improved for 10 minutes
               on cluster cluster01
-            alert_routing_key: integration-service
+            alert_team_handle: <!subteam^S041261DDEW>
+            team: integration
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md
 
 # Scenario where one cluster crosses the 10% threshold after 7 minutes and another does not
@@ -64,7 +65,8 @@ tests:
               Time from pipeline run finished to snapshot marked in progress has been over
               30s for more than 10% of requests during the last 10 minutes and has not improved for 10 minutes
               on cluster cluster01
-            alert_routing_key: integration-service
+            alert_team_handle: <!subteam^S041261DDEW>
+            team: integration
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md
 
 # Scenario where both clusters cross the 10% threshold, alert should trigger for both
@@ -95,7 +97,8 @@ tests:
               Time from pipeline run finished to snapshot marked in progress has been over
               30s for more than 10% of requests during the last 10 minutes and has not improved for 10 minutes
               on cluster cluster01
-            alert_routing_key: integration-service
+            alert_team_handle: <!subteam^S041261DDEW>
+            team: integration
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md
         - exp_labels:
             severity: critical
@@ -108,7 +111,8 @@ tests:
               Time from pipeline run finished to snapshot marked in progress has been over
               30s for more than 10% of requests during the last 10 minutes and has not improved for 10 minutes
               on cluster cluster02
-            alert_routing_key: integration-service
+            alert_team_handle: <!subteam^S041261DDEW>
+            team: integration
             runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/pipeline_to_snapshot_exceeded.md
 
 # Scenario where no alert is triggered as both clusters stay below the 10% threshold

--- a/test/promql/tests/data_plane/release_service_test.yaml
+++ b/test/promql/tests/data_plane/release_service_test.yaml
@@ -27,7 +27,8 @@ tests:
                 90% of Releases must be processed under one hour
               description: >-
                 Release service is failing to successfully process within the period of one hour for 90% of releases
-              alert_routing_key: release-service
+              alert_team_handle: <!subteam^S03SVBS426R>
+              team: release
 
   - interval: 1m
     input_series:
@@ -52,7 +53,8 @@ tests:
                 90% of Releases must start processing under 10 seconds
               description: >-
                 Release service is failing to start processing under 10 seconds for 90% of releases
-              alert_routing_key: release-service
+              alert_team_handle: <!subteam^S03SVBS426R>
+              team: release
 
   - interval: 1m
     input_series:
@@ -77,4 +79,5 @@ tests:
                 90% of Releases must be validated under 5 seconds
               description: >-
                 Release service is failing to run the validations under 5 seconds for 90% of releases
-              alert_routing_key: release-service
+              alert_team_handle: <!subteam^S03SVBS426R>
+              team: release

--- a/test/promql/tests/data_plane/seb_created_to_ready_test.yaml
+++ b/test/promql/tests/data_plane/seb_created_to_ready_test.yaml
@@ -27,7 +27,8 @@ tests:
                 Time from Snapshot Environment Binding created to marked as
                 ready has been over 120s for more than 10% of requests during
                 the last 5 minutes on cluster cluster01
-              alert_routing_key: "integration-service"
+              alert_team_handle: <!subteam^S041261DDEW>
+              team: integration
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/seb_created_to_ready.md
 
   # Scenario where both clusters exceed the 10% threshold
@@ -58,7 +59,8 @@ tests:
                 Time from Snapshot Environment Binding created to marked as
                 ready has been over 120s for more than 10% of requests during
                 the last 5 minutes on cluster cluster01
-              alert_routing_key: "integration-service"
+              alert_team_handle: <!subteam^S041261DDEW>
+              team: integration
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/seb_created_to_ready.md
 
           - exp_labels:
@@ -71,7 +73,8 @@ tests:
                 Time from Snapshot Environment Binding created to marked as
                 ready has been over 120s for more than 10% of requests during
                 the last 5 minutes on cluster cluster02
-              alert_routing_key: "integration-service"
+              alert_team_handle: <!subteam^S041261DDEW>
+              team: integration
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/seb_created_to_ready.md
 
   # Scenario where neither cluster crosses the 10% threshold

--- a/test/promql/tests/data_plane/serviceprovider_errors_test.yaml
+++ b/test/promql/tests/data_plane/serviceprovider_errors_test.yaml
@@ -32,7 +32,8 @@ tests:
                 Application controller in Pod spi-controller-manager for namespace
                 spi-system on instance cluster01 having a 50% of 5xx errors
                 from service provider GitHub for latest 60 minutes
-              alert_routing_key: spi-system
+              alert_team_handle: <!subteam^SLRSHSU1K>
+              team: spi
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/alert-rule-serviceprovider5xxErrorsRate.md
 
   - interval: 1m
@@ -65,9 +66,9 @@ tests:
                 Application controller in Pod spi-controller-manager for namespace
                 spi-system on instance cluster01 having a 33.33% of 5xx errors
                 from service provider GitHub for latest 60 minutes
-              alert_routing_key: spi-system
+              alert_team_handle: <!subteam^SLRSHSU1K>
+              team: spi
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/spi/alert-rule-serviceprovider5xxErrorsRate.md
-
 
   - interval: 1m
     input_series:

--- a/test/promql/tests/data_plane/stability_image_repository_provision_failures_test.yaml
+++ b/test/promql/tests/data_plane/stability_image_repository_provision_failures_test.yaml
@@ -29,7 +29,8 @@ tests:
               description: >
                 Provision image repository failures occured for more than 5 requests during the last 30 minutes
                 cluster01
-              alert_routing_key: image-controller
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision_failures.md
 
   # Scenario where both clusters cross the 5 threshold
@@ -57,7 +58,8 @@ tests:
               description: >
                 Provision image repository failures occured for more than 5 requests during the last 30 minutes
                 cluster01
-              alert_routing_key: image-controller
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision_failures.md
           - exp_labels:
               severity: critical
@@ -68,7 +70,8 @@ tests:
               description: >
                 Provision image repository failures occured for more than 5 requests during the last 30 minutes
                 cluster02
-              alert_routing_key: image-controller
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision_failures.md
 
   # Scenario where neither cluster crosses the 5 threshold

--- a/test/promql/tests/data_plane/stability_image_repository_provision_test.yaml
+++ b/test/promql/tests/data_plane/stability_image_repository_provision_test.yaml
@@ -34,7 +34,8 @@ tests:
                 Time taken to provision image repository has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_routing_key: image-controller
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision.md
 
   # Scenario where both clusters cross the 1% threshold
@@ -67,7 +68,8 @@ tests:
                 Time taken to provision image repository has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_routing_key: image-controller
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision.md
           - exp_labels:
               severity: critical
@@ -79,7 +81,8 @@ tests:
                 Time taken to provision image repository has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster02
-              alert_routing_key: image-controller
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/image-controller/stability_image_repository_provision.md
 
   # Scenario where neither cluster crosses the 1% threshold

--- a/test/promql/tests/data_plane/stability_pac_provision_test.yaml
+++ b/test/promql/tests/data_plane/stability_pac_provision_test.yaml
@@ -34,7 +34,8 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_provision.md
 
   # Scenario where both clusters cross the 1% threshold
@@ -67,7 +68,8 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_provision.md
           - exp_labels:
               severity: critical
@@ -79,7 +81,8 @@ tests:
                 Time taken from PaC provision request till Component is provisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster02
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_provision.md
 
   # Scenario where neither cluster crosses the 1% threshold

--- a/test/promql/tests/data_plane/stability_pac_unprovision_test.yaml
+++ b/test/promql/tests/data_plane/stability_pac_unprovision_test.yaml
@@ -34,7 +34,8 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_unprovision.md
 
   # Scenario where both clusters cross the 1% threshold
@@ -67,7 +68,8 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_unprovision.md
           - exp_labels:
               severity: critical
@@ -79,7 +81,8 @@ tests:
                 Time taken from PaC unprovision request till Component is unprovisioned for PaC builds has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster02
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_pac_unprovision.md
 
   # Scenario where neither cluster crosses the 1% threshold

--- a/test/promql/tests/data_plane/stability_simple_build_test.yaml
+++ b/test/promql/tests/data_plane/stability_simple_build_test.yaml
@@ -34,7 +34,8 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_simple_build.md
 
   # Scenario where both clusters cross the 1% threshold
@@ -67,7 +68,8 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster01
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_simple_build.md
           - exp_labels:
               severity: critical
@@ -79,7 +81,8 @@ tests:
                 Time taken from simple build request till the build pipeline is submitted has been over
                 5 minutes for more than 1% of requests during the last 10 minutes on cluster
                 cluster02
-              alert_routing_key: build-service
+              alert_team_handle: <!subteam^S0500D143S8>
+              team: build
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/build-service/stability_simple_build.md
 
   # Scenario where neither cluster crosses the 1% threshold


### PR DESCRIPTION
Now that SLO and non-SLO alerts are routed to different channels, there is no need to keep track of the namespace of each team. Instead, alert_routing_key is replaced by the slack's team handle, using the key:value `alert_team_handle`.

Since the team-handle for tagging in slack is using the team ID, a `team` key is also added to make the routing more readable.