### PR TITLE
fix: sum to count on release availability

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
@@ -69,7 +69,7 @@ spec:
             [1h:]
           )
           /
-          sum(max_over_time(sum(kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster=~"stone-prd-rh01|stone-prod-p02"}) by(source_cluster, namespace)[1h:])) by(namespace)
+          count(max_over_time(sum(kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster=~"stone-prd-rh01|stone-prod-p02"}) by(source_cluster, namespace)[1h:])) by(namespace)
         ) < 0.99
       for: 15m
       labels:


### PR DESCRIPTION
change function sum to count to avoid duplication
of clusters after outage, causing the alert to take too long to clear