### PR TITLE
chore(SRVKP-4532): expand tekton restart alert

### DIFF
--- a/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
+++ b/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
@@ -1261,7 +1261,7 @@ data:
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "The number of times the pipelines controller has restarted",
+          "description": "The number of times any of the tekton controllers have restarted",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1328,7 +1328,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"openshift-pipelines\", pod=~\"tekton-pipelines-controller-.*\"}[$__range]))",
+              "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"openshift-pipelines\", pod=~\"tekton-.*\"}[$__range]))",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,

--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -49,7 +49,7 @@ spec:
             runbook_url: TBD
         - alert: CorePipelineControllerRepeatedRestarts
           expr: |
-            sum by (source_cluster) (increase(kube_pod_container_status_restarts_total{namespace="openshift-pipelines", pod=~"tekton-pipelines-controller-.*"}[5m])) > 0
+            sum by (source_cluster) (increase(kube_pod_container_status_restarts_total{namespace="openshift-pipelines", pod=~"tekton-.*"}[5m])) > 0
           for: 5m
           labels:
             severity: critical
@@ -58,7 +58,7 @@ spec:
             summary: >-
               Tekton controller is rapidly restarting.
             description: >-
-              Tekton controller on cluster {{ $labels.source_cluster }} has restarted {{ $value }} times recently.
+              Tekton controllers on cluster {{ $labels.source_cluster }} have restarted {{ $value }} times recently.
             alert_team_handle: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: TBD

--- a/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
@@ -28,7 +28,7 @@ tests:
               summary: >-
                 Tekton controller is rapidly restarting.
               description: >-
-                Tekton controller on cluster cluster01 has restarted 5 times recently.
+                Tekton controllers on cluster cluster01 have restarted 15 times recently.
               alert_team_handle: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: TBD


### PR DESCRIPTION
Signed-off-by: Gabe Montero <gmontero@redhat.com>

expanding the restart alert to handle all `tekton-` pods in `openshift-namespace` given the recent trouble with the remote-resolver deployment 

we'll handle PAC and Results (especially given the memory leak) separately

@amisstea PTAL

@gbenhaim @zanssa @enarha  @divyansh42 @savitaashture FYI

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED