### PR TITLE
add build team availability alerts

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.build_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.build_service_alerts.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-build-service-github-app-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: build_service_github_app_alerts
+      interval: 1m
+      rules:
+        - alert: GitHubAppFailureAlert
+          expr: (konflux_up offset 1h) unless on(service, check, source_cluster) konflux_up{service="github", check="build-service"}
+          for: 1m
+          labels:
+            severity: warning
+          annotations:
+            summary: Availability metric 'konflux_up' is missing for GitHub App in {{ $labels.check }}.
+            description: >-
+              The 'konflux_up' availability metric is missing for GitHub App in {{ $labels.check }} on cluster {{ $labels.source_cluster }} indicating a possible service disruption.
+            team: build
+            alert_team_handle: <!subteam^S03DM1RL0TF>
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/build-service/availability_github_app.md

--- a/rhobs/alerting/data_plane/prometheus.image_controller_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.image_controller_alerts.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-image-controller-quay-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: image_controller_quay_alerts
+      interval: 1m
+      rules:
+        - alert: QuayFailureAlert
+          expr: (konflux_up offset 1h) unless on(service, check, source_cluster) konflux_up{service="quay", check="image-controller"}
+          for: 1m
+          labels:
+            severity: warning
+          annotations:
+            summary: Availability metric 'konflux_up' is missing for {{ $labels.service }} in {{ $labels.check }}.
+            description: >-
+              The 'konflux_up' availability metric is missing for {{ $labels.service }} in {{ $labels.check }} on cluster {{ $labels.source_cluster }} indicating a possible service disruption.
+            team: build
+            alert_team_handle: <!subteam^S03DM1RL0TF>
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/image-controller/availability_quay.md

--- a/test/promql/tests/data_plane/github_app_test.yaml
+++ b/test/promql/tests/data_plane/github_app_test.yaml
@@ -1,0 +1,33 @@
+rule_files:
+  - prometheus.build_service_alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="github", check="build-service", source_cluster="prod"}'
+        values: '1x60 _x10 1x5'
+
+    alert_rule_test:
+      - eval_time: 66m
+        alertname: GitHubAppFailureAlert
+
+      - eval_time: 67m
+        alertname: GitHubAppFailureAlert
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              check: build-service
+              service: github
+              source_cluster: prod
+            exp_annotations:
+              summary: Availability metric 'konflux_up' is missing for GitHub App in build-service.
+              description: >-
+                The 'konflux_up' availability metric is missing for GitHub App in build-service on cluster prod indicating a possible service disruption.
+              team: build
+              alert_team_handle: <!subteam^S03DM1RL0TF>
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/build-service/availability_github_app.md
+
+      - eval_time: 75m
+        alertname: GitHubAppFailureAlert

--- a/test/promql/tests/data_plane/quay_failure_test.yaml
+++ b/test/promql/tests/data_plane/quay_failure_test.yaml
@@ -1,0 +1,31 @@
+rule_files:
+  - prometheus.image_controller_alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: konflux_up{service="quay", check="image-controller", source_cluster="prod"}
+        values: '1x60 _x10 1x5'
+
+    alert_rule_test:
+      - eval_time: 66m
+        alertname: QuayFailureAlert
+      - eval_time: 67m
+        alertname: QuayFailureAlert
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              check: image-controller
+              service: quay
+              source_cluster: prod
+            exp_annotations:
+              summary: Availability metric 'konflux_up' is missing for quay in image-controller.
+              description: >-
+                The 'konflux_up' availability metric is missing for quay in image-controller on cluster prod indicating a possible service disruption.
+              team: build
+              alert_team_handle: <!subteam^S03DM1RL0TF>
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/image-controller/availability_quay.md
+      - eval_time: 75m
+        alertname: QuayFailureAlert


### PR DESCRIPTION
Jira: [STONEBLD-2651](https://issues.redhat.com/browse/STONEBLD-2651)

Add availability metrics for the build team which fire after five minutes of not having the `konflux_up` parameter
- Add GitHubAppFailureAlert for build-service
- Add QuayFailureAlert for image-controller

The alerts include `runbook_url` to currently non-existing SOPs. There is a [MR open which adds the SOPs](https://gitlab.cee.redhat.com/konflux/docs/sop/-/merge_requests/179), but it's not yet merged (will mark this PR ready for review after it's merged)