### PR TITLE
fix(KFLUXBUGS-1272): Broken URLs in slo-documents of Konflux services

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
@@ -46,6 +46,7 @@ spec:
         description: >-
           Release service is failing to successfully process within the period of one hour for 90% of releases
         alert_team_handle: <!subteam^S03SVBS426R>
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-processed-latency.md?ref_type=heads
         team: release
 
     - alert: ReleaseServicePreProcessingDurationSeconds
@@ -63,6 +64,7 @@ spec:
         description: >-
           Release service is failing to start processing under 10 seconds for 90% of releases
         alert_team_handle: <!subteam^S03SVBS426R>
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-processing-latency.md?ref_type=heads
         team: release
 
     - alert: ReleaseServiceValidationDurationSeconds
@@ -80,4 +82,5 @@ spec:
         description: >-
           Release service is failing to run the validations under 5 seconds for 90% of releases
         alert_team_handle: <!subteam^S03SVBS426R>
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-validation-latency.md?ref_type=heads
         team: release

--- a/test/promql/tests/data_plane/release_service_test.yaml
+++ b/test/promql/tests/data_plane/release_service_test.yaml
@@ -28,6 +28,7 @@ tests:
               description: >-
                 Release service is failing to successfully process within the period of one hour for 90% of releases
               alert_team_handle: <!subteam^S03SVBS426R>
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-processed-latency.md?ref_type=heads
               team: release
 
   - interval: 1m
@@ -54,6 +55,7 @@ tests:
               description: >-
                 Release service is failing to start processing under 10 seconds for 90% of releases
               alert_team_handle: <!subteam^S03SVBS426R>
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-processing-latency.md?ref_type=heads
               team: release
 
   - interval: 1m
@@ -80,4 +82,5 @@ tests:
               description: >-
                 Release service is failing to run the validations under 5 seconds for 90% of releases
               alert_team_handle: <!subteam^S03SVBS426R>
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-validation-latency.md?ref_type=heads
               team: release


### PR DESCRIPTION
- Add 'runbook_url' to Release service Prometheus urls