### PR TITLE
feat(RELEASE-996): availability metrics for release-service

### DIFF
--- a/rhobs/recording/release_service_availability_recording_rules.yaml
+++ b/rhobs/recording/release_service_availability_recording_rules.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-release-service-availability
+  labels:
+    tenant: rhtap
+spec:
+
+  groups:
+    - name: release_service_general_availability
+      interval: 1m
+      rules:
+        - record: konflux_up
+          expr: |
+            label_replace(
+              avg(release_service_check_gauge) without(Name) OR
+              label_replace(
+                floor(sum(release_service_check_gauge) without(check) / count(release_service_check_gauge) without(check)),
+              "check", "release", "", ""),
+            "Name", "release_service_check_gauge", "", "")

--- a/test/promql/tests/recording/release_service_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/release_service_availability_recording_rules_test.yaml
@@ -1,0 +1,59 @@
+evaluation_interval: 1m
+
+rule_files:
+  - release_service_availability_recording_rules.yaml
+
+tests:
+  - interval: 1m
+    name: RSExporterGithubTest
+    input_series:
+      - series: "release_service_check_gauge{service='release-service-availability-monitor-service1', check='github'}"
+        values: "1 1 1 1 1"
+      - series: "release_service_check_gauge{service='release-service-availability-monitor-service2', check='github'}"
+        values: "0 0 0 0 0"
+      - series: "release_service_check_gauge{service='release-service-availability-monitor-service3', check='github'}"
+        values: "0 1 0 1 0"
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{Name='release_service_check_gauge', service='release-service-availability-monitor-service1', check='github'}
+            value: 1
+          - labels: konflux_up{Name='release_service_check_gauge', service='release-service-availability-monitor-service2', check='github'}
+            value: 0
+          - labels: konflux_up{Name='release_service_check_gauge', service='release-service-availability-monitor-service3', check='github'}
+            value: 0
+          # need to check release as well because we are forcing it to be present by default
+          - labels: konflux_up{Name='release_service_check_gauge', service='release-service-availability-monitor-service1', check='release'}
+            value: 1
+          - labels: konflux_up{Name='release_service_check_gauge', service='release-service-availability-monitor-service2', check='release'}
+            value: 0
+          - labels: konflux_up{Name='release_service_check_gauge', service='release-service-availability-monitor-service3', check='release'}
+            value: 0
+
+  - interval: 1m
+    name: RSExporterPyxisTest
+    input_series:
+      - series: "release_service_check_gauge{Name='release_service_check_gauge', service='release-service-availability-monitor-service1', check='pyxis'}"
+        values: "1 1 1 1 1"
+      - series: "release_service_check_gauge{Name='release_service_check_gauge', service='release-service-availability-monitor-service2', check='pyxis'}"
+        values: "0 0 0 0 0"
+      - series: "release_service_check_gauge{Name='release_service_check_gauge', service='release-service-availability-monitor-service3', check='pyxis'}"
+        values: "0 1 0 1 0"
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{Name='release_service_check_gauge', service='release-service-availability-monitor-service1', check='pyxis'}
+            value: 1
+          - labels: konflux_up{Name='release_service_check_gauge', service='release-service-availability-monitor-service2', check='pyxis'}
+            value: 0
+          - labels: konflux_up{Name='release_service_check_gauge', service='release-service-availability-monitor-service3', check='pyxis'}
+            value: 0
+          # need to check release as well because we are forcing it to be present by default
+          - labels: konflux_up{Name='release_service_check_gauge', service='release-service-availability-monitor-service1', check='release'}
+            value: 1
+          - labels: konflux_up{Name='release_service_check_gauge', service='release-service-availability-monitor-service2', check='release'}
+            value: 0
+          - labels: konflux_up{Name='release_service_check_gauge', service='release-service-availability-monitor-service3', check='release'}
+            value: 0


### PR DESCRIPTION
This commit adds availability record rules and tests for the release-service availability metrics.