### PR TITLE
chore: replace integration team alert tagging

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.latency_release_creation_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_release_creation_alerts.yaml
@@ -30,6 +30,6 @@ spec:
           Time from Snapshot marked as passed to release created has been over
           10s for more than 10% of requests during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_team_handle: <!subteam^S041261DDEW>
+        alert_team_handle: <!subteam^S05M4AG8CJH>
         team: integration
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md

--- a/rhobs/alerting/data_plane/prometheus.latency_snapshot_to_static_integration_plr_creation_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_snapshot_to_static_integration_plr_creation_alerts.yaml
@@ -30,6 +30,6 @@ spec:
           Time from Snapshot created to integration PLRs in static envs created has been over
           5s for {{ $value | humanizePercentage }} of requests (tolerance 10%) during the last 5 minutes on cluster
           {{ $labels.source_cluster }}
-        alert_team_handle: <!subteam^S041261DDEW>
+        alert_team_handle: <!subteam^S05M4AG8CJH>
         team: integration
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md

--- a/test/promql/tests/data_plane/latency_release_creation_test.yaml
+++ b/test/promql/tests/data_plane/latency_release_creation_test.yaml
@@ -32,7 +32,7 @@ tests:
                 Time from Snapshot marked as passed to release created has been over
                 10s for more than 10% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_team_handle: <!subteam^S041261DDEW>
+              alert_team_handle: <!subteam^S05M4AG8CJH>
               team: integration
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md
 
@@ -66,7 +66,7 @@ tests:
                 Time from Snapshot marked as passed to release created has been over
                 10s for more than 10% of requests during the last 5 minutes on cluster
                 cluster01
-              alert_team_handle: <!subteam^S041261DDEW>
+              alert_team_handle: <!subteam^S05M4AG8CJH>
               team: integration
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md
           - exp_labels:
@@ -79,7 +79,7 @@ tests:
                 Time from Snapshot marked as passed to release created has been over
                 10s for more than 10% of requests during the last 5 minutes on cluster
                 cluster02
-              alert_team_handle: <!subteam^S041261DDEW>
+              alert_team_handle: <!subteam^S05M4AG8CJH>
               team: integration
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_release_creation.md
 

--- a/test/promql/tests/data_plane/latency_snapshot_to_static_integration_plr_creation_test.yaml
+++ b/test/promql/tests/data_plane/latency_snapshot_to_static_integration_plr_creation_test.yaml
@@ -32,7 +32,7 @@ tests:
                 Time from Snapshot created to integration PLRs in static envs created has been over
                 5s for 90% of requests (tolerance 10%) during the last 5 minutes on cluster
                 cluster01
-              alert_team_handle: <!subteam^S041261DDEW>
+              alert_team_handle: <!subteam^S05M4AG8CJH>
               team: integration
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md
 
@@ -66,7 +66,7 @@ tests:
                 Time from Snapshot created to integration PLRs in static envs created has been over
                 5s for 95% of requests (tolerance 10%) during the last 5 minutes on cluster
                 cluster01
-              alert_team_handle: <!subteam^S041261DDEW>
+              alert_team_handle: <!subteam^S05M4AG8CJH>
               team: integration
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md
           - exp_labels:
@@ -79,7 +79,7 @@ tests:
                 Time from Snapshot created to integration PLRs in static envs created has been over
                 5s for 95% of requests (tolerance 10%) during the last 5 minutes on cluster
                 cluster02
-              alert_team_handle: <!subteam^S041261DDEW>
+              alert_team_handle: <!subteam^S05M4AG8CJH>
               team: integration
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md
 


### PR DESCRIPTION
Change the integration team group to S05M4AG8CJH to their request.