### PR TITLE
Removing JAVA_COMMUNITY_DEPENDENCIES from result, migration of buildah task from .2 to .3

### DIFF
--- a/.tekton/o11y-pull-request.yaml
+++ b/.tekton/o11y-pull-request.yaml
@@ -140,9 +140,6 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
     - name: rpms-signature-scan
       params:

--- a/.tekton/o11y-push.yaml
+++ b/.tekton/o11y-push.yaml
@@ -131,9 +131,6 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
     - name: rpms-signature-scan
       params:


### PR DESCRIPTION
Removing  JAVA_COMMUNITY_DEPENDENCIES