### PR TITLE
chore(build team SLOs) Correct Build Team SLO alerts

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.stability_image_repository_provision_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_image_repository_provision_alerts.yaml
@@ -13,12 +13,12 @@ spec:
       expr: |
         (
           (
-            increase(redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="+Inf"}[10m])
+            increase(redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="+Inf"}[20m])
             - ignoring(le)
-            increase(redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="300"}[10m])
+            increase(redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="300"}[20m])
           ) / ignoring(le)
-          increase(redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="+Inf"}[10m])
-        ) > 0.01
+          increase(redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="+Inf"}[20m])
+        ) > 0.2
       for: 1m
       labels:
         severity: critical
@@ -28,7 +28,7 @@ spec:
           Stability of image repository provision time exceeded
         description: >
           Time taken to provision image repository has been over
-          5 minutes for more than 1% of requests during the last 10 minutes on cluster
+          5 minutes for more than 20% of requests during the last 20 minutes on cluster
           {{ $labels.source_cluster }}
         alert_team_handle: <!subteam^S0500D143S8>
         team: build

--- a/rhobs/alerting/data_plane/prometheus.stability_simple_build_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.stability_simple_build_alerts.yaml
@@ -13,12 +13,12 @@ spec:
       expr: |
         (
           (
-            increase(redhat_appstudio_buildservice_simple_build_pipeline_creation_time_bucket{le="+Inf"}[10m])
+            increase(redhat_appstudio_buildservice_simple_build_pipeline_creation_time_bucket{le="+Inf"}[30m])
             - ignoring(le)
-            increase(redhat_appstudio_buildservice_simple_build_pipeline_creation_time_bucket{le="300"}[10m])
+            increase(redhat_appstudio_buildservice_simple_build_pipeline_creation_time_bucket{le="300"}[30m])
           ) / ignoring(le)
-          increase(redhat_appstudio_buildservice_simple_build_pipeline_creation_time_bucket{le="+Inf"}[10m])
-        ) > 0.01
+          increase(redhat_appstudio_buildservice_simple_build_pipeline_creation_time_bucket{le="+Inf"}[30m])
+        ) > 0.2
       for: 1m
       labels:
         severity: critical
@@ -28,7 +28,7 @@ spec:
           Stability of component simple build submission time exceeded
         description: >
           Time taken from simple build request till the build pipeline is submitted has been over
-          5 minutes for more than 1% of requests during the last 10 minutes on cluster
+          5 minutes for more than 20% of requests during the last 30 minutes on cluster
           {{ $labels.source_cluster }}
         alert_team_handle: <!subteam^S0500D143S8>
         team: build

--- a/test/promql/tests/data_plane/stability_image_repository_provision_test.yaml
+++ b/test/promql/tests/data_plane/stability_image_repository_provision_test.yaml
@@ -4,17 +4,17 @@ rule_files:
   - 'prometheus.stability_image_repository_provision_alerts.yaml'
 
 tests:
-  # Scenario where only one cluster cross the 1% threshold
+  # Scenario where only one cluster cross the 20% threshold
   # Alert triggered for one cluster
   - interval: 1m
     input_series:
-      # Simulating data from Cluster 1 (crosses the 1% threshold)
+      # Simulating data from Cluster 1 (crosses the 20% threshold)
       - series: 'redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="300", source_cluster="cluster01"}'
         values: '0+1x20'  # 1 requests took less than 300s
       - series: 'redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="+Inf", source_cluster="cluster01"}'
         values: '0+200x20'  # 200 total occurrences in cluster01
 
-      # Simulating data from Cluster 2 (does not cross the 1% threshold)
+      # Simulating data from Cluster 2 (does not cross the 20% threshold)
       - series: 'redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="300", source_cluster="cluster02"}'
         values: '0+199x20'  # 199 requests took less than 300s
       - series: 'redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="+Inf", source_cluster="cluster02"}'
