### PR TITLE
feat: add availability alerts for the build team

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.build_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.build_service_alerts.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-build-service-github-app-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: build_service_github_app_alerts
+      interval: 1m
+      rules:
+        - alert: GitHubAppFailureAlert
+          expr: (konflux_up{service="build-service", check="github"} offset 1h) unless on(service, check, source_cluster) konflux_up{service="build-service", check="github"}
+          for: 1m
+          labels:
+            severity: warning
+          annotations:
+            summary: Availability metric 'konflux_up' is missing for GitHub App in {{ $labels.service }}.
+            description: >-
+              The 'konflux_up' availability metric is missing for GitHub App in {{ $labels.service }} on cluster {{ $labels.source_cluster }} indicating a possible service disruption.
+            team: build
+            alert_team_handle: <!subteam^S03DM1RL0TF>
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/build-service/availability_github_app.md

--- a/rhobs/alerting/data_plane/prometheus.image_controller_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.image_controller_alerts.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-image-controller-quay-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: image_controller_quay_alerts
+      interval: 1m
+      rules:
+        - alert: QuayFailureAlert
+          expr: (konflux_up{service="image-controller", check="quay"} offset 1h) unless on(service, check, source_cluster) konflux_up{service="image-controller", check="quay"}
+          for: 1m
+          labels:
+            severity: warning
+          annotations:
+            summary: Availability metric 'konflux_up' is missing for {{ $labels.check }} in {{ $labels.service }}.
+            description: >-
+              The 'konflux_up' availability metric is missing for {{ $labels.check }} in {{ $labels.service }} on cluster {{ $labels.source_cluster }} indicating a possible service disruption.
+            team: build
+            alert_team_handle: <!subteam^S03DM1RL0TF>
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/image-controller/availability_quay.md

--- a/test/promql/tests/data_plane/github_app_test.yaml
+++ b/test/promql/tests/data_plane/github_app_test.yaml
@@ -1,0 +1,67 @@
+rule_files:
+  - prometheus.build_service_alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # Check that the alert is triggered in build-service on check 'github'
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="build-service", check="github", source_cluster="prod"}'
+        values: '1x60 _x10 1x60'
+
+    alert_rule_test:
+      - eval_time: 66m
+        alertname: GitHubAppFailureAlert
+
+      - eval_time: 67m
+        alertname: GitHubAppFailureAlert
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              check: github
+              service: build-service
+              source_cluster: prod
+            exp_annotations:
+              summary: Availability metric 'konflux_up' is missing for GitHub App in build-service.
+              description: >-
+                The 'konflux_up' availability metric is missing for GitHub App in build-service on cluster prod indicating a possible service disruption.
+              team: build
+              alert_team_handle: <!subteam^S03DM1RL0TF>
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/build-service/availability_github_app.md
+
+      - eval_time: 75m
+        alertname: GitHubAppFailureAlert
+
+      - eval_time: 125m
+        alertname: GitHubAppFailureAlert
+
+  # Ensure the alert is not triggered on a different check than 'github'
+  - input_series:
+    - series: 'konflux_up{service="build-service", check="foo-check", source_cluster="prod"}'
+      values: '1x60 _x10 1x5'
+
+    alert_rule_test:
+      - eval_time: 66m
+        alertname: GitHubAppFailureAlert
+
+      - eval_time: 67m
+        alertname: GitHubAppFailureAlert
+
+      - eval_time: 75m
+        alertname: GitHubAppFailureAlert
+
+  # Ensure the alert is not triggered in a different service than 'build-service'
+  - input_series:
+      - series: 'konflux_up{service="foo-service", check="github", source_cluster="prod"}'
+        values: '1x60 _x10 1x5'
+
+    alert_rule_test:
+      - eval_time: 66m
+        alertname: GitHubAppFailureAlert
+
+      - eval_time: 67m
+        alertname: GitHubAppFailureAlert
+
+      - eval_time: 75m
+        alertname: GitHubAppFailureAlert

--- a/test/promql/tests/data_plane/quay_failure_test.yaml
+++ b/test/promql/tests/data_plane/quay_failure_test.yaml
@@ -1,0 +1,67 @@
+rule_files:
+  - prometheus.image_controller_alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # Check that the alert is triggered in image-controller on check 'quay'
+  - interval: 1m
+    input_series:
+      - series: konflux_up{service="image-controller", check="quay", source_cluster="prod"}
+        values: '1x60 _x10 1x60'
+
+    alert_rule_test:
+      - eval_time: 66m
+        alertname: QuayFailureAlert
+
+      - eval_time: 67m
+        alertname: QuayFailureAlert
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              check: quay
+              service: image-controller
+              source_cluster: prod
+            exp_annotations:
+              summary: Availability metric 'konflux_up' is missing for quay in image-controller.
+              description: >-
+                The 'konflux_up' availability metric is missing for quay in image-controller on cluster prod indicating a possible service disruption.
+              team: build
+              alert_team_handle: <!subteam^S03DM1RL0TF>
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/image-controller/availability_quay.md
+
+      - eval_time: 75m
+        alertname: QuayFailureAlert
+
+      - eval_time: 125m
+        alertname: QuayFailureAlert
+
+  # Ensure the alert is not triggered on a different check than 'quay'
+  - input_series:
+      - series: 'konflux_up{service="image-controller", check="foo-check", source_cluster="prod"}'
+        values: '1x60 _x10 1x5'
+
+    alert_rule_test:
+      - eval_time: 66m
+        alertname: QuayFailureAlert
+
+      - eval_time: 67m
+        alertname: QuayFailureAlert
+
+      - eval_time: 75m
+        alertname: QuayFailureAlert
+
+  # Ensure the alert is not triggered in a different service than 'image-controller'
+  - input_series:
+      - series: 'konflux_up{service="foo-service", check="quay", source_cluster="prod"}'
+        values: '1x60 _x10 1x5'
+
+    alert_rule_test:
+      - eval_time: 66m
+        alertname: QuayFailureAlert
+
+      - eval_time: 67m
+        alertname: QuayFailureAlert
+
+      - eval_time: 75m
+        alertname: QuayFailureAlert


### PR DESCRIPTION
- Add GitHubAppFailureAlert which should trigger when GitHub App is not working in build-service
- Add QuayFailureAlert which should trigger when Quay is not working in image-controller
- Add tests for both of the alerts which test that the alerts are not triggered on different checks and services than expected

Similar to https://github.com/redhat-appstudio/o11y/pull/353 which had to be reverted because the alerts were triggering in unexpected services and checks. 
- `(konflux_up offset 1h)` has been changed to  `konflux_up{service="build-service", check="github"} offset 1h)` (similarly for QuayFailureAlert) in the `expr` field which should result in the alerts triggering only on the correct combination of `service` and `check`
- `service` and `check` have been switched in the old PR, that is now fixed
- More tests have been added to test that the alerts are not triggered on different checks and services than expected