### PR TITLE
chore(STONEINTG-1042): downgrade integration alerts

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.latency_release_creation_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_release_creation_alerts.yaml
@@ -21,8 +21,8 @@ spec:
         ) > 0.10
       for: 10m
       labels:
-        severity: critical
-        slo: "true"
+        severity: high
+        slo: "false"
       annotations:
         summary: >-
           Latency of release creation time exceeded

--- a/rhobs/alerting/data_plane/prometheus.latency_snapshot_to_static_integration_plr_creation_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.latency_snapshot_to_static_integration_plr_creation_alerts.yaml
@@ -21,8 +21,8 @@ spec:
         ) > 0.10
       for: 10m
       labels:
-        severity: critical
-        slo: "true"
+        severity: high
+        slo: "false"
       annotations:
         summary: >-
           Latency from an application snapshot created to integration PLRs in static envs created

--- a/test/promql/tests/data_plane/latency_release_creation_test.yaml
+++ b/test/promql/tests/data_plane/latency_release_creation_test.yaml
@@ -23,8 +23,8 @@ tests:
         alertname: LatencyReleaseCreation
         exp_alerts:
           - exp_labels:
-              severity: critical
-              slo: "true"
+              severity: high
+              slo: "false"
               source_cluster: cluster01
             exp_annotations:
               summary: Latency of release creation time exceeded
@@ -57,8 +57,8 @@ tests:
         alertname: LatencyReleaseCreation
         exp_alerts:
           - exp_labels:
-              severity: critical
-              slo: "true"
+              severity: high
+              slo: "false"
               source_cluster: cluster01
             exp_annotations:
               summary: Latency of release creation time exceeded
@@ -70,8 +70,8 @@ tests:
               team: integration
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/latency_release_creation.md
           - exp_labels:
-              severity: critical
-              slo: "true"
+              severity: high
+              slo: "false"
               source_cluster: cluster02
             exp_annotations:
               summary: Latency of release creation time exceeded

--- a/test/promql/tests/data_plane/latency_snapshot_to_static_integration_plr_creation_test.yaml
+++ b/test/promql/tests/data_plane/latency_snapshot_to_static_integration_plr_creation_test.yaml
@@ -23,8 +23,8 @@ tests:
         alertname: LatencySnapshotToStaticIntegrationPLRCreation
         exp_alerts:
           - exp_labels:
-              severity: critical
-              slo: "true"
+              severity: high
+              slo: "false"
               source_cluster: cluster01
             exp_annotations:
               summary: Latency from an application snapshot created to integration PLRs in static envs created
@@ -57,8 +57,8 @@ tests:
         alertname: LatencySnapshotToStaticIntegrationPLRCreation
         exp_alerts:
           - exp_labels:
-              severity: critical
-              slo: "true"
+              severity: high
+              slo: "false"
               source_cluster: cluster01
             exp_annotations:
               summary: Latency from an application snapshot created to integration PLRs in static envs created
@@ -70,8 +70,8 @@ tests:
               team: integration
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/latency_snapshot_to_integration_test_static.md
           - exp_labels:
-              severity: critical
-              slo: "true"
+              severity: high
+              slo: "false"
               source_cluster: cluster02
             exp_annotations:
               summary: Latency from an application snapshot created to integration PLRs in static envs created


### PR DESCRIPTION
* Downgrade `Latency Release creation` alert to high to reflect the lack of SRE-actionable SOP
* Downgrade `Latency Snapshot to PLR created` alert to high to reflect the lack of SRE-actionable SOP

Signed-off-by: dirgim <kpavic@redhat.com>