### PR TITLE
chore(SRVKP-4532): factor k8s throttling into task alert

### DIFF
--- a/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
+++ b/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
@@ -840,6 +840,474 @@ data:
           "type": "stat"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of validated PipelineRuns not yet processed by the PipelineRun Controller.",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 54
+          },
+          "id": 106,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The number of validated PipelineRuns not yet processed by the PipelineRun Controller.</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Pending PipelineRuns",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of validated PipelineRuns not yet processed by the PipelineRun Controller.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 54
+          },
+          "id": 108,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(pipelinerun_kickoff_not_attempted_count[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Pending PipelineRuns",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of validated TaskRuns not yet processed by the TaskRun Controller.",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 61
+          },
+          "id": 107,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The number of validated TaskRuns not yet processed by the TaskRun Controller.</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Pending TaskRuns",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of validated TaskRuns not yet processed by the TaskRuns Controller.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 61
+          },
+          "id": 109,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(taskrun_pod_create_not_attempted_or_pending_count[$__range])) - sum(increase(tekton_pipelines_controller_running_taskruns_throttled_by_quota[$__range])) - sum(increase(tekton_pipelines_controller_running_taskruns_throttled_by_node[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Pending TaskRuns",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of validated TaskRuns whose Pods are throttled by Kubernetes quota",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 68
+          },
+          "id": 110,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The number of validated TaskRuns whose Pods are throttled by Kubernetes quota.</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "TaskRuns throttled by quota",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of validated TaskRuns whose Pods are throttled by Kubernetes quota.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 68
+          },
+          "id": 113,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(tekton_pipelines_controller_running_taskruns_throttled_by_quota[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "TaskRuns throttled by quota",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of validated TaskRuns whose Pods are throttled by Kubernetes node demand.",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 75
+          },
+          "id": 112,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The number of validated TaskRuns whose Pods are throttled by Kubernetes node demand.</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "TaskRuns throttled by node",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of validated TaskRuns whose Pods are throttled by Kubernetes node demand.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 75
+          },
+          "id": 111,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(tekton_pipelines_controller_running_taskruns_throttled_by_node[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "TaskRuns throttled by node",
+          "type": "stat"
+        },
+        {
           "collapsed": false,
           "gridPos": {
             "h": 1,

--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -79,7 +79,7 @@ spec:
             runbook_url: TBD
         - alert: TaskControllerDeadlock
           expr: |
-            sum by (source_cluster) (increase(taskrun_pod_create_not_attempted_or_pending_count[2m])) > 0
+            sum by (source_cluster) (increase(taskrun_pod_create_not_attempted_or_pending_count[2m])) - sum by (source_cluster) (increase(tekton_pipelines_controller_running_taskruns_throttled_by_quota[2m])) - sum by (source_cluster) (increase(tekton_pipelines_controller_running_taskruns_throttled_by_node[2m]))> 0
           for: 75m
           labels:
             severity: critical

--- a/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
@@ -121,6 +121,10 @@ tests:
         values: '1+1x780'
       - series: 'taskrun_pod_create_not_attempted_or_pending_count{namespace="tenant-2", source_cluster="cluster01"}'
         values: '0x780'
+      - series: 'tekton_pipelines_controller_running_taskruns_throttled_by_quota{namespace="tenant-1", source_cluster="cluster01"}'
+        values: '0x780'
+      - series: 'tekton_pipelines_controller_running_taskruns_throttled_by_node{namespace="tenant-1", source_cluster="cluster01"}'
+        values: '0x780'
 
     alert_rule_test:
       - eval_time: 85m
@@ -138,6 +142,57 @@ tests:
               alert_team_handle: <!subteam^S03GF42RBE2>
               team: pipelines
               runbook_url: TBD
+  - interval: 1m
+    input_series:
+
+      # see https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/ for explanations of the expanding notation used for the values
+      # tekton taskrun controller is experiencing delays getting the k8s approved pods for taskruns in tenant-1 started and should alert.  Also make sure the lack
+      # of pod issues in tenant-2 does not affect the value of the query
+      - series: 'taskrun_pod_create_not_attempted_or_pending_count{namespace="tenant-1", source_cluster="cluster01"}'
+        values: '1+2x780'
+      - series: 'taskrun_pod_create_not_attempted_or_pending_count{namespace="tenant-2", source_cluster="cluster01"}'
+        values: '0x780'
+      - series: 'tekton_pipelines_controller_running_taskruns_throttled_by_quota{namespace="tenant-1", source_cluster="cluster01"}'
+        values: '1+1x780'
+      - series: 'tekton_pipelines_controller_running_taskruns_throttled_by_node{namespace="tenant-1", source_cluster="cluster01"}'
+        values: '0x780'
+
+    alert_rule_test:
+      - eval_time: 85m
+        alertname: TaskControllerDeadlock
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo: "true"
+              source_cluster: cluster01
+            exp_annotations:
+              summary: >-
+                Tekton taskrun controller appears to have stopped processing active taskruns whose underlying Pod have not failed Kubernetes screening.
+              description: >-
+                Tekton taskrun controller on cluster cluster01 has appeared deadlocked on 2 taskruns.
+              alert_team_handle: <!subteam^S03GF42RBE2>
+              team: pipelines
+              runbook_url: TBD
+
+
+  - interval: 1m
+    input_series:
+
+      # see https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/ for explanations of the expanding notation used for the values
+      # tekton taskrun controller is experiencing delays getting the k8s approved pods for taskruns in tenant-1, but only
+      # from k8s throttling so no alert fires.
+      - series: 'taskrun_pod_create_not_attempted_or_pending_count{namespace="tenant-1", source_cluster="cluster01"}'
+        values: '1+1x780'
+      - series: 'taskrun_pod_create_not_attempted_or_pending_count{namespace="tenant-2", source_cluster="cluster01"}'
+        values: '0x780'
+      - series: 'tekton_pipelines_controller_running_taskruns_throttled_by_quota{namespace="tenant-1", source_cluster="cluster01"}'
+        values: '1+1x780'
+      - series: 'tekton_pipelines_controller_running_taskruns_throttled_by_node{namespace="tenant-1", source_cluster="cluster01"}'
+        values: '1+1x780'
+
+    alert_rule_test:
+      - eval_time: 85m
+        alertname: TaskControllerDeadlock
 
   - interval: 1m
     input_series:


### PR DESCRIPTION
Factor k8s quota and node throttling into task controller deadlock alert. Correlation often exists given the one to one coupling between pods and TaskRuns.

Signed-off-by: Gabe Montero <gmontero@redhat.com>

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED