### PR TITLE
WIP: SRVKP-4523: add alert for tekton-pipeline-controller crashlooping

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -47,3 +47,18 @@ spec:
             alert_team_handle: <!subteam^S03GF42RBE2>
             team: pipelines
             runbook_url: TBD
+        - alert: CorePipelineControllerCrashloop
+          expr: |
+            sum(kube_pod_container_status_restarts_total{namespace="openshift-pipelines", pod=~"tekton-pipelines-controller-.*"}) - sum(kube_pod_container_status_restarts_total{namespace="openshift-pipelines", pod=~"tekton-pipelines-controller-.*"} offset 2m) > 0
+          for: 5m
+          labels:
+            severity: critical
+            slo: "true"
+          annotations:
+            summary: >-
+              Tekton controller is crashlooping
+            description: >-
+              Tekton controller on cluster {{ $labels.source_cluster }} has restarted {{ $value }} the past 5 minutes.
+            alert_team_handle: <!subteam^S03GF42RBE2>
+            team: pipelines
+            runbook_url: TBD


### PR DESCRIPTION
I don't have the tests and panels yet (panels will look close to what I have for the pipeline service dashboard at https://github.com/openshift-pipelines/pipeline-service/pull/1020/files#diff-13716f85d071b7d6b050dd4f5d738d85f4627f17f20ee8b68fd8f39084c72ce9R229-R292 ) but I wanted to get the alert query up for some early feedback in https://issues.redhat.com/browse/KONFLUX-3579 

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED