### PR TITLE
chore(RHTAPWATCH-840): Update Dockerfile and .tekton to pass EC checks

### DIFF
--- a/.tekton/o11y-pull-request.yaml
+++ b/.tekton/o11y-pull-request.yaml
@@ -118,7 +118,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/o11y-push.yaml
+++ b/.tekton/o11y-push.yaml
@@ -110,7 +110,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ RUN microdnf update --setopt=install_weak_deps=0 -y && microdnf install -y libcu
 COPY --from=builder /bin/exporters /bin/exporters
 
 # It is mandatory to set these labels
+LABEL name="Konflux Observability Exporters"
 LABEL description="Konflux Observability Exporters"
+LABEL com.redhat.component="Konflux Observability Exporters"
 LABEL io.k8s.description="Konflux Observability Exporters"
 LABEL io.k8s.display-name="o11y-exporters"
 LABEL io.openshift.tags="konflux"


### PR DESCRIPTION
Added labels to the Dockerfile to mitigate the violation labels.disallowed_inherited_labels.
Updated the default value for source-build to make the EC checks pass.