### PR TITLE
fix: Fix JSON error in productization transparency dashboard

### DIFF
--- a/dashboards/grafana-dashboard-productization-transparency.configmap.yaml
+++ b/dashboards/grafana-dashboard-productization-transparency.configmap.yaml
@@ -73,7 +73,7 @@ data:
             "x": 12,
             "y": 0
           }
-        },
+        }
       ],
       "refresh": "",
       "schemaVersion": 1,


### PR DESCRIPTION
This should resolve the dashboard not showing up in grafana

Signed-off-by: Paul Cho <pacho@redhat.com>