@@ -32,23 +32,23 @@ tests:
               summary: Stability of image repository provision time exceeded
               description: >
                 Time taken to provision image repository has been over
-                5 minutes for more than 1% of requests during the last 10 minutes on cluster
+                5 minutes for more than 20% of requests during the last 20 minutes on cluster
                 cluster01
               alert_team_handle: <!subteam^S0500D143S8>
               team: build
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/image-controller/stability_image_repository_provision.md
 
-  # Scenario where both clusters cross the 1% threshold
+  # Scenario where both clusters cross the 20% threshold
   # Alert triggered for both clusters
   - interval: 1m
     input_series:
-      # Simulating data from Cluster 1 (crosses the 1% threshold)
+      # Simulating data from Cluster 1 (crosses the 20% threshold)
       - series: 'redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="300", source_cluster="cluster01"}'
         values: '0+1x20'  # 1 requests took less than 300s
       - series: 'redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="+Inf", source_cluster="cluster01"}'
         values: '0+200x20'  # 200 total occurrences in cluster01
 
-      # Simulating data from Cluster 2 (also crosses the 1% threshold)
+      # Simulating data from Cluster 2 (also crosses the 20% threshold)
       - series: 'redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="300", source_cluster="cluster02"}'
         values: '0+1x20'  # 1 requests took less than 300s
       - series: 'redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="+Inf", source_cluster="cluster02"}'
@@ -66,7 +66,7 @@ tests:
               summary: Stability of image repository provision time exceeded
               description: >
                 Time taken to provision image repository has been over
-                5 minutes for more than 1% of requests during the last 10 minutes on cluster
+                5 minutes for more than 20% of requests during the last 20 minutes on cluster
                 cluster01
               alert_team_handle: <!subteam^S0500D143S8>
               team: build
@@ -79,7 +79,7 @@ tests:
               summary: Stability of image repository provision time exceeded
               description: >
                 Time taken to provision image repository has been over
-                5 minutes for more than 1% of requests during the last 10 minutes on cluster
+                5 minutes for more than 20% of requests during the last 20 minutes on cluster
                 cluster02
               alert_team_handle: <!subteam^S0500D143S8>
               team: build
@@ -89,13 +89,13 @@ tests:
   # Alert not triggered
   - interval: 1m
     input_series:
-      # Simulating data from Cluster 1 (does not cross the 1% threshold)
+      # Simulating data from Cluster 1 (does not cross the 20% threshold)
       - series: 'redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="300", source_cluster="cluster01"}'
         values: '0+199x20'  # 199 requests took less than 300s
       - series: 'redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="+Inf", source_cluster="cluster01"}'
         values: '0+200x20'  # 200 total occurrences in cluster01
 
-      # Simulating data from Cluster 2 (does not cross the 1% threshold)
+      # Simulating data from Cluster 2 (does not cross the 20% threshold)
       - series: 'redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="300", source_cluster="cluster02"}'
         values: '0+199x20'  # 199 requests took less than 300s
       - series: 'redhat_appstudio_imagecontroller_image_repository_provision_time_bucket{le="+Inf", source_cluster="cluster02"}'

--- a/test/promql/tests/data_plane/stability_simple_build_test.yaml
+++ b/test/promql/tests/data_plane/stability_simple_build_test.yaml
@@ -4,17 +4,17 @@ rule_files:
   - 'prometheus.stability_simple_build_alerts.yaml'
 
 tests:
-  # Scenario where only one cluster cross the 1% threshold
+  # Scenario where only one cluster cross the 20% threshold
   # Alert triggered for one cluster
   - interval: 1m
     input_series:
-      # Simulating data from Cluster 1 (crosses the 1% threshold)
+      # Simulating data from Cluster 1 (crosses the 20% threshold)
       - series: 'redhat_appstudio_buildservice_simple_build_pipeline_creation_time_bucket{le="300", source_cluster="cluster01"}'
         values: '0+1x20'  # 1 requests took less than 300s
       - series: 'redhat_appstudio_buildservice_simple_build_pipeline_creation_time_bucket{le="+Inf", source_cluster="cluster01"}'
         values: '0+200x20'  # 200 total occurrences in cluster01
 
-      # Simulating data from Cluster 2 (does not cross the 1% threshold)
+      # Simulating data from Cluster 2 (does not cross the 20% threshold)
       - series: 'redhat_appstudio_buildservice_simple_build_pipeline_creation_time_bucket{le="300", source_cluster="cluster02"}'
         values: '0+199x20'  # 199 requests took less than 300s
       - series: 'redhat_appstudio_buildservice_simple_build_pipeline_creation_time_bucket{le="+Inf", source_cluster="cluster02"}'
@@ -32,13 +32,13 @@ tests:
               summary: Stability of component simple build submission time exceeded
               description: >
                 Time taken from simple build request till the build pipeline is submitted has been over
-                5 minutes for more than 1% of requests during the last 10 minutes on cluster
+                5 minutes for more than 20% of requests during the last 30 minutes on cluster
                 cluster01
               alert_team_handle: <!subteam^S0500D143S8>
               team: build
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/build-service/stability_simple_build.md
 
-  # Scenario where both clusters cross the 1% threshold
+  # Scenario where both clusters cross the 20% threshold
   # Alert triggered for both clusters
   - interval: 1m
     input_series:
@@ -66,7 +66,7 @@ tests:
               summary: Stability of component simple build submission time exceeded
               description: >
                 Time taken from simple build request till the build pipeline is submitted has been over
-                5 minutes for more than 1% of requests during the last 10 minutes on cluster
+                5 minutes for more than 20% of requests during the last 30 minutes on cluster
                 cluster01
               alert_team_handle: <!subteam^S0500D143S8>
               team: build
@@ -79,23 +79,23 @@ tests:
               summary: Stability of component simple build submission time exceeded
               description: >
                 Time taken from simple build request till the build pipeline is submitted has been over
-                5 minutes for more than 1% of requests during the last 10 minutes on cluster
+                5 minutes for more than 20% of requests during the last 30 minutes on cluster
                 cluster02
               alert_team_handle: <!subteam^S0500D143S8>
               team: build
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/build-service/stability_simple_build.md
 
-  # Scenario where neither cluster crosses the 1% threshold
+  # Scenario where neither cluster crosses the 20% threshold
   # Alert not triggered
   - interval: 1m
     input_series:
-      # Simulating data from Cluster 1 (does not cross the 1% threshold)
+      # Simulating data from Cluster 1 (does not cross the 20% threshold)
       - series: 'redhat_appstudio_buildservice_simple_build_pipeline_creation_time_bucket{le="300", source_cluster="cluster01"}'
         values: '0+199x20'  # 199 requests took less than 300s
       - series: 'redhat_appstudio_buildservice_simple_build_pipeline_creation_time_bucket{le="+Inf", source_cluster="cluster01"}'
         values: '0+200x20'  # 200 total occurrences in cluster01
 
-      # Simulating data from Cluster 2 (does not cross the 1% threshold)
+      # Simulating data from Cluster 2 (does not cross the 20% threshold)
       - series: 'redhat_appstudio_buildservice_simple_build_pipeline_creation_time_bucket{le="300", source_cluster="cluster02"}'
         values: '0+199x20'  # 199 requests took less than 300s
       - series: 'redhat_appstudio_buildservice_simple_build_pipeline_creation_time_bucket{le="+Inf", source_cluster="cluster02"}'


### PR DESCRIPTION
This PR changes the following SLO alerts:
- Build Service simple build: since simple builds are not often used, even one failure would trigger alert. Increasing thresholds to be less sensitive.
- Image Controller: sometimes Quay stability is not ideal and we shouldn't alert at the first failure. Increasing threshold to 20% since the operation is not often performed (the same for the time period).