### PR TITLE
chore: change pipeline related slack handle in alerts

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -25,7 +25,7 @@ spec:
             description: >-
               Tekton controller on cluster {{ $labels.source_cluster }} factoring out the time needed to receive PipelineRun creation
               events from the overall PipelineRun execution time is at {{ $value | humanizePercentage }} instead of 95% or greater.
-            alert_team_handle: <!subteam^S03GF42RBE2>
+            alert_team_handle: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: TBD
         - alert: HighExecutionOverhead
@@ -44,7 +44,7 @@ spec:
             description: >-
               Tekton controller on cluster {{ $labels.source_cluster }} factoring out the time needed to create
               underlying TaskRuns from the overall PipelineRun execution time is at {{ $value | humanizePercentage }} instead of 95% or greater.
-            alert_team_handle: <!subteam^S03GF42RBE2>
+            alert_team_handle: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: TBD
         - alert: CorePipelineControllerRepeatedRestarts
@@ -59,7 +59,7 @@ spec:
               Tekton controller is rapidly restarting.
             description: >-
               Tekton controller on cluster {{ $labels.source_cluster }} has restarted {{ $value }} times recently.
-            alert_team_handle: <!subteam^S03GF42RBE2>
+            alert_team_handle: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: TBD
         - alert: PipelineControllerDeadlock
@@ -74,7 +74,7 @@ spec:
               Tekton pipeline controller appears to have stopped processing active pipelineruns which have not been started yet.
             description: >-
               Tekton pipeline controller on cluster {{ $labels.source_cluster }} has appeared deadlocked on {{ $value }} pipelineruns.
-            alert_team_handle: <!subteam^S03GF42RBE2>
+            alert_team_handle: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: TBD
         - alert: TaskControllerDeadlock
@@ -89,6 +89,6 @@ spec:
               Tekton taskrun controller appears to have stopped processing active taskruns whose underlying Pod have not failed Kubernetes screening.
             description: >-
               Tekton taskrun controller on cluster {{ $labels.source_cluster }} has appeared deadlocked on {{ $value }} taskruns.
-            alert_team_handle: <!subteam^S03GF42RBE2>
+            alert_team_handle: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: TBD

--- a/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
@@ -29,7 +29,7 @@ tests:
                 Tekton controller is rapidly restarting.
               description: >-
                 Tekton controller on cluster cluster01 has restarted 5 times recently.
-              alert_team_handle: <!subteam^S03GF42RBE2>
+              alert_team_handle: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: TBD
 
@@ -82,7 +82,7 @@ tests:
                 Tekton pipeline controller appears to have stopped processing active pipelineruns which have not been started yet.
               description: >-
                 Tekton pipeline controller on cluster cluster01 has appeared deadlocked on 2 pipelineruns.
-              alert_team_handle: <!subteam^S03GF42RBE2>
+              alert_team_handle: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: TBD
 
@@ -139,7 +139,7 @@ tests:
                 Tekton taskrun controller appears to have stopped processing active taskruns whose underlying Pod have not failed Kubernetes screening.
               description: >-
                 Tekton taskrun controller on cluster cluster01 has appeared deadlocked on 2 taskruns.
-              alert_team_handle: <!subteam^S03GF42RBE2>
+              alert_team_handle: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: TBD
   - interval: 1m
@@ -170,7 +170,7 @@ tests:
                 Tekton taskrun controller appears to have stopped processing active taskruns whose underlying Pod have not failed Kubernetes screening.
               description: >-
                 Tekton taskrun controller on cluster cluster01 has appeared deadlocked on 2 taskruns.
-              alert_team_handle: <!subteam^S03GF42RBE2>
+              alert_team_handle: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: TBD
 

--- a/test/promql/tests/data_plane/pipeline_overhead_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_overhead_test.yaml
@@ -37,7 +37,7 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 factoring out the time needed to receive PipelineRun creation
                 events from the overall PipelineRun execution time is at 0% instead of 95% or greater.
-              alert_team_handle: <!subteam^S03GF42RBE2>
+              alert_team_handle: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: TBD
 
@@ -73,7 +73,7 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 factoring out the time needed to receive PipelineRun creation
                 events from the overall PipelineRun execution time is at 50% instead of 95% or greater.
-              alert_team_handle: <!subteam^S03GF42RBE2>
+              alert_team_handle: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: TBD
 
@@ -132,7 +132,7 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 factoring out the time needed to create
                 underlying TaskRuns from the overall PipelineRun execution time is at 0% instead of 95% or greater.
-              alert_team_handle: <!subteam^S03GF42RBE2>
+              alert_team_handle: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: TBD
 
@@ -172,7 +172,7 @@ tests:
               description: >-
                 Tekton controller on cluster cluster01 factoring out the time needed to create
                 underlying TaskRuns from the overall PipelineRun execution time is at 94.74% instead of 95% or greater.
-              alert_team_handle: <!subteam^S03GF42RBE2>
+              alert_team_handle: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: TBD
 


### PR DESCRIPTION
`@plnsrvce-team` is getting deprecated/removed and the openshift-pipelines team want to now use `@pipelines-ic`

@enarha @savitaashture FYI

Signed-off-by: Gabe Montero <gmontero@redhat.com>

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED