### PR TITLE
feat: demote the pipeline pod restart alert to a warning

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -15,8 +15,8 @@ spec:
             sum by (source_cluster) (increase(kube_pod_container_status_restarts_total{namespace="openshift-pipelines", pod=~"tekton-.*|pipelines-as-code-.*"}[5m])) > 0
           for: 5m
           labels:
-            severity: critical
-            slo: "true"
+            severity: warning
+            slo: "false"
           annotations:
             summary: >-
               Tekton controller is rapidly restarting.

--- a/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
@@ -21,8 +21,8 @@ tests:
         alertname: PipelinePodsRepeatedRestarts
         exp_alerts:
           - exp_labels:
-              severity: critical
-              slo: "true"
+              severity: warning
+              slo: "false"
               source_cluster: cluster01
             exp_annotations:
               summary: >-


### PR DESCRIPTION
This is related to https://github.com/redhat-appstudio/o11y/pull/411

In that PR, we added a new alert that fires when pods are in crashloopbackoff for more than 3 minutes. If they enter that state, something is definitely down.

The alert being modified in this change fires whenever pods restart more than once in a short period. Today, I observed this fire when the remote resolver controller pods all restarted a few times at the same time (4 pods, 2-3 restart each). They immediately recovered and began working happily. No perceived outage for users as far as I can tell.

If I understand that situation correctly, it means that this isn't really an SLO. It's more like a warning that can let us know if things are about to enter sustained crashloop backoff.