### PR TITLE
chore(RHTAPWATCH-890): Add Alering Rule for konflux_up metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ The different alerting rules in this repository are:
 
 * [**Alert Rule QuotaExceeded**](https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-QuotaExceeded.md)
 
+### Availability Metric Alerts
+
+These Alert rules are defined to monitor and alert if the `konflux_up` metric is missing
+for all expected permutations of the `service` and `check` labels across different environments.
+
 ### SLO Alerts
 
 SLO (Service Level Objective) alert rules are rules defined to monitor and alert 

--- a/rhobs/alerting/data_plane/prometheus.availability_metric_grafana_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.availability_metric_grafana_alerts.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-konflux-up-grafana-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: konflux_up_grafana_alerts
+    interval: 1m
+    rules:
+    - alert: KonfluxUpGrafanaAlert
+      expr: absent(konflux_up{service="grafana", check="prometheus-appstudio-ds"}) == 1
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: Availability metric 'konflux_up' is missing.
+        description: >-
+          Availability metric 'konflux_up' is missing for check {{ $labels.check }}
+          on service {{ $labels.service }} for more than 5 minutes.
+        alert_routing_key: 'appstudio-grafana'

--- a/rhobs/alerting/data_plane/prometheus.availability_metric_has_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.availability_metric_has_alerts.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-konflux-up-has-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: konflux_up_has_alerts
+    interval: 1m
+    rules:
+    - alert: KonfluxUpHasAlert
+      expr: absent(konflux_up{service="has", check="github"}) == 1
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: Availability metric 'konflux_up' is missing.
+        description: >-
+          Availability metric 'konflux_up' is missing for check {{ $labels.check }}
+          on service {{ $labels.service }} for more than 5 minutes.
+        alert_routing_key: 'appstudio-grafana'

--- a/rhobs/alerting/data_plane/prometheus.availability_metric_remotesecret_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.availability_metric_remotesecret_alerts.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-konflux-up-remote-secret-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: konflux_up_remote_secret_alerts
+    interval: 1m
+    rules:
+    - alert: KonfluxUpRemoteSecretAlert
+      expr: absent(konflux_up{service="remote-secret-controller-manager-metrics-service", check="secretstorage"}) == 1
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: Availability metric 'konflux_up' is missing.
+        description: >-
+          Availability metric 'konflux_up' is missing for check {{ $labels.check }}
+          on service {{ $labels.service }} for more than 5 minutes.
+        alert_routing_key: 'appstudio-grafana'

--- a/test/promql/tests/data_plane/availability_metric_grafana_test.yaml
+++ b/test/promql/tests/data_plane/availability_metric_grafana_test.yaml
@@ -1,0 +1,36 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.availability_metric_grafana_alerts.yaml
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds"}'
+        values: '1x15'
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: KonfluxUpGrafanaAlert
+
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="has", check="github"}'
+        values: '_x15'
+
+    alert_rule_test:
+
+      - eval_time: 15m
+        alertname: KonfluxUpGrafanaAlert
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              check: prometheus-appstudio-ds
+              service: grafana
+            exp_annotations:
+              summary: >-
+                Availability metric 'konflux_up' is missing.
+              description: >-
+                Availability metric 'konflux_up' is missing for check prometheus-appstudio-ds
+                on service grafana for more than 5 minutes.
+              alert_routing_key: 'appstudio-grafana'

--- a/test/promql/tests/data_plane/availability_metric_has_test.yaml
+++ b/test/promql/tests/data_plane/availability_metric_has_test.yaml
@@ -1,0 +1,37 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.availability_metric_has_alerts.yaml
+
+tests:
+
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="has", check="github"}'
+        values: '0x15'
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: KonfluxUpHasAlert
+
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds"}'
+        values: '1x15'
+
+    alert_rule_test:
+
+      - eval_time: 15m
+        alertname: KonfluxUpHasAlert
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              check: github
+              service: has
+            exp_annotations:
+              summary: >-
+                Availability metric 'konflux_up' is missing.
+              description: >-
+                Availability metric 'konflux_up' is missing for check github
+                on service has for more than 5 minutes.
+              alert_routing_key: 'appstudio-grafana'

--- a/test/promql/tests/data_plane/availability_metric_remote_secret_test.yaml
+++ b/test/promql/tests/data_plane/availability_metric_remote_secret_test.yaml
@@ -1,0 +1,36 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.availability_metric_remotesecret_alerts.yaml
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="remote-secret-controller-manager-metrics-service", check="secretstorage"}'
+        values: '1x15'
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: KonfluxUpRemoteSecretAlert
+
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="has", check="github"}'
+        values: '_x15'
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: KonfluxUpRemoteSecretAlert
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              check: secretstorage
+              service: remote-secret-controller-manager-metrics-service
+            exp_annotations:
+              summary: >-
+                Availability metric 'konflux_up' is missing.
+              description: >-
+                Availability metric 'konflux_up' is missing for check secretstorage
+                on service remote-secret-controller-manager-metrics-service for
+                more than 5 minutes.
+              alert_routing_key: 'appstudio-grafana'


### PR DESCRIPTION
Added alerting rule and related promql unit tests
for konflux_up metric.

Jira-Url:https://issues.redhat.com/browse/RHTAPWATCH-890