### PR TITLE
feat(KFLUXINFRA-987): Add MPC availability metric transformer

### DIFF
--- a/rhobs/recording/multi_platform_controller_availability_recording_rules.yaml
+++ b/rhobs/recording/multi_platform_controller_availability_recording_rules.yaml
@@ -1,0 +1,15 @@
+# Metric format needed
+# multi_platform_controller_available(service="multi-platform-controller-controller-manager-metrics-service") -> konflux_up(service="multi-platform-controller", check="linux-arm64")
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-mpc-service-availability
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: mpc_service_backend_availability
+      interval: 1m
+      rules:
+        - record: konflux_up
+          expr: label_replace(multi_platform_controller_available, "service", "multi-platform-controller", "__name__", "(.+)")

--- a/test/promql/tests/recording/multi_platform_controller_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/multi_platform_controller_availability_recording_rules_test.yaml
@@ -1,0 +1,29 @@
+evaluation_interval: 1m
+
+rule_files:
+  - multi_platform_controller_availability_recording_rules.yaml
+
+tests:
+  - interval: 1m
+    name: MPCExporterTest
+    input_series:
+      - series: "multi_platform_controller_available{service='multi-platform-controller-controller-manager-metrics-service', check='linux-arm64'}"
+        values: "1 1 1 1 1"
+      - series: "multi_platform_controller_available{service='multi-platform-controller-controller-manager-metrics-service', check='linux-ppc64le'}"
+        values: "1 1 1 1 1"
+      - series: "multi_platform_controller_available{service='multi-platform-controller-controller-manager-metrics-service', check='linux-amd64'}"
+        values: "0 0 0 0 0"
+      - series: "multi_platform_controller_available{service='multi-platform-controller-controller-manager-metrics-service', check='linux-s390x'}"
+        values: "0 1 0 1 0"
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{service='multi-platform-controller', check='linux-arm64'}
+            value: 1
+          - labels: konflux_up{service='multi-platform-controller', check='linux-ppc64le'}
+            value: 1
+          - labels: konflux_up{service='multi-platform-controller', check='linux-amd64'}
+            value: 0
+          - labels: konflux_up{service='multi-platform-controller', check='linux-s390x'}
+            value: 0


### PR DESCRIPTION
Add transformer for `multi_platform_controller_available` metric.