### PR TITLE
fix: cleanup chains performance alert, test

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -129,7 +129,7 @@ spec:
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/slos/tekton-pipeline-related-deadlocks.md
         - alert: ChainsControllerPerformance
           expr: |
-            (sum by (source_cluster) (increase(watcher_client_latency_bucket{app='tekton-chains-controller',le='1'}[5m]))
+            (sum by (source_cluster) (increase(watcher_client_latency_bucket{app='tekton-chains-controller',le='10'}[5m]))
             /
             sum by (source_cluster) (increase(watcher_client_latency_bucket{app='tekton-chains-controller',le='+Inf'}[5m])))
             < 0.50

--- a/test/promql/tests/data_plane/pipeline_overhead_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_overhead_test.yaml
@@ -239,7 +239,7 @@ tests:
     input_series:
 
       # see https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/ for explanations of the expanding notation used for the values
-      - series: 'watcher_client_latency_bucket{app="tekton-chains-controller", le="1", source_cluster="cluster01"}'
+      - series: 'watcher_client_latency_bucket{app="tekton-chains-controller", le="10", source_cluster="cluster01"}'
         values: '300+300x780'
       - series: 'watcher_client_latency_bucket{app="tekton-chains-controller", le="+Inf", source_cluster="cluster01"}'
         values: '400+400x780'


### PR DESCRIPTION
Failed to catch with PR #341 that the alert actually did need to be switched from the 1 second 'le' bucket to the 10 second 'le' bucket as well.

Signed-off-by: Gabe Montero <gmontero@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED