### PR TITLE
fix trailing comma in productization-transparency dashboard json

### DIFF
--- a/dashboards/grafana-dashboard-productization-transparency.configmap.yaml
+++ b/dashboards/grafana-dashboard-productization-transparency.configmap.yaml
@@ -73,7 +73,7 @@ data:
             "x": 12,
             "y": 0
           }
-        },
+        }
       ],
       "refresh": "",
       "schemaVersion": 1,


### PR DESCRIPTION
failure to load this dashboard in grafana:

```
logger=provisioning.dashboard type=file name=RHTAP t=2024-12-04T12:28:48.385451243Z level=error msg="failed to load dashboard from " file=/grafana-dashboard-definitions/RHTAP/namespace_app-sre-observability-production.configmap_grafana-dashboard-productization-transparency.productization-transparency.json error="invalid character ']' looking for beginning of value"
```