### PR TITLE
chore: update konflux_up alert routing

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml
@@ -20,4 +20,4 @@ spec:
           Availability metric 'konflux_up' is missing some entries for check {{ $labels.check }}
           on service {{ $labels.service }} and cluster {{ $labels.source_cluster }} when compared
           to previous hour.
-        alert_routing_key: 'konflux-up'
+        alert_routing_key: 'o11y'

--- a/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
+++ b/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
@@ -27,7 +27,7 @@ tests:
                 Availability metric 'konflux_up' is missing some entries for check
                 prometheus-appstudio-ds on service grafana and cluster stone-stg-rh01 when
                 compared to previous hour.
-              alert_routing_key: 'konflux-up'
+              alert_routing_key: 'o11y'
 
   - interval: 1m
     input_series:


### PR DESCRIPTION
The konflux_up metric had a routing key which did not correspond to any routing rule in app-interface. Here we change it to a value that corresponds to an existing routing statement.