### PR TITLE
fix(DEVHAS-598): Add in HAS recording rules for availability metrics

### DIFF
--- a/rhobs/recording/has_recording_rules.yaml
+++ b/rhobs/recording/has_recording_rules.yaml
@@ -1,0 +1,15 @@
+# Metric format needed
+# has_availability(check=github) -> konflux_up(service=has, check=github)
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-has-label-replace
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: has_availability
+    interval: 1m
+    rules:
+    - record: konflux_up
+      expr: label_replace(has_availability, "service", "has", "__name__", "(.+)")

--- a/test/promql/tests/recording/has_recording_rules_test.yml
+++ b/test/promql/tests/recording/has_recording_rules_test.yml
@@ -1,0 +1,25 @@
+evaluation_interval: 1m
+
+rule_files:
+- has_recording_rules.yaml
+
+tests:
+- interval: 1m
+  name: HASExporterTest
+  input_series:
+    - series: "has_availability{check='github'}"
+      values: "1 1 1 1 1"
+    - series: "has_availability{check='gitlab'}"
+      values: "0 0 0 0 0"
+    - series: "has_availability{other_label='bitbucket'}"
+      values: "0 1 0 1 0"
+  promql_expr_test:
+    - expr: konflux_up
+      eval_time: 5m
+      exp_samples:
+        - labels: konflux_up{service='has', check='github'}
+          value: 1
+        - labels: konflux_up{service='has', check='gitlab'}
+          value: 0
+        - labels: konflux_up{service='has', other_label='bitbucket'}
+          value: 0


### PR DESCRIPTION
https://issues.redhat.com/browse/DEVHAS-598

Recording Rule for the [HAS Availability metrics](https://github.com/redhat-appstudio/application-service/pull/453)
```
has_availability(check=github) -> konflux_up(service=has, check=github)
```