### PR TITLE
fix(PVO11Y-4589): fix routing variable for pipeline alerts

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -16,13 +16,12 @@ spec:
           for: 5m
           labels:
             severity: warning
-            slo: "false"
           annotations:
             summary: >-
               Tekton controller is rapidly restarting.
             description: >-
               Tekton controllers on cluster {{ $labels.source_cluster }} have restarted {{ $value }} times recently.
-            alert_team_handle: <!subteam^S04PYECHCCU>
+            alert_routing_key: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/sre/core-pipeline-controller-repeated-restarts.md
         - alert: PipelinePodsCrashLoopBackOff
@@ -235,7 +234,7 @@ spec:
             description: >-
               Tekton Resolver Bundle resolver leases not distributed across more than one pod
               on cluster {{ $labels.source_cluster }}.
-            alert_team_handle: <!subteam^S04PYECHCCU>
+            alert_routing_key: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
         - alert: TektonResolverBundleResolverLeasesHolderMissing
@@ -248,7 +247,7 @@ spec:
             description: >-
               Tekton Resolver Bundle resolver leases holder does not have pod assigned to it
               on cluster {{ $labels.source_cluster }}.
-            alert_team_handle: <!subteam^S04PYECHCCU>
+            alert_routing_key: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
         - alert: TektonResolverClusterResolverLeasesNotDistributed
@@ -261,7 +260,7 @@ spec:
             description: >-
               Tekton Resolver Cluster resolver leases not distributed across more than one pod
               on cluster {{ $labels.source_cluster }}.
-            alert_team_handle: <!subteam^S04PYECHCCU>
+            alert_routing_key: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
         - alert: TektonResolverClusterResolverLeasesHolderMissing
@@ -274,7 +273,7 @@ spec:
             description: >-
               Tekton Resolver Cluster resolver leases holder does not have pod assigned to it
               on cluster {{ $labels.source_cluster }}.
-            alert_team_handle: <!subteam^S04PYECHCCU>
+            alert_routing_key: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
         - alert: TektonResolverGitResolverLeasesNotDistributed
@@ -287,7 +286,7 @@ spec:
             description: >-
               Tekton Resolver Git resolver leases not distributed across more than one pod
               on cluster {{ $labels.source_cluster }}.
-            alert_team_handle: <!subteam^S04PYECHCCU>
+            alert_routing_key: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
         - alert: TektonResolverGitResolverLeasesHolderMissing
@@ -300,7 +299,7 @@ spec:
             description: >-
               Tekton Resolver Git resolver leases holder does not have pod assigned to it
               on cluster {{ $labels.source_cluster }}.
-            alert_team_handle: <!subteam^S04PYECHCCU>
+            alert_routing_key: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
         - alert: TektonResolverHttpResolverLeasesNotDistributed
@@ -313,7 +312,7 @@ spec:
             description: >-
               Tekton Resolver Http resolver leases not distributed across more than one pod
               on cluster {{ $labels.source_cluster }}.
-            alert_team_handle: <!subteam^S04PYECHCCU>
+            alert_routing_key: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
         - alert: TektonResolverHttpResolverLeasesHolderMissing
@@ -326,7 +325,7 @@ spec:
             description: >-
               Tekton Resolver Http resolver leases holder does not have pod assigned to it
               on cluster {{ $labels.source_cluster }}.
-            alert_team_handle: <!subteam^S04PYECHCCU>
+            alert_routing_key: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
         - alert: TektonResolverHubResolverLeasesNotDistributed
@@ -339,7 +338,7 @@ spec:
             description: >-
               Tekton Resolver Hub resolver leases not distributed across more than one pod
               on cluster {{ $labels.source_cluster }}.
-            alert_team_handle: <!subteam^S04PYECHCCU>
+            alert_routing_key: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
         - alert: TektonResolverHubResolverLeasesHolderMissing
@@ -352,6 +351,6 @@ spec:
             description: >-
               Tekton Resolver Hub resolver leases holder does not have pod assigned to it
               on cluster {{ $labels.source_cluster }}.
-            alert_team_handle: <!subteam^S04PYECHCCU>
+            alert_routing_key: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md

--- a/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
@@ -22,14 +22,13 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: warning
-              slo: "false"
               source_cluster: cluster01
             exp_annotations:
               summary: >-
                 Tekton controller is rapidly restarting.
               description: >-
                 Tekton controllers on cluster cluster01 have restarted 15 times recently.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/sre/core-pipeline-controller-repeated-restarts.md
 

--- a/test/promql/tests/data_plane/pipeline_leases_distribution_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_leases_distribution_test.yaml
@@ -567,7 +567,7 @@ tests:
               description: >-
                 Tekton Resolver Bundle resolver leases not distributed across more than one pod
                 on cluster cluster01.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
   - interval: 1m
