### PR TITLE
Use trusted artifacts

### DIFF
--- a/.tekton/kube-linter-oci-ta.yaml
+++ b/.tekton/kube-linter-oci-ta.yaml
@@ -1,0 +1,102 @@
+---
+# This Task is based on task/kube-linter/0.1/kube-linter.yaml from https://github.com/tektoncd/catalog.git
+# The main difference is that it relies on a Trusted Artifact, instead of a workspace, to provide
+# the code to be scanned.
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: kube-linter-oci-ta
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Code Quality
+    tekton.dev/tags: Kubernetes, Misconfiguration
+    tekton.dev/displayName: "Kube-Linter"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    This task makes it possible to use kube-linter within Tekton Pipeline.
+    The KubeLinter tool by StackRox is an open-source command-line interface to identify misconfigurations in Kubernetes objects.
+    KubeLinter offers the ability to integrate checks on Kubernetes YAML files and Helm charts before deployment into a Kubernetes cluster.
+    With 31 standard built-in checks and the room to configure your own, you get immediate feedback about misconfigurations and Kubernetes security violations.
+  params:
+    - description: The Trusted Artifact URI pointing to the artifact with the application source code.
+      name: SOURCE_ARTIFACT
+      type: string
+    - name: config_file_url
+      type: string
+      description: url from where the config file would be fetched.
+      default: ""
+    - name: config_file_path
+      type: string
+      description: path to config file.
+      default: ""
+    - name: manifest
+      type: string
+      description: path to manifest files or manifest directory to be checked.
+      default: "."
+    - name: includelist
+      type: string
+      description: "A string with comma separated checks to be included"
+      default: ""
+    - name: excludelist
+      type: string
+      description: "A string with comma separated checks to be excluded"
+      default: ""
+    - name: default_option
+      type: string
+      description: "provides two options (adding all built-in checks or disabling all default checks): add-all-built-in and/do-not-auto-add-defaults"
+      default: ""
+    - name: output_format
+      type: string
+      description: format in which report will be generated. (json|sarif|plain) (default:"json")
+      default: json
+    - name: args
+      type: array
+      description: "args"
+      default: []
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+    workingDir: /var/workdir/source
+  steps:
+    - image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:4e39fb97f4444c2946944482df47b39c5bbc195c54c6560b0647635f553ab23d
+      name: use-trusted-artifact
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+
+    - name: fetch-config-file
+      image: registry.access.redhat.com/ubi8/ubi-minimal:8.2
+      script: |
+         #!/usr/bin/env bash
+         set -e
+         if [ -n "$(params.config_file_url)" ]
+         then
+          curl "$(params.config_file_url)" --output "$(params.config_file_path)"
+          echo "Fetched the config file from given ($(params.config_file_url)) URL and successfully saved at /var/workdir/source/$(params.config_file_path)"
+         else
+          echo "No config file url was set"
+         fi
+    - name: lint-yaml
+      image: docker.io/stackrox/kube-linter:0.2.2-2-g7d10a69154-alpine@sha256:e520e9d8d3a2dfa611914836536545b135845e7bda9f1df34b060e116232dbf0
+      script: |
+        if [ -n "$(params.config_file_path)" ]
+        then
+          /kube-linter lint  "$(params.manifest)" --config "$(params.config_file_path)" --format "$(params.output_format)" "$@"
+        else
+          if [ -n "$(params.default_option)" ]
+          then
+            /kube-linter lint "$(params.manifest)" --"$(params.default_option)" --include "$(params.includelist)" --exclude "$(params.excludelist)" --format "$(params.output_format)" "$@"
+          else
+            /kube-linter lint "$(params.manifest)" --include "$(params.includelist)" --exclude "$(params.excludelist)" --format "$(params.output_format)" "$@"
+          fi
+        fi
+      args:
+      - $(params.args)
+
+  volumes:
+    - name: workdir
+      emptyDir: {}

--- a/.tekton/o11y-pull-request.yaml
+++ b/.tekton/o11y-pull-request.yaml
@@ -312,26 +312,42 @@ spec:
       params:
         - name: target-branch
           value: $(params.target-branch)
-      workspaces:
-        - name: workspace
-          workspace: workspace
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.clone-repository-oci-ta.results.SOURCE_ARTIFACT)
       runAfter:
-        - clone-repository
+        - clone-repository-oci-ta
       taskSpec:
         params:
           - name: target-branch
-        workspaces:
-          - name: workspace
+          - description: The Trusted Artifact URI pointing to the artifact with the application source code.
+            name: SOURCE_ARTIFACT
+            type: string
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          # This is needed because the steps below both write to git source but execute as
+          # different users by default.
+          securityContext:
+            runAsUser: 0
         steps:
+          - name: use-trusted-artifact
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:8391272c4e5011120e9e7fee2c1f339e9405366110bf239dadcbc21e953ce099
+            args:
+              - use
+              - $(params.SOURCE_ARTIFACT)=/var/workdir/source
           - name: run-gitlint
             image: registry.access.redhat.com/ubi9/python-39:latest
-            workingDir: $(workspaces.workspace.path)/source
+            workingDir: /var/workdir/source
             script: |
               #!/bin/bash -ex
               python -m pip install gitlint
               git config --global --add safe.directory '*'
               git fetch origin "$(params.target-branch)"
               gitlint --fail-without-commits --commits "origin/$(params.target-branch)..HEAD"
+        volumes:
+          - name: workdir
+            emptyDir: {}
     - name: run-kubelint
       runAfter:
       - clone-repository-oci-ta

--- a/.tekton/o11y-pull-request.yaml
+++ b/.tekton/o11y-pull-request.yaml
@@ -568,22 +568,10 @@ spec:
         values:
         - "false"
     workspaces:
-    - name: workspace
     - name: git-auth
       optional: true
   taskRunTemplate: {}
   workspaces:
-  - name: workspace
-    volumeClaimTemplate:
-      metadata:
-        creationTimestamp: null
-      spec:
-        accessModes:
-        - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
-      status: {}
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'

--- a/.tekton/o11y-pull-request.yaml
+++ b/.tekton/o11y-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main"
+    pipelinesascode.tekton.dev/task: "[.tekton/kube-linter-oci-ta.yaml]"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: o11y
@@ -305,22 +306,14 @@ spec:
               gitlint --fail-without-commits --commits "origin/$(params.target-branch)..HEAD"
     - name: run-kubelint
       runAfter:
-      - clone-repository
-      workspaces:
-      - name: source
-        workspace: workspace
+      - clone-repository-oci-ta
       taskRef:
-        resolver: git
-        params:
-        - name: url
-          value: https://github.com/tektoncd/catalog.git
-        - name: revision
-          value: 710c77d5c520d8dbce1e7e0055543415b57d6cb9
-        - name: pathInRepo
-          value: task/kube-linter/0.1/kube-linter.yaml
+        name: kube-linter-oci-ta
       params:
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository-oci-ta.results.SOURCE_ARTIFACT)
       - name: config_file_path
-        value: source/.kube-linter.yaml
+        value: .kube-linter.yaml
     - name: run-go-unit-tests
       workspaces:
         - name: workspace

--- a/.tekton/o11y-pull-request.yaml
+++ b/.tekton/o11y-pull-request.yaml
@@ -393,19 +393,33 @@ spec:
           - name: workdir
             emptyDir: {}
     - name: test-kustomize-build
-      workspaces:
-        - name: workspace
-          workspace: workspace
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.clone-repository-oci-ta.results.SOURCE_ARTIFACT)
       runAfter:
-        - clone-repository
+        - clone-repository-oci-ta
       taskSpec:
-        workspaces:
-          - name: workspace
+        params:
+          - description: The Trusted Artifact URI pointing to the artifact with the application source code.
+            name: SOURCE_ARTIFACT
+            type: string
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
         steps:
+          - name: use-trusted-artifact
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:8391272c4e5011120e9e7fee2c1f339e9405366110bf239dadcbc21e953ce099
+            args:
+              - use
+              - $(params.SOURCE_ARTIFACT)=/var/workdir/source
           - name: kustomize-build
             image: registry.access.redhat.com/ubi8/ubi:latest
-            workingDir: $(workspaces.workspace.path)/source
+            workingDir: /var/workdir/source
             script: yum install -y make && make kustomize-build
+        volumes:
+          - name: workdir
+            emptyDir: {}
     - name: build-container
       params:
       - name: IMAGE

--- a/.tekton/o11y-pull-request.yaml
+++ b/.tekton/o11y-pull-request.yaml
@@ -173,35 +173,6 @@ spec:
         value: $(params.git-url)
       - name: revision
         value: $(params.revision)
-      - name: depth
-        value: 20
-      runAfter:
-      - init
-      taskRef:
-        params:
-        - name: name
-          value: git-clone
-        - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:a5fd411406ea3614c583aa57cf4bb4b2d7f024ac98c7fb966343ede3790d64e6
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(tasks.init.results.build)
-        operator: in
-        values:
-        - "true"
-      workspaces:
-      - name: output
-        workspace: workspace
-      - name: basic-auth
-        workspace: git-auth
-    - name: clone-repository-oci-ta
-      params:
-      - name: url
-        value: $(params.git-url)
-      - name: revision
-        value: $(params.revision)
       - name: ociStorage
         value: "$(params.output-image).git"
       - name: ociArtifactExpiresAfter
@@ -234,13 +205,13 @@ spec:
       - name: dev-package-managers
         value: $(params.prefetch-dev-package-managers-enabled)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository-oci-ta.results.SOURCE_ARTIFACT)
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
       - name: ociStorage
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
       runAfter:
-      - clone-repository-oci-ta
+      - clone-repository
       taskRef:
         params:
         - name: name
@@ -253,9 +224,9 @@ spec:
     - name: check-and-test-prometheus-rules
       params:
         - name: SOURCE_ARTIFACT
-          value: $(tasks.clone-repository-oci-ta.results.SOURCE_ARTIFACT)
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
       runAfter:
-        - clone-repository-oci-ta
+        - clone-repository
       taskSpec:
         params:
           - description: The Trusted Artifact URI pointing to the artifact with the application source code.
@@ -282,10 +253,10 @@ spec:
             emptyDir: {}
     - name: yaml-lint
       runAfter:
-        - clone-repository-oci-ta
+        - clone-repository
       params:
         - name: SOURCE_ARTIFACT
-          value: $(tasks.clone-repository-oci-ta.results.SOURCE_ARTIFACT)
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
       taskSpec:
         params:
           - description: The Trusted Artifact URI pointing to the artifact with the application source code.
@@ -313,9 +284,9 @@ spec:
         - name: target-branch
           value: $(params.target-branch)
         - name: SOURCE_ARTIFACT
-          value: $(tasks.clone-repository-oci-ta.results.SOURCE_ARTIFACT)
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
       runAfter:
-        - clone-repository-oci-ta
+        - clone-repository
       taskSpec:
         params:
           - name: target-branch
@@ -350,20 +321,20 @@ spec:
             emptyDir: {}
     - name: run-kubelint
       runAfter:
-      - clone-repository-oci-ta
+      - clone-repository
       taskRef:
         name: kube-linter-oci-ta
       params:
       - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository-oci-ta.results.SOURCE_ARTIFACT)
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
       - name: config_file_path
         value: .kube-linter.yaml
     - name: run-go-unit-tests
       params:
         - name: SOURCE_ARTIFACT
-          value: $(tasks.clone-repository-oci-ta.results.SOURCE_ARTIFACT)
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
       runAfter:
-        - clone-repository-oci-ta
+        - clone-repository
       taskSpec:
         params:
           - description: The Trusted Artifact URI pointing to the artifact with the application source code.
@@ -395,9 +366,9 @@ spec:
     - name: test-kustomize-build
       params:
         - name: SOURCE_ARTIFACT
-          value: $(tasks.clone-repository-oci-ta.results.SOURCE_ARTIFACT)
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
       runAfter:
-        - clone-repository-oci-ta
+        - clone-repository
       taskSpec:
         params:
           - description: The Trusted Artifact URI pointing to the artifact with the application source code.

--- a/.tekton/o11y-pull-request.yaml
+++ b/.tekton/o11y-pull-request.yaml
@@ -359,21 +359,39 @@ spec:
       - name: config_file_path
         value: .kube-linter.yaml
     - name: run-go-unit-tests
-      workspaces:
-        - name: workspace
-          workspace: workspace
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.clone-repository-oci-ta.results.SOURCE_ARTIFACT)
       runAfter:
-        - clone-repository
+        - clone-repository-oci-ta
       taskSpec:
-        workspaces:
-          - name: workspace
+        params:
+          - description: The Trusted Artifact URI pointing to the artifact with the application source code.
+            name: SOURCE_ARTIFACT
+            type: string
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          # This is needed because the steps below both write to git source but execute as
+          # different users by default.
+          securityContext:
+            runAsUser: 0
         steps:
+          - name: use-trusted-artifact
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:8391272c4e5011120e9e7fee2c1f339e9405366110bf239dadcbc21e953ce099
+            args:
+              - use
+              - $(params.SOURCE_ARTIFACT)=/var/workdir/source
           - name: go-unit-tests
             image: registry.access.redhat.com/ubi9/go-toolset:1.21.11-2.1720624888
-            workingDir: $(workspaces.workspace.path)/source
+            workingDir: /var/workdir/source
             script: |
               go get -v -t -d ./...
               go test -v ./...
+        volumes:
+          - name: workdir
+            emptyDir: {}
     - name: test-kustomize-build
       workspaces:
         - name: workspace

--- a/.tekton/o11y-pull-request.yaml
+++ b/.tekton/o11y-pull-request.yaml
@@ -251,21 +251,35 @@ spec:
           value: task
         resolver: bundles
     - name: check-and-test-prometheus-rules
-      workspaces:
-        - name: workspace
-          workspace: workspace
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.clone-repository-oci-ta.results.SOURCE_ARTIFACT)
       runAfter:
-        - clone-repository
+        - clone-repository-oci-ta
       taskSpec:
-        workspaces:
-          - name: workspace
+        params:
+          - description: The Trusted Artifact URI pointing to the artifact with the application source code.
+            name: SOURCE_ARTIFACT
+            type: string
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
         steps:
+          - name: use-trusted-artifact
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:8391272c4e5011120e9e7fee2c1f339e9405366110bf239dadcbc21e953ce099
+            args:
+              - use
+              - $(params.SOURCE_ARTIFACT)=/var/workdir/source
           - name: check-and-test-all
             image: quay.io/rhobs/obsctl-reloader-rules-checker:1.0.7
-            workingDir: $(workspaces.workspace.path)/source
+            workingDir: /var/workdir/source
             script: |
               yum install -y make && \
               CMD=obsctl-reloader-rules-checker make check-and-test
+        volumes:
+          - name: workdir
+            emptyDir: {}
     - name: yaml-lint
       workspaces:
         - name: workspace

--- a/.tekton/o11y-pull-request.yaml
+++ b/.tekton/o11y-pull-request.yaml
@@ -281,19 +281,33 @@ spec:
           - name: workdir
             emptyDir: {}
     - name: yaml-lint
-      workspaces:
-        - name: workspace
-          workspace: workspace
       runAfter:
-        - clone-repository
+        - clone-repository-oci-ta
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.clone-repository-oci-ta.results.SOURCE_ARTIFACT)
       taskSpec:
-        workspaces:
-          - name: workspace
+        params:
+          - description: The Trusted Artifact URI pointing to the artifact with the application source code.
+            name: SOURCE_ARTIFACT
+            type: string
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
         steps:
+          - name: use-trusted-artifact
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:8391272c4e5011120e9e7fee2c1f339e9405366110bf239dadcbc21e953ce099
+            args:
+              - use
+              - $(params.SOURCE_ARTIFACT)=/var/workdir/source
           - name: yaml-lint
             image: registry.access.redhat.com/ubi9/python-39:latest
-            workingDir: $(workspaces.workspace.path)/source
+            workingDir: /var/workdir/source
             script: make install_pipenv sync_pipenv lint_yamls
+        volumes:
+          - name: workdir
+            emptyDir: {}
     - name: run-gitlint
       params:
         - name: target-branch


### PR DESCRIPTION
This pull request changes the Tekton Pipelines to use Trusted Artifacts to share data between its Tasks. The main benefit is the assurance that the output of one Task is consumed by another Task without having been modified. This enables a more fine-grained validation by the Enterprise Contract. Not every Task in the Pipeline needs to be trusted, just the ones involved in building the image.

From the GitHub checks, you can see that the existing Enterprise Contract policy passes for the image built as part of this pull request. But that's not saying much because the policy currently exclude things like `trusted_task.trusted`.

I have verified that EC validation also passes for an even more restrictive policy:

