### PR TITLE
fix: remove pipeline overhead panels

### DIFF
--- a/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
+++ b/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
@@ -2,2444 +2,2214 @@ apiVersion: v1
 data:
   rhtap-slo-dashboard.json: |-
     {
-        "annotations": {
-            "list": [
-                {
-                    "builtIn": 1,
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                    },
-                    "enable": true,
-                    "hide": true,
-                    "iconColor": "rgba(0, 211, 255, 1)",
-                    "name": "Annotations & Alerts",
-                    "target": {
-                        "limit": 100,
-                        "matchAny": false,
-                        "tags": [],
-                        "type": "dashboard"
-                    },
-                    "type": "dashboard"
-                }
-            ]
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "RHTAP Service Level Objectives",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 931285,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "",
+          "gridPos": {
+            "h": 3,
+            "w": 20,
+            "x": 0,
+            "y": 0
+          },
+          "id": 31,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "This dashboard shows all SLOs for RHTAP over a specified time window.\n\nSelect a datasource to switch between environments.",
+            "mode": "markdown"
+          },
+          "pluginVersion": "10.4.1",
+          "transparent": true,
+          "type": "text"
         },
-        "description": "RHTAP Service Level Objectives",
-        "editable": true,
-        "fiscalYearStartMonth": 0,
-        "graphTooltip": 0,
-        "id": 931285,
-        "links": [],
-        "liveNow": false,
-        "panels": [
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "",
-                "gridPos": {
-                    "h": 3,
-                    "w": 20,
-                    "x": 0,
-                    "y": 0
-                },
-                "id": 31,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "This dashboard shows all SLOs for RHTAP over a specified time window.\n\nSelect a datasource to switch between environments.",
-                    "mode": "markdown"
-                },
-                "pluginVersion": "10.4.1",
-                "transparent": true,
-                "type": "text"
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 3
+          },
+          "id": 80,
+          "panels": [],
+          "title": "Integration Service SLO's",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The objective for the given time window.",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 4
+          },
+          "id": 77,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
             },
