### PR TITLE
Add a crashloopbackoff alert for tekton

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -25,6 +25,22 @@ spec:
             alert_team_handle: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/sre/core-pipeline-controller-repeated-restarts.md
+        - alert: PipelinePodsCrashLoopBackOff
+          expr: |
+            sum by (source_cluster) (max_over_time(kube_pod_container_status_waiting_reason{namespace="openshift-pipelines", reason="CrashLoopBackOff"}[3m]) or vector(0)) > 0
+          for: 3m
+          labels:
+            severity: critical
+            slo: "true"
+          annotations:
+            summary: >-
+              Tekton controller is in a crashloop
+            description: >-
+              Tekton controllers on cluster {{ $labels.source_cluster }} has degraded into CrashLoopBackOff status and is not starting up.
+            alert_team_handle: <!subteam^S04PYECHCCU>
+            team: pipelines
+            # Same runbook as the repeated restarts alert
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/sre/core-pipeline-controller-repeated-restarts.md
         - alert: PipelineControllerDeadlock
           expr: |
             sum by (source_cluster) (increase(pipelinerun_kickoff_not_attempted_count[2m])) > 0


### PR DESCRIPTION
I noticed that the PipelinePodsRepeatedRestarts alert has a problem: at first, when pods are restarting, it fires. Good! But then, after a short while, the pod enters CrashLoopBackOff and it starts restarting less frequently. This causes PipelinePodsRepeatedRestarts to stop firing, making it appear as if the outage has resolved itself, when in fact it hasn't.

Adding this second alert will cause a second alert to fire when the situation cements itself into a CrashLoopBackOff.

Perhaps we should just remove the PipelinePodsRepeatedRestarts alert and replace it with this second one? Or - we could try both for a while and see how they play together before deciding?