### PR TITLE
fix(RELEASE-1031): remove release_processing_duration SLO

### DIFF
--- a/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
+++ b/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
@@ -28,7 +28,7 @@ data:
         "editable": true,
         "fiscalYearStartMonth": 0,
         "graphTooltip": 0,
-        "id": 920922,
+        "id": 931285,
         "links": [],
         "liveNow": false,
         "panels": [
@@ -662,128 +662,12 @@ data:
                 "type": "gauge"
             },
             {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Measure the time it takes for a successful Release to be marked as Processed.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 40
-                },
-                "id": 102,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>90% of the Releases should be processed within 1 hour</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Release Processing SLO",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Measure the time it takes for a Release to be marked as Processed.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "max": 1,
-                        "min": 0,
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "red",
-                                    "value": null
-                                },
-                                {
-                                    "color": "green",
-                                    "value": 90
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 40
-                },
-                "id": 103,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [
-                            "mean"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum by (job) (rate(release_processing_duration_seconds_bucket{le=\"3600\"}[$__rate_interval])) / sum by (job) (rate(release_processing_duration_seconds_count[$__rate_interval]) > 0)",
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Measured",
-                "type": "gauge"
-            },
-            {
                 "collapsed": true,
                 "gridPos": {
                     "h": 1,
                     "w": 24,
                     "x": 0,
-                    "y": 47
+                    "y": 40
                 },
                 "id": 33,
                 "panels": [
@@ -982,7 +866,7 @@ data:
                     "h": 1,
                     "w": 24,
                     "x": 0,
-                    "y": 48
+                    "y": 41
                 },
                 "id": 64,
                 "panels": [],
@@ -999,7 +883,7 @@ data:
                     "h": 7,
                     "w": 10,
                     "x": 0,
-                    "y": 49
+                    "y": 42
                 },
                 "id": 65,
                 "options": {
@@ -1070,7 +954,7 @@ data:
                     "h": 7,
                     "w": 5,
                     "x": 10,
-                    "y": 49
+                    "y": 42
                 },
                 "id": 68,
                 "maxDataPoints": 100,
@@ -1114,7 +998,7 @@ data:
                     "h": 7,
                     "w": 10,
                     "x": 0,
-                    "y": 56
+                    "y": 49
                 },
                 "id": 69,
                 "options": {
@@ -1185,7 +1069,7 @@ data:
                     "h": 7,
                     "w": 5,
                     "x": 10,
-                    "y": 56
+                    "y": 49
                 },
                 "id": 70,
                 "maxDataPoints": 100,
@@ -1229,7 +1113,7 @@ data:
                     "h": 7,
                     "w": 10,
                     "x": 0,
-                    "y": 63
+                    "y": 56
                 },
                 "id": 104,
                 "options": {
@@ -1298,7 +1182,7 @@ data:
                     "h": 7,
                     "w": 5,
                     "x": 10,
-                    "y": 63
+                    "y": 56
                 },
                 "id": 105,
                 "maxDataPoints": 100,
@@ -1346,7 +1230,7 @@ data:
                     "h": 7,
                     "w": 10,
                     "x": 0,
-                    "y": 70
+                    "y": 63
                 },
                 "id": 106,
                 "options": {
@@ -1415,7 +1299,7 @@ data:
                     "h": 7,
                     "w": 5,
                     "x": 10,
-                    "y": 70
+                    "y": 63
                 },
                 "id": 107,
                 "maxDataPoints": 100,
@@ -1463,7 +1347,7 @@ data:
                     "h": 7,
                     "w": 10,
                     "x": 0,
-                    "y": 77
+                    "y": 70
                 },
                 "id": 108,
                 "options": {
@@ -1532,7 +1416,7 @@ data:
                     "h": 7,
                     "w": 5,
                     "x": 10,
-                    "y": 77
+                    "y": 70
                 },
                 "id": 109,
                 "maxDataPoints": 100,
@@ -1580,7 +1464,7 @@ data:
                     "h": 7,
                     "w": 10,
                     "x": 0,
-                    "y": 84
+                    "y": 77
                 },
                 "id": 110,
                 "options": {
@@ -1649,7 +1533,7 @@ data:
                     "h": 7,
                     "w": 5,
                     "x": 10,
-                    "y": 84
+                    "y": 77
                 },
                 "id": 111,
                 "maxDataPoints": 100,
@@ -1745,7 +1629,7 @@ data:
         "timezone": "",
         "title": "RHTAP SLOs",
         "uid": "rhtap-slos",
-        "version": 7,
+        "version": 8,
         "weekStart": ""
     }
 kind: ConfigMap

--- a/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
@@ -10,13 +10,6 @@ spec:
     interval: 1m
 
     rules:
-    # record rules for `ReleaseServiceProcessingDuration`
-    - record: rate_of_release_processing_duration_seconds_shorter_than_1h_per_10m
-      expr: sum by (job) (rate(release_processing_duration_seconds_bucket{le="3600"}[10m]))
-
-    - record: rate_of_release_processing_duration_seconds_counter_per_10m
-      expr: sum by (job) (rate(release_processing_duration_seconds_count[10m]) > 0)
-
     # record rules for `ReleaseServicePreProcessingDurationSeconds`
     - record: rate_of_release_pre_processing_duration_seconds_shorter_than_10s_per_10m
       expr: sum by (job) (rate(release_pre_processing_duration_seconds_bucket{le="10"}[10m]))
@@ -31,10 +24,10 @@ spec:
     - record: rate_of_release_validation_duration_seconds_counter_per_10m
       expr: sum by (job) (rate(release_validation_duration_seconds_count[10m]) > 0)
 
-    - alert: ReleaseServiceProcessingDuration
+    - alert: ReleaseServiceValidationDurationSeconds
       expr: |
         (
-          rate_of_release_processing_duration_seconds_shorter_than_1h_per_10m / rate_of_release_processing_duration_seconds_counter_per_10m
+          rate_of_release_validation_duration_seconds_shorter_than_5s_per_10m / rate_of_release_validation_duration_seconds_counter_per_10m
         ) < 0.90
       for: 15m
       labels:
@@ -42,11 +35,11 @@ spec:
         slo: "true"
       annotations:
         summary: >-
-          90% of Releases must be processed under one hour
+          90% of Releases must be validated under 5 seconds
         description: >-
-          Release service is failing to successfully process within the period of one hour for 90% of releases
+          Release service is failing to run the validations under 5 seconds for 90% of releases
         alert_team_handle: <!subteam^S03SVBS426R>
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-processed-latency.md?ref_type=heads
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-validation-latency.md?ref_type=heads
         team: release
 
     - alert: ReleaseServicePreProcessingDurationSeconds
@@ -65,22 +58,4 @@ spec:
           Release service is failing to start processing under 10 seconds for 90% of releases
         alert_team_handle: <!subteam^S03SVBS426R>
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-processing-latency.md?ref_type=heads
-        team: release
-
-    - alert: ReleaseServiceValidationDurationSeconds
-      expr: |
-        (
-          rate_of_release_validation_duration_seconds_shorter_than_5s_per_10m / rate_of_release_validation_duration_seconds_counter_per_10m
-        ) < 0.90
-      for: 15m
-      labels:
-        severity: critical
-        slo: "true"
-      annotations:
-        summary: >-
-          90% of Releases must be validated under 5 seconds
-        description: >-
-          Release service is failing to run the validations under 5 seconds for 90% of releases
-        alert_team_handle: <!subteam^S03SVBS426R>
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-validation-latency.md?ref_type=heads
         team: release

--- a/test/promql/tests/data_plane/release_service_test.yaml
+++ b/test/promql/tests/data_plane/release_service_test.yaml
@@ -6,33 +6,6 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: 'release_processing_duration_seconds_bucket{le="3600", job="release", namespace="foo", source_cluster="cluster01"}'
-        values: '1+8x59'
-      - series: 'release_processing_duration_seconds_count{job="release", namespace="foo", source_cluster="cluster01"}'
-        values: '1+9x59'
-      - series: 'release_processing_duration_seconds_bucket{le="3600", job="release", namespace="foo", source_cluster="cluster02"}'
-        values: '1+8x59'
-      - series: 'release_processing_duration_seconds_count{job="release", namespace="foo", source_cluster="cluster02"}'
-        values: '1+9x59'
-    alert_rule_test:
-      - eval_time: 1h
-        alertname: ReleaseServiceProcessingDuration
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-              slo: "true"
-              job: "release"
-            exp_annotations:
-              summary: >-
-                90% of Releases must be processed under one hour
-              description: >-
-                Release service is failing to successfully process within the period of one hour for 90% of releases
-              alert_team_handle: <!subteam^S03SVBS426R>
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-processed-latency.md?ref_type=heads
-              team: release
-
-  - interval: 1m
-    input_series:
       - series: 'release_pre_processing_duration_seconds_bucket{le="10", job="release", namespace="foo", source_cluster="cluster01"}'
         values: '1+8x59'
       - series: 'release_pre_processing_duration_seconds_count{job="release", namespace="foo", source_cluster="cluster01"}'


### PR DESCRIPTION
This commit removes the release_processing_duration SLO from alerting and dashboard as for the current moment the metrics available in this sensor can not be trusted as releases can have different processing time for different users.