### PR TITLE
chore(SRVKP-4527): alert/panels chain deadlock/performance

### DIFF
--- a/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
+++ b/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
@@ -1686,6 +1686,240 @@ data:
                 ],
                 "title": "Deadlocked ResolutionRequests",
                 "type": "stat"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                },
+                "description": "The number of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller",
+                "gridPos": {
+                    "h": 7,
+                    "w": 10,
+                    "x": 0,
+                    "y": 91
+                },
+                "id": 112,
+                "options": {
+                    "code": {
+                        "language": "plaintext",
+                        "showLineNumbers": false,
+                        "showMiniMap": false
+                    },
+                    "content": "<h1><center>The number of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller</center></h1>",
+                    "mode": "html"
+                },
+                "pluginVersion": "10.4.1",
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "${datasource}"
+                        },
+                        "refId": "A"
+                    }
+                ],
+                "title": "Deadlocked Chains",
+                "type": "text"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                },
+                "description": "The number of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+                            {
+                                "options": {
+                                    "match": "null",
+                                    "result": {
+                                        "text": "N/A"
+                                    }
+                                },
+                                "type": "special"
+                            }
+                        ],
+                        "noValue": "No data",
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 50
+                                }
+                            ]
+                        },
+                        "unit": "none"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 7,
+                    "w": 5,
+                    "x": 10,
+                    "y": 91
+                },
+                "id": 113,
+                "maxDataPoints": 100,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "showPercentChange": false,
+                    "textMode": "auto",
+                    "wideLayout": true
+                },
+                "pluginVersion": "10.4.1",
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "${datasource}"
+                        },
+                        "editorMode": "code",
+                        "expr": "sum(increase(watcher_workqueue_depth{container='tekton-chains-controller',app='tekton-chains-controller'}[$__range]))",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true,
+                        "refId": "A"
+                    }
+                ],
+                "title": "Deadlocked Chains",
+                "type": "stat"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                },
+                "description": "The Kubernetes client latency of the  Tekton Chains Controller",
+                "gridPos": {
+                    "h": 7,
+                    "w": 10,
+                    "x": 0,
+                    "y": 98
+                },
+                "id": 114,
+                "options": {
+                    "code": {
+                        "language": "plaintext",
+                        "showLineNumbers": false,
+                        "showMiniMap": false
+                    },
+                    "content": "<h1><center>The Kubernetes client latency of the  Tekton Chains Controller</center></h1>",
+                    "mode": "html"
+                },
+                "pluginVersion": "10.4.1",
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "${datasource}"
+                        },
+                        "refId": "A"
+                    }
+                ],
+                "title": "Chains Performance",
+                "type": "text"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                },
+                "description": "The number of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+                            {
+                                "options": {
+                                    "match": "null",
+                                    "result": {
+                                        "text": "N/A"
+                                    }
+                                },
+                                "type": "special"
+                            }
+                        ],
+                        "noValue": "No data",
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 50
+                                }
+                            ]
+                        },
+                        "unit": "none"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 7,
+                    "w": 5,
+                    "x": 10,
+                    "y": 98
+                },
+                "id": 115,
+                "maxDataPoints": 100,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "showPercentChange": false,
+                    "textMode": "auto",
+                    "wideLayout": true
+                },
+                "pluginVersion": "10.4.1",
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "${datasource}"
+                        },
+                        "editorMode": "code",
+                        "expr": "sum(increase(watcher_client_latency_bucket{app='tekton-chains-controller',le='1'}[$__range])) / sum(increase(watcher_client_latency_bucket{app='tekton-chains-controller',le='+Inf'}[$__range]))",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true,
+                        "refId": "A"
+                    }
+                ],
+                "title": "Chains Performance",
+                "type": "stat"
             }
         ],
         "refresh": "1h",
@@ -1745,7 +1979,7 @@ data:
         "timezone": "",
         "title": "RHTAP SLOs",
         "uid": "rhtap-slos",
-        "version": 7,
+        "version": 8,
         "weekStart": ""
     }
 kind: ConfigMap

--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -107,3 +107,36 @@ spec:
             alert_team_handle: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: TBD
