### PR TITLE
Remotesecret availability mertic rule

### DIFF
--- a/rhobs/recording/remotesecret_availability_recording_rules.yaml
+++ b/rhobs/recording/remotesecret_availability_recording_rules.yaml
@@ -1,0 +1,15 @@
+# Metric format needed
+# redhat_appstudio_remotesecret_secretstorage_system_available(service="remote-secret-controller-manager-metrics-service") -> konflux_up(service="remote-secret-controller-manager-metrics-service", check="secretstorage")
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-remotesecret-availability
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: remotesecret_secretstorage_availability
+      interval: 1m
+      rules:
+        - record: konflux_up
+          expr: label_replace(redhat_appstudio_remotesecret_secretstorage_system_available, "check", "secretstorage", "","")

--- a/test/promql/tests/recording/remotesecret_availability_recording_rules_test.yml
+++ b/test/promql/tests/recording/remotesecret_availability_recording_rules_test.yml
@@ -1,0 +1,25 @@
+evaluation_interval: 1m
+
+rule_files:
+- remotesecret_availability_recording_rules.yaml
+
+tests:
+- interval: 1m
+  name: RSExporterTest
+  input_series:
+    - series: "redhat_appstudio_remotesecret_secretstorage_system_available{service='remote-secret-controller-manager-metrics-service'}"
+      values: "1 1 1 1 1"
+    - series: "redhat_appstudio_remotesecret_secretstorage_system_available{service='remote-secret-controller-manager-metrics-service1'}"
+      values: "0 0 0 0 0"
+    - series: "redhat_appstudio_remotesecret_secretstorage_system_available{service='remote-secret-controller-manager-metrics-service2'}"
+      values: "0 1 0 1 0"
+  promql_expr_test:
+    - expr: konflux_up
+      eval_time: 5m
+      exp_samples:
+        - labels: konflux_up{service='remote-secret-controller-manager-metrics-service', check='secretstorage'}
+          value: 1
+        - labels: konflux_up{service='remote-secret-controller-manager-metrics-service1', check='secretstorage'}
+          value: 0
+        - labels: konflux_up{service='remote-secret-controller-manager-metrics-service2', check='secretstorage'}
+          value: 0


### PR DESCRIPTION
Transform existed `redhat_appstudio_remotesecret_secretstorage_system_available` metric to the form `onflux_up(service="remote-secret-controller-manager-metrics-service", check="secretstorage")`