### PR TITLE
chore(RHTAPWATCH-840): Update Dockerfile to pass EC checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,12 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3-1361.1699548032
 RUN microdnf update --setopt=install_weak_deps=0 -y && microdnf install -y libcurl-minimal libcurl-devel
 
 COPY --from=builder /bin/exporters /bin/exporters
+
+# It is mandatory to set these labels
+LABEL description="Konflux Observability Exporters"
+LABEL io.k8s.description="Konflux Observability Exporters"
+LABEL io.k8s.display-name="o11y-exporters"
+LABEL io.openshift.tags="konflux"
+LABEL summary="Konflux Observability Exporters"
+
 CMD ["/bin/exporters"]


### PR DESCRIPTION
Added labels to the Dockerfile to mitigate the violation labels.disallowed_inherited_labels and make the EC checks pass.

Jira-Url: https://issues.redhat.com/browse/RHTAPWATCH-840