+        - alert: ChainsControllerDeadlock
+          expr: |
+            sum by (source_cluster) (increase(watcher_workqueue_depth{container='tekton-chains-controller',app='tekton-chains-controller'}[2m])) > 50
+          for: 75m
+          labels:
+            severity: critical
+            slo: "true"
+          annotations:
+            summary: >-
+              Tekton chains controller appears to have stopped processing active pipelineruns.
+            description: >-
+              Tekton chains controller on cluster {{ $labels.source_cluster }} has appeared deadlocked on {{ $value }} pipelinerun events.
+            alert_team_handle: <!subteam^S04PYECHCCU>
+            team: pipelines
+            runbook_url: TBD
+        - alert: ChainsControllerPerformance
+          expr: |
+            (sum by (source_cluster) (increase(watcher_client_latency_bucket{app='tekton-chains-controller',le='1'}[5m]))
+            /
+            sum by (source_cluster) (increase(watcher_client_latency_bucket{app='tekton-chains-controller',le='+Inf'}[5m])))
+            < 0.50
+          for: 75m
+          labels:
+            severity: critical
+            slo: "true"
+          annotations:
+            summary: >-
+              Tekton chains controller performance appears degraded with uncommonly high client latency.
+            description: >-
+              Tekton chains controller on cluster {{ $labels.source_cluster }} performance appears degraded with client latency {{ $value | humanizePercentage }}.
+            alert_team_handle: <!subteam^S04PYECHCCU>
+            team: pipelines
+            runbook_url: TBD

--- a/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
@@ -258,3 +258,90 @@ tests:
     alert_rule_test:
       - eval_time: 10m
         alertname: ResolverControllerDeadlock
+
+  # ----- Chains Controller Potential Deadlock Kicking ----
+  - interval: 1m
+    input_series:
+
+      # see https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/ for explanations of the expanding notation used for the values
+      # tekton chains controller is experiencing delays processing pipelineruns in tenant-1 started and should alert.  Also make sure the lack
+      # of issues in another app does not affect the value of the query
+      - series: 'watcher_workqueue_depth{container="tekton-chains-controller", app="tekton-chains-controller", source_cluster="cluster01"}'
+        values: '300+300x780'
+      - series: 'watcher_workqueue_depth{container="tekton-pipelines-controller", app="tekton-pipelines-controller", source_cluster="cluster01"}'
+        values: '0x780'
+
+    alert_rule_test:
+      - eval_time: 85m
+        alertname: ChainsControllerDeadlock
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo: "true"
+              source_cluster: cluster01
+            exp_annotations:
+              summary: >-
+                Tekton chains controller appears to have stopped processing active pipelineruns.
+              description: >-
+                Tekton chains controller on cluster cluster01 has appeared deadlocked on 600 pipelinerun events.
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: TBD
+
+  - interval: 1m
+    input_series:
+
+      # see https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/ for explanations of the expanding notation used for the values
+      # tekton chains controller is experiencing some delays processing pipelineruns but not fast enough so it should not alert
+      - series: 'watcher_workqueue_depth{container="tekton-chains-controller", app="tekton-chains-controller", source_cluster="cluster01"}'
+        values: '1x780'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ChainsControllerDeadlock
+
+  # ----- Chains Controller Potential Deadlock Kicking ----
+  - interval: 1m
+    input_series:
+
+      # see https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/ for explanations of the expanding notation used for the values
+      - series: 'watcher_client_latency_bucket{app="tekton-chains-controller", le="1", source_cluster="cluster01"}'
+        values: '300+300x780'
+      - series: 'watcher_client_latency_bucket{app="tekton-chains-controller", le="10", source_cluster="cluster01"}'
+        values: '300+300x780'
+      - series: 'watcher_client_latency_bucket{app="tekton-chains-controller", le="+Inf", source_cluster="cluster01"}'
+        values: '900+900x780'
+      - series: 'watcher_client_latency_bucket{app="tekton-pipelines-controller", le="1", source_cluster="cluster01"}'
+        values: '1x780'
+      - series: 'watcher_client_latency_bucket{app="tekton-pipelines-controller", le="+Inf", source_cluster="cluster01"}'
+        values: '1x780'
+
+    alert_rule_test:
+      - eval_time: 85m
+        alertname: ChainsControllerPerformance
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo: "true"
+              source_cluster: cluster01
+            exp_annotations:
+              summary: >-
+                Tekton chains controller performance appears degraded with uncommonly high client latency.
+              description: >-
+                Tekton chains controller on cluster cluster01 performance appears degraded with client latency 33.33%.
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: TBD
+
+  - interval: 1m
+    input_series:
+
+      # see https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/ for explanations of the expanding notation used for the values
+      - series: 'watcher_client_latency_bucket{app="tekton-chains-controller", le="1", source_cluster="cluster01"}'
+        values: '300+300x780'
+      - series: 'watcher_client_latency_bucket{app="tekton-chains-controller", le="+Inf", source_cluster="cluster01"}'
+        values: '400+400x780'
+
+    alert_rule_test:
+      - eval_time: 85m
+        alertname: ChainsControllerPerformance


### PR DESCRIPTION
These are the alerts, panels, and alert unit tests for determining if tekton chains controller is either deadlocked or experiencing abnormally poor performance.

Signed-off-by: Gabe Montero <gmontero@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED