### PR TITLE
chore(RHTAPWATCH-794): tag DegradedArgoCdApp alerts correctly

### DIFF
--- a/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
+++ b/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
@@ -6,46 +6,53 @@ metadata:
     tenant: rhtap
 spec:
   groups:
-  - name: argocd-alerts
-    interval: 1m
-    rules:
-    - alert: DegradedArgocdApp
-      expr: |
-        last_over_time(
-          argocd_app_info{health_status="Degraded", namespace=~"argocd-staging|argocd"}[2m]
-        ) == 1
-      for: 5m
-      labels:
-        severity: warning
-        team: rhtap
-      annotations:
-        summary: Argocd App '{{ $labels.name }}' is degraded
-        description: |
-          Environment: {{ $labels.source_environment }}
-          Application: {{ $labels.name }}
-          Cluster: {{ $labels.dest_server }}
-          Health status Degraded.
-        alert_routing_key: '{{ $labels.dest_namespace }}'
-        runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
-    - alert: ProgressingArgocdApp
-      expr: |
-        max_over_time(
-          argocd_app_info{health_status="Progressing", namespace=~"argocd-staging|argocd"}[19m]
-        ) == 1
-        unless ignoring (health_status)
-        max_over_time(
-          argocd_app_info{health_status!="Progressing", namespace=~"argocd-staging|argocd"}[19m]
-        ) == 1
-      for: 1m
-      labels:
-        severity: warning
-        team: rhtap
-      annotations:
-        summary: Argocd App '{{ $labels.name }}' is progressing for too long
-        description: |-
-          Environment: {{ $labels.source_environment }}
-          Application: {{ $labels.name }}
-          Cluster: {{ $labels.dest_server }}
-          App progressing for too long.
-        alert_routing_key: '{{ $labels.dest_namespace }}'
-        runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-ProgressingArgocdApp.md
+    - name: argocd-alerts
+      interval: 1m
+      rules:
+        - alert: DegradedArgocdApp
+          expr: |
+            last_over_time(
+              argocd_app_info{health_status="Degraded", namespace=~"argocd-staging|argocd"}[2m]
+            ) == 1
+          for: 5m
+          labels:
+            severity: warning
+            team: rhtap
+          annotations:
+            summary: Argocd App '{{ $labels.name }}' is degraded
+            description: |
+              Environment: {{ $labels.source_environment }}
+              Application: {{ $labels.name }}
+              Cluster: {{ $labels.dest_server }}
+              Health status Degraded.
+            alert_routing_key: "{{ $labels.dest_namespace }}"
+            runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
+        - alert: ProgressingArgocdApp
+          expr: |
+            max_over_time(
+              argocd_app_info{health_status="Progressing", namespace=~"argocd-staging|argocd"}[19m]
+            ) == 1
+            unless ignoring (health_status)
+            max_over_time(
+              argocd_app_info{health_status!="Progressing", namespace=~"argocd-staging|argocd"}[19m]
+            ) == 1
+          for: 1m
+          labels:
+            severity: warning
+            team: rhtap
+          annotations:
+            summary: Argocd App '{{ $labels.name }}' is progressing for too long
+            description: |-
+              Environment: {{ $labels.source_environment }}
+              Application: {{ $labels.name }}
+              Cluster: {{ $labels.dest_server }}
+              App progressing for too long.
+            alert_routing_key: >-
+              {{ if eq $labels.dest_namespace "default" -}}
+                  {{ $name := $labels.name -}}
+                  {{ $modifiedName :=  reReplaceAll ".*?(-stone-[^-]+-[^-]+).*" "$1" $name }}
+                  {{ $modifiedName -}}
+              {{ else -}}
+                {{ $labels.dest_namespace -}}
+              {{ end }}
+            runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-ProgressingArgocdApp.md

--- a/test/promql/tests/control_plane/argocd_test.yaml
+++ b/test/promql/tests/control_plane/argocd_test.yaml
@@ -7,39 +7,78 @@ tests:
   # DegradedArgocdApp alert
   - interval: 1m
     input_series:
-
       # no app is degraded - shouldn't trigger alerts
-      - series: 'argocd_app_info{health_status="Degraded", name="not-degraded-app", namespace="argocd-staging", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Degraded", name="not-degraded-app",
+          namespace="argocd-staging", dest_namespace="test_dest_namespace",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="staging-cluster"}'
         values: _x9
 
       # an app is constantly degraded - should trigger alerts
