### PR TITLE
fix: fixing availability query

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
@@ -65,11 +65,11 @@ spec:
         (
           avg_over_time
           (
-            (sum(kube_pod_container_status_ready{namespace="release-service", container="manager"}))
+            count(sum(kube_pod_container_status_ready{namespace="release-service", container="manager"}) by(namespace, source_cluster) > 0) by(namespace)
             [1h:]
           )
           /
-          max_over_time(sum(kube_pod_container_status_ready{namespace="release-service", container="manager"}) [1d:])
+          count(max_over_time(sum(kube_pod_container_status_ready{namespace="release-service", container="manager"}) by(source_cluster, namespace)[1d:])) by(namespace)
         ) < 0.99
       for: 15m
       labels:

--- a/test/promql/tests/data_plane/release_service_test.yaml
+++ b/test/promql/tests/data_plane/release_service_test.yaml
@@ -76,6 +76,7 @@ tests:
           - exp_labels:
               severity: critical
               slo: "true"
+              namespace: "release-service"
             exp_annotations:
               summary: >-
                 The Release Service Controller Manager must be available 99% of the time
@@ -102,6 +103,7 @@ tests:
           - exp_labels:
               severity: critical
               slo: "true"
+              namespace: "release-service"
             exp_annotations:
               summary: >-
                 The Release Service Controller Manager must be available 99% of the time


### PR DESCRIPTION
this commit fixes the query that fetches the availability data, by ignoring duplicate data
and not counting data with value 0.
