### PR TITLE
fix(KFLUXBUGS-1248): adjust panel threshold to match query

### DIFF
--- a/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
+++ b/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
@@ -1280,7 +1280,7 @@ data:
               "showLineNumbers": false,
               "showMiniMap": false
             },
-            "content": "<h1><center>Less than 5% overhead</center></h1>",
+            "content": "<h1><center>95% of pipeline run duration excludes scheduling overhead</center></h1>",
             "mode": "html"
           },
           "pluginVersion": "9.3.8",
@@ -1325,12 +1325,12 @@ data:
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green",
+                    "color": "red",
                     "value": null
                   },
                   {
-                    "color": "red",
-                    "value": 5
+                    "color": "green",
+                    "value": 95
                   }
                 ]
               },
@@ -1394,7 +1394,7 @@ data:
               "showLineNumbers": false,
               "showMiniMap": false
             },
-            "content": "<h1><center>Less than 5% overhead</center></h1>",
+            "content": "<h1><center>95% of pipeline run duration excludes execution overhead</center></h1>",
             "mode": "html"
           },
           "pluginVersion": "9.3.8",
@@ -1439,12 +1439,12 @@ data:
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green",
+                    "color": "red",
                     "value": null
                   },
                   {
-                    "color": "red",
-                    "value": 5
+                    "color": "green",
+                    "value": 95
                   }
                 ]
               },


### PR DESCRIPTION
since we went from <query> to "1 - <query>" we had to flip the threshold base and colors so that it is green if 95 or above and red if below 95

Signed-off-by: Gabe Montero <gmontero@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED