### PR TITLE
feat(KONFLUX-4930): add availability rule for namespace-lister

### DIFF
--- a/rhobs/recording/namespace_lister_availability_recording_rules.yaml
+++ b/rhobs/recording/namespace_lister_availability_recording_rules.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-namespace-lister-availability
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: namespace_lister_availability
+      interval: 1m
+      rules:
+        # recorded value: 0 if spec is higher than available, 1 otherwise
+        # labels: check=replicas-available, service=<deployment-name>
+        - record: konflux_up
+          expr: |
+            clamp_max(
+              label_replace(
+                label_replace(
+                  floor(
+                    kube_deployment_status_replicas_available{
+                      namespace="namespace-lister"
+                    } / kube_deployment_spec_replicas
+                  ), "check", "replicas-available", "",""
+                ), "service", "$1", "deployment","(.*)"
+              ), 1
+            )

--- a/test/promql/tests/recording/namespace_lister_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/namespace_lister_availability_recording_rules_test.yaml
@@ -1,0 +1,79 @@
+evaluation_interval: 1m
+
+rule_files:
+  - namespace_lister_availability_recording_rules.yaml
+
+tests:
+  - name: NamespaceListerAvailabilityAllUpTest
+    interval: 1m
+    input_series:
+      - series: "kube_deployment_status_replicas_available{namespace='namespace-lister', deployment='d1'}"
+        values: "3 3 3 3 3"
+      - series: "kube_deployment_spec_replicas{namespace='namespace-lister', deployment='d1'}"
+        values: "3 3 3 3 3"
+
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{service='d1', check='replicas-available', namespace='namespace-lister', deployment='d1'}
+            value: 1
+
+  - name: NamespaceListerAvailabilitySomeUpTest
+    interval: 1m
+    input_series:
+      - series: "kube_deployment_status_replicas_available{namespace='namespace-lister', deployment='d1'}"
+        values: "2 2 2 2 2"
+      - series: "kube_deployment_spec_replicas{namespace='namespace-lister', deployment='d1'}"
+        values: "4 4 4 4 4"
+
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{service='d1', check='replicas-available', namespace='namespace-lister', deployment='d1'}
+            value: 0
+
+  - name: NamespaceListerAvailabilityMultipleDeploymentsTest
+    interval: 1m
+    input_series:
+      # should be up (c1)
+      - series: "kube_deployment_status_replicas_available{namespace='namespace-lister', deployment='d1', source_cluster='c1'}"
+        values: "1 1 1 1 1"
+      - series: "kube_deployment_spec_replicas{namespace='namespace-lister', deployment='d1', source_cluster='c1'}"
+        values: "1 1 1 1 1"
+
+      # should be down (c2)
+      - series: "kube_deployment_status_replicas_available{namespace='namespace-lister', deployment='d1', source_cluster='c2'}"
+        values: "0 0 0 0 0"
+      - series: "kube_deployment_spec_replicas{namespace='namespace-lister', deployment='d1', source_cluster='c2'}"
+        values: "1 1 1 1 1"
+
+      # should be up (another deployment from c1)
+      - series: "kube_deployment_status_replicas_available{namespace='namespace-lister', deployment='d2', source_cluster='c1'}"
+        values: "2 2 2 2 2"
+      - series: "kube_deployment_spec_replicas{namespace='namespace-lister', deployment='d2', source_cluster='c1'}"
+        values: "1 1 1 1 1"
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{service='d1', check='replicas-available', namespace='namespace-lister', deployment='d1', source_cluster='c1'}
+            value: 1
+          - labels: konflux_up{service='d1', check='replicas-available', namespace='namespace-lister', deployment='d1', source_cluster='c2'}
+            value: 0
+          - labels: konflux_up{service='d2', check='replicas-available', namespace='namespace-lister', deployment='d2', source_cluster='c1'}
+            value: 1
+
+  - name: NamespaceListerAbsent
+    interval: 1m
+    input_series:
+      - series: "kube_deployment_status_replicas_available{namespace='another-controller', deployment='d1'}"
+        values: "1 1 1 1 1"
+      - series: "kube_deployment_spec_replicas{namespace='another-controller', deployment='d1'}"
+        values: "1 1 1 1 1"
+
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples: []


### PR DESCRIPTION
Add a `konflux_up` metric for namespace-lister, which is a dependency of the new UI for konflux.

See [ASC-803](https://issues.redhat.com/browse/ASC-803) for details.