### PR TITLE
fix: use sha instead of branch name for clone-repo step

### DIFF
--- a/.tekton/o11y-pull-request.yaml
+++ b/.tekton/o11y-pull-request.yaml
@@ -280,7 +280,7 @@ spec:
         - name: url
           value: https://github.com/tektoncd/catalog.git
         - name: revision
-          value: main
+          value: 710c77d5c520d8dbce1e7e0055543415b57d6cb9
         - name: pathInRepo
           value: task/kube-linter/0.1/kube-linter.yaml
       params:


### PR DESCRIPTION
Using branch name causes EC to fail. Using commit sha instead