### PR TITLE
chore(RHTAPWATCH-794): update alert_routing_key in argocd alerts

### DIFF
--- a/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
+++ b/rhobs/alerting/control_plane/prometheus.argocd_alerts.yaml
@@ -26,7 +26,7 @@ spec:
           Application: {{ $labels.name }}
           Cluster: {{ $labels.dest_server }}
           Health status Degraded.
-        alert_routing_key: '{{ $labels.dest_namespace }}'
+        alert_routing_key: '{{ $labels.name }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
     - alert: ProgressingArgocdApp
       expr: |
@@ -49,5 +49,5 @@ spec:
           Application: {{ $labels.name }}
           Cluster: {{ $labels.dest_server }}
           App progressing for too long.
-        alert_routing_key: '{{ $labels.dest_namespace }}'
+        alert_routing_key: '{{ $labels.name }}'
         runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-ProgressingArgocdApp.md

--- a/test/promql/tests/control_plane/argocd_test.yaml
+++ b/test/promql/tests/control_plane/argocd_test.yaml
@@ -62,7 +62,7 @@ tests:
                 Application: degraded-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 Health status Degraded.
-              alert_routing_key: test_dest_namespace
+              alert_routing_key: degraded-app
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
 
           - exp_labels:
@@ -82,7 +82,7 @@ tests:
                 Application: flapping-1m-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 Health status Degraded.
-              alert_routing_key: test_dest_namespace
+              alert_routing_key: flapping-1m-app
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
 
           - exp_labels:
@@ -102,7 +102,7 @@ tests:
                 Application: flapping-2m-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 Health status Degraded.
-              alert_routing_key: test_dest_namespace
+              alert_routing_key: flapping-2m-app
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-degradedArgocdApp.md
 
   # ProgressingArgocdApp alert
@@ -144,7 +144,7 @@ tests:
                 Application: progressing-only-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 App progressing for too long.
-              alert_routing_key: test_dest_namespace
+              alert_routing_key: progressing-only-app
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-ProgressingArgocdApp.md
 
   - interval: 1m
@@ -228,5 +228,5 @@ tests:
                 Application: Progressing_first-app
                 Cluster: https://api.foo.openshiftapps.com:6443
                 App progressing for too long.
-              alert_routing_key: test_dest_namespace
+              alert_routing_key: Progressing_first-app
               runbook_url: https://gitlab.cee.redhat.com/rhtap/docs/sop/-/blob/main/o11y/alert-rule-ProgressingArgocdApp.md


### PR DESCRIPTION
Update `alert_routing_key` to be assigned with the application name instead of namespace in ArgoCD alerts