### PR TITLE
feat(KONFLUX-5411): Increase alert limits for EtcdFsyncLatency and EtcdCommitLatency

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.performance_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.performance_alerts.yaml
@@ -12,7 +12,7 @@ spec:
         # ETCD alerts
         - alert: EtcdFsyncLatency
           expr: |
-            avg_over_time(histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[2m]))[10m:]) > 0.01
+            avg_over_time(histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[2m]))[10m:]) > 0.04
           for: 10m
           labels:
             severity: warning
@@ -20,12 +20,12 @@ spec:
             summary: >-
               ETCD slow file system synchronization.
             description: >-
-              10 minutes avg. 99th etcd fsync latency on {{$labels.pod}} higher than 10ms.
+              10 minutes avg. 99th etcd fsync latency on {{$labels.pod}} higher than 40ms.
             alert_routing_key: perfandscale
 
         - alert: EtcdCommitLatency
           expr: |
-            avg_over_time(histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))[10m:]) > 0.03
+            avg_over_time(histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))[10m:]) > 0.04
           for: 10m
           labels:
             severity: warning
@@ -33,7 +33,7 @@ spec:
             summary: >-
               ETCD slow writes observed.
             description: >-
-              10 minutes avg. 99th etcd commit latency on {{$labels.pod}} higher than 30ms.
+              10 minutes avg. 99th etcd commit latency on {{$labels.pod}} higher than 40ms.
             alert_routing_key: perfandscale
 
         - alert: EtcdProposalFailures

--- a/test/promql/tests/data_plane/performance_test.yaml
+++ b/test/promql/tests/data_plane/performance_test.yaml
@@ -7,8 +7,8 @@ tests:
   # Etcd Alerts
   - interval: 1m
     input_series:
-      # Average Fsync latency higher than 10ms, so it will be alerted.
-      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{le="0.02", pod="etcd-pod-1"}'
+      # Average Fsync latency higher than 40ms, so it will be alerted.
+      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{le="0.05", pod="etcd-pod-1"}'
         values: '0+0.01x15'
 
       - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{le="+Inf", pod="etcd-pod-1"}'
@@ -23,7 +23,7 @@ tests:
               pod: etcd-pod-1
             exp_annotations:
               summary: "ETCD slow file system synchronization."
-              description: "10 minutes avg. 99th etcd fsync latency on etcd-pod-1 higher than 10ms."
+              description: "10 minutes avg. 99th etcd fsync latency on etcd-pod-1 higher than 40ms."
               alert_routing_key: perfandscale
 
   - interval: 1m
@@ -39,8 +39,8 @@ tests:
 
   - interval: 1m
     input_series:
-      # Average commit latency higher than 30ms, so it will be alerted.
-      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{le="0.04", pod="etcd-pod-1"}'
+      # Average commit latency higher than 40ms, so it will be alerted.
+      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{le="0.05", pod="etcd-pod-1"}'
         values: '0+0.01x15'
 
       - series: 'etcd_disk_backend_commit_duration_seconds_bucket{le="+Inf", pod="etcd-pod-1"}'
@@ -55,7 +55,7 @@ tests:
               pod: etcd-pod-1
             exp_annotations:
               summary: "ETCD slow writes observed."
-              description: "10 minutes avg. 99th etcd commit latency on etcd-pod-1 higher than 30ms."
+              description: "10 minutes avg. 99th etcd commit latency on etcd-pod-1 higher than 40ms."
               alert_routing_key: perfandscale
 
   - interval: 1m


### PR DESCRIPTION
This PR increases the threshold limit for the ETCD alerts to **40ms** - **EtcdFsyncLatency** and **EtcdCommitLatency**.

Parent Story: https://issues.redhat.com/browse/KONFLUX-5411