+            "content": "<h1><center>90% of requests must be within required response time</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
             {
-                "collapsed": false,
-                "gridPos": {
-                    "h": 1,
-                    "w": 24,
-                    "x": 0,
-                    "y": 3
-                },
-                "id": 80,
-                "panels": [],
-                "title": "Integration Service SLO's",
-                "type": "row"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The objective for the given time window.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 4
-                },
-                "id": 77,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>90% of requests must be within required response time</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Latency Service Response SLO",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The current measurement for the given time window.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "max": 1,
-                        "min": 0,
-                        "noValue": "-",
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "red",
-                                    "value": null
-                                },
-                                {
-                                    "color": "green",
-                                    "value": 90
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 4
-                },
-                "id": 78,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(integration_svc_response_seconds_bucket{le=\"30\"}[$__rate_interval])) by (job)\n/\nsum(rate(integration_svc_response_seconds_count[$__rate_interval]) > 0) by (job)",
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Measured",
-                "type": "gauge"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The objective for the given time window.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 11
-                },
-                "id": 83,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>90% of equests must be within required time</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Time to start Pipeline Run",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The current measurement for the given time window.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "max": 1,
-                        "min": 0,
-                        "noValue": "-",
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "red",
-                                    "value": null
-                                },
-                                {
-                                    "color": "green",
-                                    "value": 90
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 11
-                },
-                "id": 86,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(integration_svc_snapshot_created_to_pipelinerun_started_seconds_bucket{le=\"5\"}[$__rate_interval])) by (job)\n/\nsum(rate(integration_svc_snapshot_created_to_pipelinerun_started_seconds_count[$__rate_interval]) > 0) by (job)",
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Measured",
-                "type": "gauge"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The objective for the given time window.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 18
-                },
-                "id": 82,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>90% of requests must be within required time</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Latency of Release Creation",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The current measurement for the given time window.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "max": 1,
-                        "min": 0,
-                        "noValue": "-",
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "red",
-                                    "value": null
-                                },
-                                {
-                                    "color": "green",
-                                    "value": 90
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 18
-                },
-                "id": 84,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(integration_svc_release_latency_seconds_bucket{le=\"10\"}[$__rate_interval])) by (job) / sum(rate(integration_svc_release_latency_seconds_count[$__rate_interval])) by (job)",
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Measured",
-                "type": "gauge"
-            },
-            {
-                "collapsed": false,
-                "gridPos": {
-                    "h": 1,
-                    "w": 24,
-                    "x": 0,
-                    "y": 25
-                },
-                "id": 96,
-                "panels": [],
-                "title": "Release Service SLOs",
-                "type": "row"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Measure the time it takes for a Release to be marked as Validated.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 26
-                },
-                "id": 97,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>90% of the Releases should be validated below 5 seconds</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Release Validation SLO",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Measure the time it takes for a Release to be marked as Processed.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "max": 1,
-                        "min": 0,
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "red",
-                                    "value": null
-                                },
-                                {
-                                    "color": "green",
-                                    "value": 90
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 26
-                },
-                "id": 101,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [
-                            "mean"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum by (job) (rate(release_validation_duration_seconds_bucket{le=\"5\"}[$__rate_interval])) / sum by (job) (rate(release_validation_duration_seconds_count[$__rate_interval]) > 0)",
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Measured",
-                "type": "gauge"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Measure the time it takes for a Release to be marked as Processing",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 33
-                },
-                "id": 99,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>90% of the Releases should be pre-processed within 10 seconds</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Release Pre-Processing SLO",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Measure the time it takes for a Release to be marked as Processed.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "max": 1,
-                        "min": 0,
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "red",
-                                    "value": null
-                                },
-                                {
-                                    "color": "green",
-                                    "value": 90
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 33
-                },
-                "id": 100,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [
-                            "mean"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum by (job) (rate(release_pre_processing_duration_seconds_bucket{le=\"10\"}[$__rate_interval])) / sum by (job) (rate(release_pre_processing_duration_seconds_count[$__rate_interval]) > 0)",
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Measured",
-                "type": "gauge"
-            },
-            {
-                "collapsed": false,
-                "gridPos": {
-                    "h": 1,
-                    "w": 24,
-                    "x": 0,
-                    "y": 40
-                },
-                "id": 64,
-                "panels": [],
-                "title": "Pipeline SLOs",
-                "type": "row"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Factoring out the time needed to receive PipelineRun creation events from the overall PipelineRun execution time is at or above the defined percentile",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 41
-                },
-                "id": 65,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>95% of pipeline run duration excludes scheduling overhead</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Pipeline Scheduling Overhead (alert removed, panel removal occurring soon)",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The current measurement for the given time window.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "max": 1,
-                        "min": 0,
-                        "noValue": "-",
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "red",
-                                    "value": null
-                                },
-                                {
-                                    "color": "green",
-                                    "value": 95
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 41
-                },
-                "id": 68,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "1-(sum(increase(pipeline_service_schedule_overhead_percentage_sum{status='succeded'}[$__range])) \n/  \nsum(increase(pipeline_service_schedule_overhead_percentage_count{status='succeded'}[$__range])))",
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Scheduling overhead",
-                "type": "gauge"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Factoring out the time needed to create underlying TaskRuns from the overall PipelineRun execution time is at or above the defined percentile",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 48
-                },
-                "id": 69,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>95% of pipeline run duration excludes execution overhead</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Pipeline Execution Overhead (alert removed, panel removal occurring soon)",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The current measurement for the given time window.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "max": 1,
-                        "min": 0,
-                        "noValue": "-",
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "red",
-                                    "value": null
-                                },
-                                {
-                                    "color": "green",
-                                    "value": 95
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 48
-                },
-                "id": 70,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "1-(sum(increase(pipeline_service_execution_overhead_percentage_sum{status='succeded'}[$__range])) \n/  \nsum(increase(pipeline_service_execution_overhead_percentage_count{status='succeded'}[$__range])))",
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Execution overhead",
-                "type": "gauge"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The rate that any of the pipeline controllers have restarted",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 55
-                },
-                "id": 104,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>The rate that any of the pipeline controllers have restarted</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Pipeline Controller Restarts",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The number of times any of the tekton controllers have restarted",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                },
-                                {
-                                    "color": "red",
-                                    "value": 5
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 55
-                },
-                "id": 105,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(kube_pod_container_status_restarts_total{namespace=\"openshift-pipelines\", pod=~\"tekton-.*|pipelines-as-code-.*\"}[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Controller Restart Rates",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The number of validated PipelineRuns not yet processed by the PipelineRun Controller.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 62
-                },
-                "id": 106,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>The number of validated PipelineRuns not yet processed by the PipelineRun Controller.</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked PipelineRuns",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The number of validated PipelineRuns not yet processed by the PipelineRun Controller.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                },
-                                {
-                                    "color": "red",
-                                    "value": 30
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 62
-                },
-                "id": 107,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(increase(pipelinerun_kickoff_not_attempted_count[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked PipelineRuns",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The rate of validated TaskRuns not yet processed by the TaskRuns Controller.  Negative numbers mean no TaskRuns Controller deadlocks despite Kubernetes throttling.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 69
-                },
-                "id": 108,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>The rate of validated TaskRuns not yet processed by the TaskRuns Controller.  Negative numbers mean no TaskRun Controller deadlocks despite Kubernetes throttling.</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked TaskRuns",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The rate of validated TaskRuns not yet processed by the TaskRuns Controller.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                },
-                                {
-                                    "color": "red",
-                                    "value": 30
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 69
-                },
-                "id": 109,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(taskrun_pod_create_not_attempted_or_pending_count[$__range])) - sum(rate(tekton_pipelines_controller_running_taskruns_throttled_by_quota[$__range])) - sum(rate(tekton_pipelines_controller_running_taskruns_throttled_by_node[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked TaskRuns",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The number of validated ResolutionRequests  not yet processed by the Resolver Controller.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 76
-                },
-                "id": 110,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>The number of validated ResolutionRequests not yet processed by the Resolver Controller.</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked ResolutionRequests",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The number of validated ResolutionRequests not yet processed by the Resolver Controller.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                },
-                                {
-                                    "color": "red",
-                                    "value": 30
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 76
-                },
-                "id": 111,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(increase(pending_resolutionrequest_count[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked ResolutionRequests",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Indicator whether Tekton Results is deadlocked",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 83
-                },
-                "id": 116,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>If there are PipelineRuns on the cluster, but no corresponding GRPC processed by Tekton Results, Tekton Results is possibly deadlocked </center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Results Deadlocked Part 1",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The rate of PipelineRuns existing on cluster for the poling interval",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 83
-                },
-                "id": 122,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(tekton_pipelines_controller_pipelinerun_count[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "PipelineRun Total Rate - Results Deadlock Part 1",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Indicator whether Tekton Results is deadlocked",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 90
-                },
-                "id": 119,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>If there are PipelineRuns on the cluster, but no corresponding GRPC processed by Tekton Results, Tekton Results is possibly deadlocked </center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Results Deadlocked Part 2",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The rate of PipelineRun related GRPC API calls made against Tekton Results",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 90
-                },
-                "id": 118,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(grpc_server_handled_total{job='tekton-results-api', grpc_service=~'tekton.results.*'}[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Tekton Results GRPC Rate - Results Deadlock Part 2",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Tekton Results API Success Rate",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 97
-                },
-                "id": 121,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>Tekton Results API Success Rate </center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Results Success Rate",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The success rate of API calls made to Tekton Results",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "max": 1,
-                        "min": 0,
-                        "noValue": "-",
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "red",
-                                    "value": null
-                                },
-                                {
-                                    "color": "green",
-                                    "value": 75
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 97
-                },
-                "id": 120,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(grpc_server_handled_total{job='tekton-results-api', grpc_service=~'tekton.results.*', grpc_code='OK'}[$__range])) / sum(rate(grpc_server_handled_total{job='tekton-results-api', grpc_service=~'tekton.results.*'}[$__range]))",
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Tekton Results API Success",
-                "type": "gauge"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The rate of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 104
-                },
-                "id": 112,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>The rate of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked Chains",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The rate of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                },
-                                {
-                                    "color": "red",
-                                    "value": 50
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 104
-                },
-                "id": 113,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(delta(watcher_workqueue_depth{container='tekton-chains-controller',app='tekton-chains-controller'}[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked Chains",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Percentage of Chains PipielineRun event processing completing within acceptable performance ranges.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 111
-                },
-                "id": 114,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>Percentage of Chains PipielineRun event processing completing within acceptable performance ranges.</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Chains Performance",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Percentage of Chains PipielineRun event processing completing within acceptable performance ranges.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                },
-                                {
-                                    "color": "red",
-                                    "value": 50
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 111
-                },
-                "id": 115,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(increase(watcher_client_latency_bucket{app='tekton-chains-controller',le='10'}[$__range])) / sum(increase(watcher_client_latency_bucket{app='tekton-chains-controller',le='+Inf'}[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Chains Performance",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The number of PipelineRuns/TaskRuns still needing processing by Tekton PAC Controller",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 118
-                },
-                "id": 123,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>The number of PipelineRuns/TaskRuns still needing processing by Tekton PAC Controller</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked PAC",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The number of PipelineRuns/TaskRuns still needing processing by Tekton PAC Controller",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                },
-                                {
-                                    "color": "red",
-                                    "value": 50
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 118
-                },
-                "id": 124,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(delta(pac_watcher_work_queue_depth[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked PAC",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Percentage of PAC PipielineRun event processing completing within acceptable performance ranges.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 125
-                },
-                "id": 125,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>Percentage of PAC PipielineRun event processing completing within acceptable performance ranges.</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "PAC Performance",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Percentage of PAC PipielineRun event processing completing within acceptable performance ranges.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                },
-                                {
-                                    "color": "red",
-                                    "value": 50
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 125
-                },
-                "id": 117,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(increase(pac_watcher_client_latency_bucket{le='10'}[$__range])) / sum(increase(pac_watcher_client_latency_bucket{le='+Inf'}[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "PAC Performance",
-                "type": "stat"
-            },
-            {
-                "collapsed": true,
-                "gridPos": {
-                    "h": 1,
-                    "w": 24,
-                    "x": 0,
-                    "y": 132
-                },
-                "id": 33,
-                "panels": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "description": "The objective for the given time window.",
-                        "gridPos": {
-                            "h": 7,
-                            "w": 10,
-                            "x": 0,
-                            "y": 48
-                        },
-                        "id": 10,
-                        "options": {
-                            "code": {
-                                "language": "plaintext",
-                                "showLineNumbers": false,
-                                "showMiniMap": false
-                            },
-                            "content": "<h1><center>SLO Definition</center></h1>",
-                            "mode": "html"
-                        },
-                        "pluginVersion": "10.4.1",
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "type": "prometheus",
-                                    "uid": "${datasource}"
-                                },
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "SLO",
-                        "type": "text"
-                    },
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "description": "The current measurement for the given time window.",
-                        "fieldConfig": {
-                            "defaults": {
-                                "color": {
-                                    "mode": "thresholds"
-                                },
-                                "mappings": [
-                                    {
-                                        "options": {
-                                            "match": "null",
-                                            "result": {
-                                                "text": "N/A"
-                                            }
-                                        },
-                                        "type": "special"
-                                    }
-                                ],
-                                "thresholds": {
-                                    "mode": "absolute",
-                                    "steps": [
-                                        {
-                                            "color": "green"
-                                        },
-                                        {
-                                            "color": "red",
-                                            "value": 80
-                                        }
-                                    ]
-                                },
-                                "unit": "none"
-                            },
-                            "overrides": []
-                        },
-                        "gridPos": {
-                            "h": 7,
-                            "w": 5,
-                            "x": 0,
-                            "y": 55
-                        },
-                        "id": 98,
-                        "maxDataPoints": 100,
-                        "options": {
-                            "colorMode": "none",
-                            "graphMode": "none",
-                            "justifyMode": "auto",
-                            "orientation": "horizontal",
-                            "reduceOptions": {
-                                "calcs": [
-                                    "mean"
-                                ],
-                                "fields": "",
-                                "values": false
-                            },
-                            "showPercentChange": false,
-                            "textMode": "auto",
-                            "wideLayout": true
-                        },
-                        "pluginVersion": "10.4.1",
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "type": "prometheus",
-                                    "uid": "${datasource}"
-                                },
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "Measured",
-                        "type": "stat"
-                    },
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "description": "The remaining error budget for the given time window.",
-                        "fieldConfig": {
-                            "defaults": {
-                                "color": {
-                                    "mode": "thresholds"
-                                },
-                                "mappings": [
-                                    {
-                                        "options": {
-                                            "match": "null",
-                                            "result": {
-                                                "text": "N/A"
-                                            }
-                                        },
-                                        "type": "special"
-                                    }
-                                ],
-                                "thresholds": {
-                                    "mode": "absolute",
-                                    "steps": [
-                                        {
-                                            "color": "green"
-                                        },
-                                        {
-                                            "color": "red",
-                                            "value": 80
-                                        }
-                                    ]
-                                },
-                                "unit": "none"
-                            },
-                            "overrides": []
-                        },
-                        "gridPos": {
-                            "h": 7,
-                            "w": 5,
-                            "x": 5,
-                            "y": 55
-                        },
-                        "id": 29,
-                        "maxDataPoints": 100,
-                        "options": {
-                            "colorMode": "none",
-                            "graphMode": "none",
-                            "justifyMode": "auto",
-                            "orientation": "horizontal",
-                            "reduceOptions": {
-                                "calcs": [
-                                    "mean"
-                                ],
-                                "fields": "",
-                                "values": false
-                            },
-                            "showPercentChange": false,
-                            "textMode": "auto",
-                            "wideLayout": true
-                        },
-                        "pluginVersion": "10.4.1",
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "type": "prometheus",
-                                    "uid": "${datasource}"
-                                },
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "Error Budget (%)",
-                        "type": "stat"
-                    }
-                ],
-                "title": "SLO Template",
-                "type": "row"
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
             }
-        ],
-        "refresh": "1h",
-        "schemaVersion": 39,
-        "tags": [],
-        "templating": {
-            "list": [
+          ],
+          "title": "Latency Service Response SLO",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The current measurement for the given time window.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
                 {
-                    "current": {
-                        "selected": true,
-                        "text": "rhtap-observatorium-production",
-                        "value": "rhtap-observatorium-production"
-                    },
-                    "hide": 0,
-                    "includeAll": false,
-                    "multi": false,
-                    "name": "datasource",
-                    "options": [],
-                    "query": "prometheus",
-                    "queryValue": "",
-                    "refresh": 1,
-                    "regex": "/^rhtap-/",
-                    "skipUrlSync": false,
-                    "type": "datasource"
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
                 }
-            ]
+              ],
+              "max": 1,
+              "min": 0,
+              "noValue": "-",
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 4
+          },
+          "id": 78,
+          "maxDataPoints": 100,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(integration_svc_response_seconds_bucket{le=\"30\"}[$__rate_interval])) by (job)\n/\nsum(rate(integration_svc_response_seconds_count[$__rate_interval]) > 0) by (job)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Measured",
+          "type": "gauge"
         },
-        "time": {
-            "from": "now-28d",
-            "to": "now"
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The objective for the given time window.",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 11
+          },
+          "id": 83,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>90% of equests must be within required time</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Time to start Pipeline Run",
+          "type": "text"
         },
