### PR TITLE
fix: add Pod alert and change SLO to 1d

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
@@ -66,12 +66,12 @@ spec:
           avg_over_time
           (
             count(sum(kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster=~"stone-prd-rh01|stone-prod-p02"}) by(namespace, source_cluster) > 0) by(namespace)
-            [1h:]
+            [1d:]
           )
           /
-          count(max_over_time(sum(kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster=~"stone-prd-rh01|stone-prod-p02"}) by(source_cluster, namespace)[1h:])) by(namespace)
+          count(max_over_time(sum(kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster=~"stone-prd-rh01|stone-prod-p02"}) by(source_cluster, namespace)[1d:])) by(namespace)
         ) < 0.99
-      for: 15m
+      for: 1h
       labels:
         severity: critical
         slo: "true"
@@ -80,6 +80,22 @@ spec:
           The Release Service Controller Manager must be available 99% of the time
         description: >-
           The Release Service Controller Manager is failing to be available for 99% of the time
+        alert_team_handle: <!subteam^S03SVBS426R>
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-controller-availability.md?ref_type=heads
+        team: release
+
+    - alert: ReleaseServiceControllerManagerPodNotReady
+      expr: |
+        sum by (source_cluster) (kube_pod_container_status_ready{container="manager",namespace="release-service",source_cluster=~"stone-prd-rh01|stone-prod-p02"}) == 0
+      for: 10m
+      labels:
+        severity: high
+        slo: "false"
+      annotations:
+        summary: >-
+          The Release Service Controller Manager is down in the {{ $labels.source_cluster }} for the last 10 minutes
+        description: >-
+          The Release Service Controller Manager is down in the {{ $labels.source_cluster }} for the last 10 minutes
         alert_team_handle: <!subteam^S03SVBS426R>
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-controller-availability.md?ref_type=heads
         team: release

--- a/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
@@ -86,16 +86,15 @@ spec:
 
     - alert: ReleaseServiceControllerManagerPodNotReady
       expr: |
-        sum by (source_cluster) (kube_pod_container_status_ready{container="manager",namespace="release-service",source_cluster=~"stone-prd-rh01|stone-prod-p02"}) == 0
+        sum by (source_cluster, namespace) (kube_pod_container_status_ready{container="manager",namespace="release-service",source_cluster=~"stone-prd-rh01|stone-prod-p02"}) == 0
       for: 10m
       labels:
         severity: high
-        slo: "false"
       annotations:
         summary: >-
           The Release Service Controller Manager is down in the {{ $labels.source_cluster }} for the last 10 minutes
         description: >-
           The Release Service Controller Manager is down in the {{ $labels.source_cluster }} for the last 10 minutes
-        alert_team_handle: <!subteam^S03SVBS426R>
+        alert_team_key: "{{ $labels.namespace }}"
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-controller-availability.md?ref_type=heads
         team: release

--- a/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
@@ -95,6 +95,6 @@ spec:
           The Release Service Controller Manager is down in the {{ $labels.source_cluster }} for the last 10 minutes
         description: >-
           The Release Service Controller Manager is down in the {{ $labels.source_cluster }} for the last 10 minutes
-        alert_team_key: "{{ $labels.namespace }}"
+        alert_routing_key: "{{ $labels.namespace }}"
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-controller-availability.md?ref_type=heads
         team: release

--- a/test/promql/tests/data_plane/release_service_test.yaml
+++ b/test/promql/tests/data_plane/release_service_test.yaml
@@ -140,13 +140,13 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: high
-              slo: "false"
               source_cluster: "stone-prd-rh01"
+              namespace: "release-service"
             exp_annotations:
               summary: The Release Service Controller Manager is down in the stone-prd-rh01 for the last 10 minutes
               description: >-
                 The Release Service Controller Manager is down in the stone-prd-rh01 for the last 10 minutes
-              alert_team_handle: "<!subteam^S03SVBS426R>"
+              alert_routing_key: "release-service"
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-controller-availability.md?ref_type=heads
               team: release
 
@@ -163,13 +163,13 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: high
-              slo: "false"
               source_cluster: "stone-prod-p02"
+              namespace: "release-service"
             exp_annotations:
               summary: The Release Service Controller Manager is down in the stone-prod-p02 for the last 10 minutes
               description: >-
                 The Release Service Controller Manager is down in the stone-prod-p02 for the last 10 minutes
-              alert_team_handle: "<!subteam^S03SVBS426R>"
+              alert_routing_key: "release-service"
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-controller-availability.md?ref_type=heads
               team: release
 

--- a/test/promql/tests/data_plane/release_service_test.yaml
+++ b/test/promql/tests/data_plane/release_service_test.yaml
@@ -70,7 +70,7 @@ tests:
       - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="cluster03"}'
         values: '1x59'
     alert_rule_test:
-      - eval_time: 1h
+      - eval_time: 24h
         alertname: ReleaseServiceControllerManagerAvailability
         exp_alerts:
           - exp_labels:
@@ -96,7 +96,7 @@ tests:
       - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="cluster03"}'
         values: '1 1x58'
     alert_rule_test:
-      - eval_time: 1h
+      - eval_time: 24h
         alertname: ReleaseServiceControllerManagerAvailability
         exp_alerts:
           - exp_labels:
@@ -124,4 +124,63 @@ tests:
     alert_rule_test:
       - eval_time: 1h
         alertname: ReleaseServiceControllerManagerAvailability
+        exp_alerts: []
+
+
+  - name: ReleaseServiceControllerManagerOnPodNotReadyStonePrdRh01
+    interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="stone-prd-rh01"}'
+        values: '1 0x58'
+      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="stone-prod-p02"}'
+        values: '1 1x58'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: ReleaseServiceControllerManagerPodNotReady
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              slo: "false"
+              source_cluster: "stone-prd-rh01"
+            exp_annotations:
+              summary: The Release Service Controller Manager is down in the stone-prd-rh01 for the last 10 minutes
+              description: >-
+                The Release Service Controller Manager is down in the stone-prd-rh01 for the last 10 minutes
+              alert_team_handle: "<!subteam^S03SVBS426R>"
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-controller-availability.md?ref_type=heads
+              team: release
+
+  - name: ReleaseServiceControllerManagerOnPodNotReadyStoneProdP02
+    interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="stone-prd-rh01"}'
+        values: '1 1x58'
+      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="stone-prod-p02"}'
+        values: '1 0x58'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: ReleaseServiceControllerManagerPodNotReady
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              slo: "false"
+              source_cluster: "stone-prod-p02"
+            exp_annotations:
+              summary: The Release Service Controller Manager is down in the stone-prod-p02 for the last 10 minutes
+              description: >-
+                The Release Service Controller Manager is down in the stone-prod-p02 for the last 10 minutes
+              alert_team_handle: "<!subteam^S03SVBS426R>"
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-controller-availability.md?ref_type=heads
+              team: release
+
+  - name: ReleaseServiceControllerManagerOnPodReady
+    interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="stone-prd-rh01"}'
+        values: '1 1x58'
+      - series: 'kube_pod_container_status_ready{namespace="release-service", container="manager", source_cluster="stone-prod-p02"}'
+        values: '1 1x58'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: ReleaseServiceControllerManagerPodNotReady
         exp_alerts: []


### PR DESCRIPTION
This commit adds a new alert when the Release
Controller Manager Pod is in Not Ready state.

In addition it also changes the SLO alert for a 24h period, for less sensitivity.