### PR TITLE
chore(KFLUXVNGD-136): record project-controller availability

### DIFF
--- a/rhobs/recording/project_controller_availability_recording_rules.yaml
+++ b/rhobs/recording/project_controller_availability_recording_rules.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-project-controller-availability
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: project_controller_availability
+      interval: 1m
+      rules:
+        # recorded value: 0 if spec is higher than available, 1 otherwise
+        # labels: check=replicas-available, service=<deployment-name>
+        - record: konflux_up
+          expr: |
+            clamp_max(
+              label_replace(
+                label_replace(
+                  floor(
+                    kube_deployment_status_replicas_available{
+                      namespace="project-controller"
+                    } / kube_deployment_spec_replicas
+                  ), "check", "replicas-available", "",""
+                ), "service", "$1", "deployment","(.*)"
+              ), 1
+            )

--- a/test/promql/tests/recording/project_controller_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/project_controller_availability_recording_rules_test.yaml
@@ -1,0 +1,79 @@
+evaluation_interval: 1m
+
+rule_files:
+  - project_controller_availability_recording_rules.yaml
+
+tests:
+  - name: ProjectControllerAvailabilityAllUpTest
+    interval: 1m
+    input_series:
+      - series: "kube_deployment_status_replicas_available{namespace='project-controller', deployment='d1'}"
+        values: "3 3 3 3 3"
+      - series: "kube_deployment_spec_replicas{namespace='project-controller', deployment='d1'}"
+        values: "3 3 3 3 3"
+
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{service='d1', check='replicas-available', namespace='project-controller', deployment='d1'}
+            value: 1
+
+  - name: ProjectControllerAvailabilitySomeUpTest
+    interval: 1m
+    input_series:
+      - series: "kube_deployment_status_replicas_available{namespace='project-controller', deployment='d1'}"
+        values: "2 2 2 2 2"
+      - series: "kube_deployment_spec_replicas{namespace='project-controller', deployment='d1'}"
+        values: "4 4 4 4 4"
+
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{service='d1', check='replicas-available', namespace='project-controller', deployment='d1'}
+            value: 0
+
+  - name: ProjectControllerAvailabilityMultipleDeploymentsTest
+    interval: 1m
+    input_series:
+      # should be up (c1)
+      - series: "kube_deployment_status_replicas_available{namespace='project-controller', deployment='d1', source_cluster='c1'}"
+        values: "1 1 1 1 1"
+      - series: "kube_deployment_spec_replicas{namespace='project-controller', deployment='d1', source_cluster='c1'}"
+        values: "1 1 1 1 1"
+
+      # should be down (c2)
+      - series: "kube_deployment_status_replicas_available{namespace='project-controller', deployment='d1', source_cluster='c2'}"
+        values: "0 0 0 0 0"
+      - series: "kube_deployment_spec_replicas{namespace='project-controller', deployment='d1', source_cluster='c2'}"
+        values: "1 1 1 1 1"
+
+      # should be up (another deployment from c1)
+      - series: "kube_deployment_status_replicas_available{namespace='project-controller', deployment='d2', source_cluster='c1'}"
+        values: "2 2 2 2 2"
+      - series: "kube_deployment_spec_replicas{namespace='project-controller', deployment='d2', source_cluster='c1'}"
+        values: "1 1 1 1 1"
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{service='d1', check='replicas-available', namespace='project-controller', deployment='d1', source_cluster='c1'}
+            value: 1
+          - labels: konflux_up{service='d1', check='replicas-available', namespace='project-controller', deployment='d1', source_cluster='c2'}
+            value: 0
+          - labels: konflux_up{service='d2', check='replicas-available', namespace='project-controller', deployment='d2', source_cluster='c1'}
+            value: 1
+
+  - name: ProjectControllerAbsent
+    interval: 1m
+    input_series:
+      - series: "kube_deployment_status_replicas_available{namespace='another-controller', deployment='d1'}"
+        values: "1 1 1 1 1"
+      - series: "kube_deployment_spec_replicas{namespace='another-controller', deployment='d1'}"
+        values: "1 1 1 1 1"
+
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples: []


### PR DESCRIPTION
Create a recording rule that translates the ratio between available replicas and spec replicas to project-controller's konflux_up metric.