-        "timepicker": {
-            "refresh_intervals": [
-                "5s",
-                "10s",
-                "30s",
-                "1m",
-                "5m",
-                "15m",
-                "30m",
-                "1h",
-                "2h",
-                "1d"
-            ],
-            "time_options": [
-                "5m",
-                "15m",
-                "1h",
-                "6h",
-                "12h",
-                "24h",
-                "2d",
-                "7d",
-                "30d"
-            ]
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The current measurement for the given time window.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "noValue": "-",
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 11
+          },
+          "id": 86,
+          "maxDataPoints": 100,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(integration_svc_snapshot_created_to_pipelinerun_started_seconds_bucket{le=\"5\"}[$__rate_interval])) by (job)\n/\nsum(rate(integration_svc_snapshot_created_to_pipelinerun_started_seconds_count[$__rate_interval]) > 0) by (job)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Measured",
+          "type": "gauge"
         },
-        "timezone": "",
-        "title": "RHTAP SLOs",
-        "uid": "rhtap-slos",
-        "version": 10,
-        "weekStart": ""
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The objective for the given time window.",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 18
+          },
+          "id": 82,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>90% of requests must be within required time</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Latency of Release Creation",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The current measurement for the given time window.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "noValue": "-",
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 18
+          },
+          "id": 84,
+          "maxDataPoints": 100,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(integration_svc_release_latency_seconds_bucket{le=\"10\"}[$__rate_interval])) by (job) / sum(rate(integration_svc_release_latency_seconds_count[$__rate_interval])) by (job)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Measured",
+          "type": "gauge"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 25
+          },
+          "id": 96,
+          "panels": [],
+          "title": "Release Service SLOs",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Measure the time it takes for a Release to be marked as Validated.",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 26
+          },
+          "id": 97,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>90% of the Releases should be validated below 5 seconds</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Release Validation SLO",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Measure the time it takes for a Release to be marked as Processed.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 26
+          },
+          "id": 101,
+          "maxDataPoints": 100,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(release_validation_duration_seconds_bucket{le=\"5\"}[$__rate_interval])) / sum by (job) (rate(release_validation_duration_seconds_count[$__rate_interval]) > 0)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Measured",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Measure the time it takes for a Release to be marked as Processing",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 33
+          },
+          "id": 99,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>90% of the Releases should be pre-processed within 10 seconds</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Release Pre-Processing SLO",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Measure the time it takes for a Release to be marked as Processed.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 33
+          },
+          "id": 100,
+          "maxDataPoints": 100,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(release_pre_processing_duration_seconds_bucket{le=\"10\"}[$__rate_interval])) / sum by (job) (rate(release_pre_processing_duration_seconds_count[$__rate_interval]) > 0)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Measured",
+          "type": "gauge"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 40
+          },
+          "id": 64,
+          "panels": [],
+          "title": "Pipeline SLOs",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The rate that any of the pipeline controllers have restarted",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 41
+          },
+          "id": 104,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The rate that any of the pipeline controllers have restarted</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Pipeline Controller Restarts",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of times any of the tekton controllers have restarted",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 5
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 41
+          },
+          "id": 105,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(kube_pod_container_status_restarts_total{namespace=\"openshift-pipelines\", pod=~\"tekton-.*|pipelines-as-code-.*\"}[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Controller Restart Rates",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of validated PipelineRuns not yet processed by the PipelineRun Controller.",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 48
+          },
+          "id": 106,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The number of validated PipelineRuns not yet processed by the PipelineRun Controller.</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Deadlocked PipelineRuns",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of validated PipelineRuns not yet processed by the PipelineRun Controller.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 48
+          },
+          "id": 107,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(pipelinerun_kickoff_not_attempted_count[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Deadlocked PipelineRuns",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The rate of validated TaskRuns not yet processed by the TaskRuns Controller.  Negative numbers mean no TaskRuns Controller deadlocks despite Kubernetes throttling.",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 55
+          },
+          "id": 108,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The rate of validated TaskRuns not yet processed by the TaskRuns Controller.  Negative numbers mean no TaskRun Controller deadlocks despite Kubernetes throttling.</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Deadlocked TaskRuns",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The rate of validated TaskRuns not yet processed by the TaskRuns Controller.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 55
+          },
+          "id": 109,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(taskrun_pod_create_not_attempted_or_pending_count[$__range])) - sum(rate(tekton_pipelines_controller_running_taskruns_throttled_by_quota[$__range])) - sum(rate(tekton_pipelines_controller_running_taskruns_throttled_by_node[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Deadlocked TaskRuns",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of validated ResolutionRequests  not yet processed by the Resolver Controller.",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 62
+          },
+          "id": 110,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The number of validated ResolutionRequests not yet processed by the Resolver Controller.</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Deadlocked ResolutionRequests",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of validated ResolutionRequests not yet processed by the Resolver Controller.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 62
+          },
+          "id": 111,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(pending_resolutionrequest_count[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Deadlocked ResolutionRequests",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Indicator whether Tekton Results is deadlocked",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 69
+          },
+          "id": 116,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>If there are PipelineRuns on the cluster, but no corresponding GRPC processed by Tekton Results, Tekton Results is possibly deadlocked </center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Results Deadlocked Part 1",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The rate of PipelineRuns existing on cluster for the poling interval",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 69
+          },
+          "id": 122,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(tekton_pipelines_controller_pipelinerun_count[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "PipelineRun Total Rate - Results Deadlock Part 1",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Indicator whether Tekton Results is deadlocked",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 76
+          },
+          "id": 119,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>If there are PipelineRuns on the cluster, but no corresponding GRPC processed by Tekton Results, Tekton Results is possibly deadlocked </center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Results Deadlocked Part 2",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The rate of PipelineRun related GRPC API calls made against Tekton Results",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 76
+          },
+          "id": 118,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(grpc_server_handled_total{job='tekton-results-api', grpc_service=~'tekton.results.*'}[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Tekton Results GRPC Rate - Results Deadlock Part 2",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Tekton Results API Success Rate",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 83
+          },
+          "id": 121,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>Tekton Results API Success Rate </center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Results Success Rate",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The success rate of API calls made to Tekton Results",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "noValue": "-",
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 75
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 83
+          },
+          "id": 120,
+          "maxDataPoints": 100,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(grpc_server_handled_total{job='tekton-results-api', grpc_service=~'tekton.results.*', grpc_code='OK'}[$__range])) / sum(rate(grpc_server_handled_total{job='tekton-results-api', grpc_service=~'tekton.results.*'}[$__range]))",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Tekton Results API Success",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The rate of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 90
+          },
+          "id": 112,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The rate of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Deadlocked Chains",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The rate of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 50
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 90
+          },
+          "id": 113,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(delta(watcher_workqueue_depth{container='tekton-chains-controller',app='tekton-chains-controller'}[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Deadlocked Chains",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Percentage of Chains PipielineRun event processing completing within acceptable performance ranges.",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 97
+          },
+          "id": 114,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>Percentage of Chains PipielineRun event processing completing within acceptable performance ranges.</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Chains Performance",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Percentage of Chains PipielineRun event processing completing within acceptable performance ranges.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 50
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 97
+          },
+          "id": 115,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(watcher_client_latency_bucket{app='tekton-chains-controller',le='10'}[$__range])) / sum(increase(watcher_client_latency_bucket{app='tekton-chains-controller',le='+Inf'}[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Chains Performance",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of PipelineRuns/TaskRuns still needing processing by Tekton PAC Controller",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 104
+          },
+          "id": 123,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The number of PipelineRuns/TaskRuns still needing processing by Tekton PAC Controller</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Deadlocked PAC",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of PipelineRuns/TaskRuns still needing processing by Tekton PAC Controller",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 50
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 104
+          },
+          "id": 124,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(delta(pac_watcher_work_queue_depth[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Deadlocked PAC",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Percentage of PAC PipielineRun event processing completing within acceptable performance ranges.",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 111
+          },
+          "id": 125,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>Percentage of PAC PipielineRun event processing completing within acceptable performance ranges.</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "PAC Performance",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Percentage of PAC PipielineRun event processing completing within acceptable performance ranges.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 50
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 111
+          },
+          "id": 117,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(pac_watcher_client_latency_bucket{le='10'}[$__range])) / sum(increase(pac_watcher_client_latency_bucket{le='+Inf'}[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "PAC Performance",
+          "type": "stat"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 118
+          },
+          "id": 33,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "The objective for the given time window.",
+              "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 0,
+                "y": 48
+              },
+              "id": 10,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<h1><center>SLO Definition</center></h1>",
+                "mode": "html"
+              },
+              "pluginVersion": "10.4.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "refId": "A"
+                }
+              ],
+              "title": "SLO",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "The current measurement for the given time window.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "N/A"
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 5,
+                "x": 0,
+                "y": 55
+              },
+              "id": 98,
+              "maxDataPoints": 100,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "10.4.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "refId": "A"
+                }
+              ],
+              "title": "Measured",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "The remaining error budget for the given time window.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "N/A"
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 5,
+                "x": 5,
+                "y": 55
+              },
+              "id": 29,
+              "maxDataPoints": 100,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "10.4.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "refId": "A"
+                }
+              ],
+              "title": "Error Budget (%)",
+              "type": "stat"
+            }
+          ],
+          "title": "SLO Template",
+          "type": "row"
+        }
+      ],
+      "refresh": "1h",
+      "schemaVersion": 39,
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": true,
+              "text": "rhtap-observatorium-production",
+              "value": "rhtap-observatorium-production"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "queryValue": "",
+            "refresh": 1,
+            "regex": "/^rhtap-/",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-28d",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "",
+      "title": "RHTAP SLOs",
+      "uid": "rhtap-slos",
+      "version": 11,
+      "weekStart": ""
     }
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Signed-off-by: Gabe Montero <gmontero@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED

definitely use `?w=` to disable white space when reviewing; aside from the deleted panels, you'll only see the updated y gridPos for the panels that were below the deleted panels, and the bump in the version at the bottom

![remove-overhead-panels](https://github.com/user-attachments/assets/801d734e-b266-4a3d-964c-11abebf9eac0)
