### PR TITLE
chore(RHTAPWATCH-954): Alert rule to check konflux_up metric

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-konflux-up-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: konflux_up_alerts
+    interval: 1m
+    rules:
+    - alert: KonfluxAlert
+      expr: (konflux_up offset 1h) unless on(service, check, source_cluster) konflux_up
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: Availability metric 'konflux_up' is missing.
+        description: >-
+          Availability metric 'konflux_up' is missing some entries for check {{ $labels.check }}
+          on service {{ $labels.service }} and cluster {{ $labels.source_cluster }} when compared
+          to previous hour.
+        alert_routing_key: 'konflux-up'

--- a/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
+++ b/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
@@ -1,0 +1,50 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.availability_metric_konflux_alerts.yaml
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", source_cluster="stone-stg-rh01"}'
+        values: '1x59 _x61'
+      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", source_cluster="stone-stg-m01"}'
+        values: '1x120'
+
+    alert_rule_test:
+      - eval_time: 120m
+        alertname: KonfluxAlert
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              check: prometheus-appstudio-ds
+              service: grafana
+              source_cluster: stone-stg-rh01
+            exp_annotations:
+              summary: >-
+                Availability metric 'konflux_up' is missing.
+              description: >-
+                Availability metric 'konflux_up' is missing some entries for check
+                prometheus-appstudio-ds on service grafana and cluster stone-stg-rh01 when
+                compared to previous hour.
+              alert_routing_key: 'konflux-up'
+
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", source_cluster="stone-stg-rh01"}'
+        values: '1x30 _x90'
+
+    alert_rule_test:
+      - eval_time: 120m
+        alertname: KonfluxAlert
+
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", source_cluster="stone-stg-rh01", pod="grafana-pod1"}'
+        values: '_x59 1x61'
+      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", source_cluster="stone-stg-rh01", pod="grafana-pod2"}'
+        values: '1x59 _x61'
+
+    alert_rule_test:
+      - eval_time: 120m
+        alertname: KonfluxAlert


### PR DESCRIPTION
This alert rule checks if konflux_up metric is available over all the clusters

Jira-Url: https://issues.redhat.com/browse/RHTAPWATCH-954