### PR TITLE
fix(RHTAPWATCH-568): Add authentication to service and servicemonitor

### DIFF
--- a/config/exporters/monitoring/grafana/base/prometheus-exporter-service.yaml
+++ b/config/exporters/monitoring/grafana/base/prometheus-exporter-service.yaml
@@ -35,7 +35,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kube-rbac-proxy-grafana
+  name: kube-rbac-proxy
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources:
@@ -53,7 +53,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kube-rbac-proxy-grafana
+  name: kube-rbac-proxy
 subjects:
 - kind: ServiceAccount
   name: exporter-sa
@@ -91,7 +91,7 @@ spec:
     spec:
       serviceAccountName: exporter-sa
       containers:
-      - name: kube-rbac-proxy-grafana
+      - name: kube-rbac-proxy
         image: quay.io/brancz/kube-rbac-proxy:v0.14.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"


### PR DESCRIPTION
- Revert the changes made to the container name (config/exporters/monitoring/grafana/base/prometheus-exporter-service.yaml)