### PR TITLE
ci: Update kube-linter container image

### DIFF
--- a/.tekton/kube-linter-oci-ta.yaml
+++ b/.tekton/kube-linter-oci-ta.yaml
@@ -81,7 +81,7 @@ spec:
           echo "No config file url was set"
          fi
     - name: lint-yaml
-      image: docker.io/stackrox/kube-linter:0.2.2-2-g7d10a69154-alpine@sha256:e520e9d8d3a2dfa611914836536545b135845e7bda9f1df34b060e116232dbf0
+      image: ghcr.io/stackrox/kube-linter:v0.7.1-alpine@sha256:d8d21654b7a1929c4842e0720813793059242eb0ad60837dc72b978550afe3dd
       script: |
         if [ -n "$(params.config_file_path)" ]
         then


### PR DESCRIPTION
Use a newer version of kube-linter and switch over to ghcr.io to avoid issues with rate limits.

Signed-off-by: Paul Cho <pacho@redhat.com>