### PR TITLE
fix: SLO alert improvement

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
@@ -69,7 +69,7 @@ spec:
             [1h:]
           )
           /
-          count(max_over_time(sum(kube_pod_container_status_ready{namespace="release-service", container="manager"}) by(source_cluster, namespace)[1d:])) by(namespace)
+          sum(max_over_time(sum(kube_pod_container_status_ready{namespace="release-service", container="manager"}) by(source_cluster, namespace)[1h:])) by(namespace)
         ) < 0.99
       for: 15m
       labels:

--- a/test/promql/tests/data_plane/release_service_test.yaml
+++ b/test/promql/tests/data_plane/release_service_test.yaml
@@ -87,17 +87,16 @@ tests:
               team: release
 
   - name: ReleaseServiceControllerAvailabilityAlertOnClusterDataMissingSLOFailure
-    interval: 5m
+    interval: 1m
     input_series:
       - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="cluster01"}'
-        values: '1 1x791'
+        values: '1 1x58'
       - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="cluster02"}'
-        values: '1 1x791'
-      # the release pod of cluster03 was up for 1 hour and went down for the rest of the period
+        values: '1 1x58'
       - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="cluster03"}'
-        values: '1x33 _x759'
+        values: '1 _x58'
     alert_rule_test:
-      - eval_time: 1d
+      - eval_time: 1h
         alertname: ReleaseServiceControllerManagerAvailability
         exp_alerts:
           - exp_labels:


### PR DESCRIPTION
this commit decreases the observation period and
moves the aggregation function back to sum.

testing historical data for the observation, this
query seems to be the most accurate so far conside-
ring the eventual occurence of the service in clusters not releasing.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>