-      - series: 'argocd_app_info{health_status="Degraded", name="degraded-app", namespace="argocd-staging", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Degraded", name="degraded-app",
+          namespace="argocd-staging", dest_namespace="test_dest_namespace",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="staging-cluster"}'
+        values: 1x9
+
+      # an app is constantly degraded - should trigger alerts with "test-namespace-route" as the alert routing key instead of dest_namespace "default".
+      - series:
+          'argocd_app_info{health_status="Degraded",
+          name="degraded-app-test-stone-stg-m01", namespace="argocd-staging",
+          dest_namespace="default",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="staging-cluster"}'
         values: 1x9
 
       # an app with some 1m degraded status - shouldn't trigger alerts
-      - series: 'argocd_app_info{health_status="Degraded", name="degraded-1m-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Degraded", name="degraded-1m-app",
+          namespace="argocd", dest_namespace="test_dest_namespace",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
         values: 1 _ _ _ 1 _ _ _ _ _
 
       # an app with a 4m degraded status - shouldn't trigger alerts
-      - series: 'argocd_app_info{health_status="Degraded", name="degraded-4m-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Degraded", name="degraded-4m-app",
+          namespace="argocd", dest_namespace="test_dest_namespace",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
         values: _ 1 1 1 1 _ _ _ _ _
 
       # an app is flapping every 1m - should trigger alerts triggers
-      - series: 'argocd_app_info{health_status="Degraded", name="flapping-1m-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Degraded", name="flapping-1m-app",
+          namespace="argocd", dest_namespace="test_dest_namespace",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
         values: 1 _ 1 _ 1 _ 1 _ 1 _
 
       # an app is flapping every 2m - should trigger alerts triggers
-      - series: 'argocd_app_info{health_status="Degraded", name="flapping-2m-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Degraded", name="flapping-2m-app",
+          namespace="argocd", dest_namespace="test_dest_namespace",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
         values: 1 _ _ 1 _ _ 1 _ _ 1
 
       # an app is flapping every 2m but on arbitrary namespace - should not trigger
-      - series: 'argocd_app_info{health_status="Degraded", name="flapping-2m-app", namespace="baz", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Degraded", name="flapping-2m-app",
+          namespace="baz", dest_namespace="test_dest_namespace",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
         values: 1 _ _ 1 _ _ 1 _ _ 1
 
       # an app is in another health status which is not 'Degraded' - the rule shouldn't alert.
-      - series: 'argocd_app_info{health_status="Progressing", name="progressing-app", namespace="argocd-staging", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Progressing", name="progressing-app",
+          namespace="argocd-staging", dest_namespace="test_dest_namespace",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="staging-cluster"}'
         values: 1x9
-
 
     alert_rule_test:
       - eval_time: 5m
@@ -85,6 +124,25 @@ tests:
 
           - exp_labels:
               severity: warning
+              dest_namespace: "default"
+              dest_server: https://api.foo.openshiftapps.com:6443
+              namespace: argocd-staging
+              health_status: Degraded
+              name: degraded-app-test-stone-stg-m01
+              source_environment: staging-cluster
+              team: rhtap
+            exp_annotations:
+              summary: Argocd App 'degraded-app' is degraded
+              description: |
+                Environment: staging-cluster
+                Application: degraded-app
+                Cluster: https://api.foo.openshiftapps.com:6443
+                Health status Degraded.
+              alert_routing_key: degraded-app-test
+              runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
+
+          - exp_labels:
+              severity: warning
               dest_namespace: test_dest_namespace
               dest_server: https://api.foo.openshiftapps.com:6443
               namespace: argocd
@@ -106,9 +164,17 @@ tests:
   - interval: 1m
     input_series:
       # App was progessing and then healthy for the last 9 min, should not raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="Progressing-Healthy-9min-app", namespace="argocd-staging", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Progressing",
+          name="Progressing-Healthy-9min-app", namespace="argocd-staging",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="staging-cluster"}'
         values: 1x10 _x8
-      - series: 'argocd_app_info{health_status="Healthy", name="Progressing-Healthy-9min-app", namespace="argocd-staging", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Healthy",
+          name="Progressing-Healthy-9min-app", namespace="argocd-staging",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="staging-cluster"}'
         values: _x10 1x8
     alert_rule_test:
       - eval_time: 20m
@@ -118,7 +184,12 @@ tests:
   - interval: 1m
     input_series:
       # App is always progressing, should raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="progressing-only-app", namespace="argocd-staging", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Progressing",
+          name="progressing-only-app", namespace="argocd-staging",
+          dest_namespace="test_dest_namespace",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="staging-cluster"}'
         values: 1x19
     alert_rule_test:
       - eval_time: 20m
@@ -134,7 +205,8 @@ tests:
               source_environment: staging-cluster
               team: rhtap
             exp_annotations:
-              summary: Argocd App 'progressing-only-app' is progressing for too long
+              summary:
+                Argocd App 'progressing-only-app' is progressing for too long
               description: |-
                 Environment: staging-cluster
                 Application: progressing-only-app