```yaml
publicKey: |
  -----BEGIN PUBLIC KEY-----
  MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZP/0htjhVt2y0ohjgtIIgICOtQtA
  naYJRuLprwIv6FDhZ5yFjYUEtsmoNcW7rx2KM6FOXGsCX3BNc7qhHELT+g==
  -----END PUBLIC KEY-----
sources:
- config:
    exclude:
    - hermetic_build_task
    include:
    - '@redhat'
  data:
  - github.com/release-engineering/rhtap-ec-policy//data
  - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
  policy:
  - oci::quay.io/enterprise-contract/ec-release-policy:git-0539ec4@sha256:f407c22e76c46c5a7f669f92c87b6770c8ede5bc5036ef015566e4e95ec0053e
```

You can validate it locally with ec (assuming the policy above is saved as `policy.yaml`):
```yaml
$ ec validate image --image quay.io/redhat-user-workloads/rhtap-o11y-tenant/o11y/o11y@sha256:cba7c178c2aa98a9cc2b1bff8a892093da504b7db08c0b10db60f795231d9c84 --policy policy.yaml --ignore-rekor --output yaml
components:
- attestations:
  - predicateBuildType: tekton.dev/v1beta1/PipelineRun
    predicateType: https://slsa.dev/provenance/v0.2
    signatures:
    - keyid: SHA256:IhiN7gY+Z3uSSd7tmj6w5Zfhqafzdhm3DZjIvGc6iYY
      sig: MEYCIQCtHdjPGT4YpecUkIKqU+l1/wqF5+2o1K/cOB7sYAx9lQIhAKGdpXmAJ8d43x+J7Bv38zcuwW0IrfRyWMgLmtz25PK1
    type: https://in-toto.io/Statement/v0.1
  containerImage: quay.io/redhat-user-workloads/rhtap-o11y-tenant/o11y/o11y@sha256:cba7c178c2aa98a9cc2b1bff8a892093da504b7db08c0b10db60f795231d9c84
  name: Unnamed
  signatures:
  - keyid: ""
    sig: MEYCIQDYqd4/q3SbyZTp+2XMfEUwdsQmziZ6mjzDIu40EtwhwQIhANi3Q0a8wQOgswzsTUYPli0jeA27+CwIoStbFyZnn8Kc
  source: {}
  success: true
  warnings:
  - metadata:
      code: cve.deprecated_cve_result_name
    msg: CVE scan uses deprecated result name
  - metadata:
      code: cve.deprecated_unpatched_cve_result_name
    msg: CVE scan uses deprecated result name
  - metadata:
      code: slsa_source_correlated.source_code_reference_provided
    msg: Expected source code reference was not provided for verification
ec-version: v0.4.51
effective-time: "2024-05-30T13:48:22.9464321Z"
key: |
  -----BEGIN PUBLIC KEY-----
  MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZP/0htjhVt2y0ohjgtIIgICOtQtA
  naYJRuLprwIv6FDhZ5yFjYUEtsmoNcW7rx2KM6FOXGsCX3BNc7qhHELT+g==
  -----END PUBLIC KEY-----
policy:
  publicKey: |
    -----BEGIN PUBLIC KEY-----
    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZP/0htjhVt2y0ohjgtIIgICOtQtA
    naYJRuLprwIv6FDhZ5yFjYUEtsmoNcW7rx2KM6FOXGsCX3BNc7qhHELT+g==
    -----END PUBLIC KEY-----
  sources:
  - config:
      exclude:
      - hermetic_build_task
      include:
      - '@redhat'
    data:
    - github.com/release-engineering/rhtap-ec-policy//data
    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
    policy:
    - oci::quay.io/enterprise-contract/ec-release-policy:git-0539ec4@sha256:f407c22e76c46c5a7f669f92c87b6770c8ede5bc5036ef015566e4e95ec0053e
success: true
```

One negative aspect of using Trusted Artifacts is that Tasks must understand them. This means using a Task directly from the upstream Tekton catalog is likely not going in many cases. This was true for the kube-linter Task unfortunately. One thing to consider is bringing this Task to the build-definitions repo as it could benefit other teams as well, and we can ensure it meets the criteria of being a trusted Task.

NOTE: You can probably easily get this image to be built in hermetic mode, but I didn't want to add more to this already large PR.

NOTE: I took the liberty of updating the UBI image used in the Dockerfile because the previous one was failing the CVE scanner.