@@ -604,7 +604,7 @@ tests:
               description: >-
                 Tekton Resolver Bundle resolver leases not distributed across more than one pod
                 on cluster cluster01.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
           - exp_labels:
@@ -615,7 +615,7 @@ tests:
               description: >-
                 Tekton Resolver Bundle resolver leases not distributed across more than one pod
                 on cluster cluster02.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
   # ----- Tekton Resolver Bundle resolver leases not distributed across more than one pod Tests ----
@@ -669,7 +669,7 @@ tests:
               description: >-
                 Tekton Resolver Bundle resolver leases holder does not have pod assigned to it
                 on cluster cluster01.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
   # ----- Tekton Resolver Bundle resolver leases holder does not have pod assigned to it Tests ----
@@ -777,7 +777,7 @@ tests:
               description: >-
                 Tekton Resolver Cluster resolver leases not distributed across more than one pod
                 on cluster cluster01.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
   - interval: 1m
@@ -814,7 +814,7 @@ tests:
               description: >-
                 Tekton Resolver Cluster resolver leases not distributed across more than one pod
                 on cluster cluster01.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
           - exp_labels:
@@ -825,7 +825,7 @@ tests:
               description: >-
                 Tekton Resolver Cluster resolver leases not distributed across more than one pod
                 on cluster cluster02.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
   # ----- Tekton Resolver Cluster resolver leases not distributed across more than one pod Tests ----
@@ -879,7 +879,7 @@ tests:
               description: >-
                 Tekton Resolver Cluster resolver leases holder does not have pod assigned to it
                 on cluster cluster01.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
   # ----- Tekton Resolver Cluster resolver leases holder does not have pod assigned to it Tests ----
@@ -987,7 +987,7 @@ tests:
               description: >-
                 Tekton Resolver Git resolver leases not distributed across more than one pod
                 on cluster cluster01.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
   - interval: 1m
@@ -1024,7 +1024,7 @@ tests:
               description: >-
                 Tekton Resolver Git resolver leases not distributed across more than one pod
                 on cluster cluster01.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
           - exp_labels:
@@ -1035,7 +1035,7 @@ tests:
               description: >-
                 Tekton Resolver Git resolver leases not distributed across more than one pod
                 on cluster cluster02.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
   # ----- Tekton Resolver Git resolver leases not distributed across more than one pod Tests ----
@@ -1089,7 +1089,7 @@ tests:
               description: >-
                 Tekton Resolver Git resolver leases holder does not have pod assigned to it
                 on cluster cluster01.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
   # ----- Tekton Resolver Git resolver leases holder does not have pod assigned to it Tests ----
@@ -1197,7 +1197,7 @@ tests:
               description: >-
                 Tekton Resolver Http resolver leases not distributed across more than one pod
                 on cluster cluster01.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
   - interval: 1m
@@ -1234,7 +1234,7 @@ tests:
               description: >-
                 Tekton Resolver Http resolver leases not distributed across more than one pod
                 on cluster cluster01.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
           - exp_labels:
@@ -1245,7 +1245,7 @@ tests:
               description: >-
                 Tekton Resolver Http resolver leases not distributed across more than one pod
                 on cluster cluster02.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
   # ----- Tekton Resolver Http resolver leases not distributed across more than one pod Tests ----
@@ -1299,7 +1299,7 @@ tests:
               description: >-
                 Tekton Resolver Http resolver leases holder does not have pod assigned to it
                 on cluster cluster01.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
   # ----- Tekton Resolver Http resolver leases holder does not have pod assigned to it Tests ----
@@ -1407,7 +1407,7 @@ tests:
               description: >-
                 Tekton Resolver Hub resolver leases not distributed across more than one pod
                 on cluster cluster01.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
   - interval: 1m
@@ -1444,7 +1444,7 @@ tests:
               description: >-
                 Tekton Resolver Hub resolver leases not distributed across more than one pod
                 on cluster cluster01.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
           - exp_labels:
@@ -1455,7 +1455,7 @@ tests:
               description: >-
                 Tekton Resolver Hub resolver leases not distributed across more than one pod
                 on cluster cluster02.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
   # ----- Tekton Resolver Hub resolver leases not distributed across more than one pod Tests ----
@@ -1509,7 +1509,7 @@ tests:
               description: >-
                 Tekton Resolver Hub resolver leases holder does not have pod assigned to it
                 on cluster cluster01.
-              alert_team_handle: <!subteam^S04PYECHCCU>
+              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-LeasesNotDistributed.md
   # ----- Tekton Resolver Hub resolver leases holder does not have pod assigned to it Tests ----


### PR DESCRIPTION
Fix routing to have correct routing variable for non slo alerts from pipeline alerts, not to ping o11y. 

Signed-off-by: Tomas Behal [tbehal@redhat.com](mailto:tbehal@redhat.com)