@@ -146,7 +218,11 @@ tests:
   - interval: 1m
     input_series:
       # App is always progressing, but on unrelated namespace. should NOT raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="progressing-only-app", namespace="not-us", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="staging-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Progressing",
+          name="progressing-only-app", namespace="not-us",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="staging-cluster"}'
         values: 1x19
     alert_rule_test:
       - eval_time: 20m
@@ -156,11 +232,23 @@ tests:
   - interval: 1m
     input_series:
       # Apps are always healthy, should not raise an alert
-      - series: 'argocd_app_info{health_status="Healthy", name="Healthy-only-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Healthy", name="Healthy-only-app",
+          namespace="argocd",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
         values: 1x19
-      - series: 'argocd_app_info{health_status="Progressing", name="Healthy-only-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Progressing", name="Healthy-only-app",
+          namespace="argocd",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
         values: _x19
-      - series: 'argocd_app_info{health_status="Healthy", name="another-Healthy-only-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Healthy",
+          name="another-Healthy-only-app", namespace="argocd",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
         values: 1x19
     alert_rule_test:
       - eval_time: 20m
@@ -170,9 +258,17 @@ tests:
   - interval: 1m
     input_series:
       # App was progessing and then healthy for the last 4 min, should not raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="progressing-healthy-4min-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Progressing",
+          name="progressing-healthy-4min-app", namespace="argocd",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
         values: 1x15 _x3
-      - series: 'argocd_app_info{health_status="Healthy", name="progressing-healthy-4min-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Healthy",
+          name="progressing-healthy-4min-app", namespace="argocd",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
         values: _x15 1x3
     alert_rule_test:
       - eval_time: 20m
@@ -182,10 +278,18 @@ tests:
   - interval: 1m
     input_series:
       # the app is switching health states (flapping), should not raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="flapping-should-not-alert-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
-        values: '_ 1 _ 1 1 _ 1 1 1 _ _ _ _ 1 _ 1 1 1 1 _'
-      - series: 'argocd_app_info{health_status="Healthy", name="flapping-should-not-alert-app", namespace="argocd", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
-        values: '1 _ 1 _ _ 1 _ _ _ 1 1 1 1 _ 1 _ _ _ _ 1'
+      - series:
+          'argocd_app_info{health_status="Progressing",
+          name="flapping-should-not-alert-app", namespace="argocd",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
+        values: "_ 1 _ 1 1 _ 1 1 1 _ _ _ _ 1 _ 1 1 1 1 _"
+      - series:
+          'argocd_app_info{health_status="Healthy",
+          name="flapping-should-not-alert-app", namespace="argocd",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
+        values: "1 _ 1 _ _ 1 _ _ _ 1 1 1 1 _ 1 _ _ _ _ 1"
     alert_rule_test:
       - eval_time: 20m
         alertname: ProgressingArgocdApp
@@ -194,14 +298,34 @@ tests:
   - interval: 1m
     input_series:
       # App 1: Progressing all of the time, should raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="Progressing_first-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Progressing",
+          name="Progressing_first-app", namespace="argocd",
+          dest_namespace="test_dest_namespace",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
         values: 1x19
-      - series: 'argocd_app_info{health_status="Healthy", name="Progressing_first-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Healthy",
+          name="Progressing_first-app", namespace="argocd",
+          dest_namespace="test_dest_namespace",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
         values: _x19
       # App 2: Progressing for 17 minutes and then healthy for 3 minutes, should not raise an alert
-      - series: 'argocd_app_info{health_status="Progressing", name="Progressing_second-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Progressing",
+          name="Progressing_second-app", namespace="argocd",
+          dest_namespace="test_dest_namespace",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
         values: 1x16 _ _ _
-      - series: 'argocd_app_info{health_status="Healthy", name="Progressing_second-app", namespace="argocd", dest_namespace="test_dest_namespace", dest_server="https://api.foo.openshiftapps.com:6443", source_environment="production-cluster"}'
+      - series:
+          'argocd_app_info{health_status="Healthy",
+          name="Progressing_second-app", namespace="argocd",
+          dest_namespace="test_dest_namespace",
+          dest_server="https://api.foo.openshiftapps.com:6443",
+          source_environment="production-cluster"}'
         values: _x16 1 1 1
     alert_rule_test:
       - eval_time: 20m
@@ -217,7 +341,8 @@ tests:
               source_environment: production-cluster
               team: rhtap
             exp_annotations:
-              summary: Argocd App 'Progressing_first-app' is progressing for too long
+              summary:
+                Argocd App 'Progressing_first-app' is progressing for too long
               description: |-
                 Environment: production-cluster
                 Application: Progressing_first-app


### PR DESCRIPTION
an attempt to introduce logic that will be able to tag DegradedArgoCdApp alerts of different teams correctly.