### PR TITLE
chore(RHTAPWATCH-891): Update rolebinding to clusterrolebinding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /bin/exporters .
 EXPOSE 8090
 
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3-1361.1699548032
-RUN microdnf update --setopt=install_weak_deps=0 -y && microdnf install -y libcurl-minimal libcurl-devel
+FROM registry.access.redhat.com/ubi9-micro@sha256:8e33df2832f039b4b1adc53efd783f9404449994b46ae321ee4a0bf4499d5c42
 
 COPY --from=builder /bin/exporters /bin/exporters
 

--- a/config/exporters/monitoring/grafana/base/prometheus-exporter-service-monitor.yaml
+++ b/config/exporters/monitoring/grafana/base/prometheus-exporter-service-monitor.yaml
@@ -24,10 +24,9 @@ rules:
   - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: exporter-role-binding-metrics-reader
-  namespace: appstudio-grafana-datasource-exporter
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/exporters/monitoring/grafana/base/prometheus-exporter-service.yaml
+++ b/config/exporters/monitoring/grafana/base/prometheus-exporter-service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: appstudio-grafana-datasource-exporter
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec: {}
 ---
 apiVersion: v1


### PR DESCRIPTION
Updating the rolebinding to clusterrolebinding to make the exporter
work after authentication and prioritize namespace to create first.
Updated the ubi-minimal image to ubi-micro to make integration
test pass.