### PR TITLE
chore: ignore PodNotReady alerts in mintmaker namespace

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
@@ -36,7 +36,7 @@ spec:
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-crashLoopBackOff.md
     - alert: PodNotReady
       expr: |
-            kube_pod_status_phase{phase=~"Pending|Unknown|Failed", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci)"} == 1
+            kube_pod_status_phase{phase=~"Pending|Unknown|Failed", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci|mintmaker)"} == 1
             unless ignoring (phase) (kube_pod_status_unschedulable == 1)
       for: 30m
       labels:

--- a/test/promql/tests/data_plane/notready_pods_test.yaml
+++ b/test/promql/tests/data_plane/notready_pods_test.yaml
@@ -205,6 +205,12 @@ tests:
       - series: 'kube_pod_status_unschedulable{namespace="konflux-ci", pod="test-pod", source_cluster="cluster01"}'
         values: '0x29'
 
+      # Pod is in the Pending state and scheduled, but it's in the 'mintmaker' namespace so it's ignored.
+      - series: 'kube_pod_status_phase{pod="renovate-123-pod", namespace="mintmaker", phase="Pending"}'
+        values: '1x29'
+      - series: 'kube_pod_status_unschedulable{namespace="mintmaker", pod="renovate-123-pod", source_cluster="cluster01"}'
+        values: '0x29'
+
     alert_rule_test:
       - eval_time: 30m
         alertname: PodNotReady


### PR DESCRIPTION
mintmaker runs pipelineruns for users within its own namespace, these pipelineruns are renovate jobs, we don't need to be alerted about such errors.