### PR TITLE
Build-service availability mertic rules

### DIFF
--- a/rhobs/recording/build_service_availability_recording_rules.yaml
+++ b/rhobs/recording/build_service_availability_recording_rules.yaml
@@ -1,0 +1,15 @@
+# Metric format needed
+# redhat_appstudio_buildservice_global_github_app_available(service="build-service-controller-manager-metrics-service") -> konflux_up(service="build-service-controller-manager-metrics-service", check="github")
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-build-service-availability
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: build_service_github_availability
+      interval: 1m
+      rules:
+        - record: konflux_up
+          expr: label_replace(redhat_appstudio_buildservice_global_github_app_available, "check", "github", "","")

--- a/rhobs/recording/image_controller_availability_recording_rules.yaml
+++ b/rhobs/recording/image_controller_availability_recording_rules.yaml
@@ -1,0 +1,15 @@
+# Metric format needed
+# redhat_appstudio_imagecontroller_global_quay_app_available(service="image-controller-controller-manager-metrics-service") -> konflux_up(service="image-controller-controller-manager-metrics-service", check="quay")
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-image-controller-availability
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: image_controller_quay_availability
+      interval: 1m
+      rules:
+        - record: konflux_up
+          expr: label_replace(redhat_appstudio_imagecontroller_global_quay_app_available, "check", "quay", "","")

--- a/test/promql/tests/recording/build_service_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/build_service_availability_recording_rules_test.yaml
@@ -1,0 +1,25 @@
+evaluation_interval: 1m
+
+rule_files:
+  - build_service_availability_recording_rules.yaml
+
+tests:
+  - interval: 1m
+    name: RSExporterTest
+    input_series:
+      - series: "redhat_appstudio_buildservice_global_github_app_available{service='build-service-controller-manager-metrics-service'}"
+        values: "1 1 1 1 1"
+      - series: "redhat_appstudio_buildservice_global_github_app_available{service='build-service-controller-manager-metrics-service1'}"
+        values: "0 0 0 0 0"
+      - series: "redhat_appstudio_buildservice_global_github_app_available{service='build-service-controller-manager-metrics-service2'}"
+        values: "0 1 0 1 0"
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{service='build-service-controller-manager-metrics-service', check='github'}
+            value: 1
+          - labels: konflux_up{service='build-service-controller-manager-metrics-service1', check='github'}
+            value: 0
+          - labels: konflux_up{service='build-service-controller-manager-metrics-service2', check='github'}
+            value: 0

--- a/test/promql/tests/recording/image_controller_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/image_controller_availability_recording_rules_test.yaml
@@ -1,0 +1,25 @@
+evaluation_interval: 1m
+
+rule_files:
+  - image_controller_availability_recording_rules.yaml
+
+tests:
+  - interval: 1m
+    name: RSExporterTest
+    input_series:
+      - series: "redhat_appstudio_imagecontroller_global_quay_app_available{service='image-controller-controller-manager-metrics-service'}"
+        values: "1 1 1 1 1"
+      - series: "redhat_appstudio_imagecontroller_global_quay_app_available{service='image-controller-controller-manager-metrics-service1'}"
+        values: "0 0 0 0 0"
+      - series: "redhat_appstudio_imagecontroller_global_quay_app_available{service='image-controller-controller-manager-metrics-service2'}"
+        values: "0 1 0 1 0"
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{service='image-controller-controller-manager-metrics-service', check='quay'}
+            value: 1
+          - labels: konflux_up{service='image-controller-controller-manager-metrics-service1', check='quay'}
+            value: 0
+          - labels: konflux_up{service='image-controller-controller-manager-metrics-service2', check='quay'}
+            value: 0


### PR DESCRIPTION
Transform existing `redhat_appstudio_buildservice_global_github_app_available` and `redhat_appstudio_imagecontroller_global_quay_app_available`  into
to the form `konflux_up(service="build-service-controller-manager-metrics-service", check="github")` and
`konflux_up(service="image-controller-controller-manager-metrics-service", check="quay")`
