### PR TITLE
fix: release SLO alert should consider clusters in use

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
@@ -65,11 +65,11 @@ spec:
         (
           avg_over_time
           (
-            count(sum(kube_pod_container_status_ready{namespace="release-service", container="manager"}) by(namespace, source_cluster) > 0) by(namespace)
+            count(sum(kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster=~"stone-prd-rh01|stone-prod-p02"}) by(namespace, source_cluster) > 0) by(namespace)
             [1h:]
           )
           /
-          sum(max_over_time(sum(kube_pod_container_status_ready{namespace="release-service", container="manager"}) by(source_cluster, namespace)[1h:])) by(namespace)
+          sum(max_over_time(sum(kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster=~"stone-prd-rh01|stone-prod-p02"}) by(source_cluster, namespace)[1h:])) by(namespace)
         ) < 0.99
       for: 15m
       labels:

--- a/test/promql/tests/data_plane/release_service_test.yaml
+++ b/test/promql/tests/data_plane/release_service_test.yaml
@@ -63,12 +63,12 @@ tests:
   - name: ReleaseServiceControllerAvailabilityAlertOnBelowOf99SLOFailure
     interval: 1m
     input_series:
-      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="cluster01"}'
-        values: '0 1x32'
-      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="cluster02"}'
-        values: '0 1x32'
+      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="stone-prd-rh01"}'
+        values: '1x59'
+      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="stone-prod-p02"}'
+        values: '1x29 0x29'
       - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="cluster03"}'
-        values: '1 1x32'
+        values: '1x59'
     alert_rule_test:
       - eval_time: 1h
         alertname: ReleaseServiceControllerManagerAvailability
@@ -89,12 +89,12 @@ tests:
   - name: ReleaseServiceControllerAvailabilityAlertOnClusterDataMissingSLOFailure
     interval: 1m
     input_series:
-      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="cluster01"}'
+      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="stone-prd-rh01"}'
         values: '1 1x58'
-      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="cluster02"}'
-        values: '1 1x58'
-      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="cluster03"}'
+      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="stone-prod-p02"}'
         values: '1 _x58'
+      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="cluster03"}'
+        values: '1 1x58'
     alert_rule_test:
       - eval_time: 1h
         alertname: ReleaseServiceControllerManagerAvailability
@@ -115,13 +115,13 @@ tests:
   - name: ReleaseServiceControllerAvailabilityNoAlert
     interval: 5m
     input_series:
-      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="cluster01"}'
+      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="stone-prd-rh01"}'
         values: '1 1x791'
-      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="cluster02"}'
+      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="stone-prod-p02"}'
         values: '1 1x791'
       - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="cluster03"}'
         values: '1 1x791'
     alert_rule_test:
-      - eval_time: 1d
+      - eval_time: 1h
         alertname: ReleaseServiceControllerManagerAvailability
         exp_alerts: []


### PR DESCRIPTION
this PR change the release's controller SLO alert to consider only the clusters used for releasing software, namely stone-prd-rh01 and stone-prod-p02.