### PR TITLE
chore: name and condition change for ChainsControllerDeadlock alert

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -85,18 +85,18 @@ spec:
             alert_team_handle: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/sre/tekton-pipeline-related-deadlocks.md
-        - alert: ChainsControllerDeadlock
+        - alert: ChainsControllerOverhead
           expr: |
-            sum by (source_cluster) (increase(watcher_workqueue_depth{container='tekton-chains-controller',app='tekton-chains-controller'}[2m])) > 50
-          for: 75m
+            sum by (source_cluster) (increase(watcher_workqueue_depth{container='tekton-chains-controller',app='tekton-chains-controller'}[2m])) > 100
+          for: 55m
           labels:
             severity: critical
             slo: "true"
           annotations:
             summary: >-
-              Tekton chains controller appears to have stopped processing active pipelineruns.
+              Tekton chains controller is experiencing high overhead in processing pipelineruns.
             description: >-
-              Tekton chains controller on cluster {{ $labels.source_cluster }} has appeared deadlocked on {{ $value }} pipelinerun events.
+              Tekton chains controller on cluster {{ $labels.source_cluster }} has recorded {{ $value }} pipelinerun events. This suggests potential performance degradation and a risk of an eventual deadlock condition.
             alert_team_handle: <!subteam^S04PYECHCCU>
             team: pipelines
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/sre/tekton-pipeline-related-deadlocks.md

--- a/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
@@ -258,47 +258,6 @@ tests:
       - eval_time: 10m
         alertname: ResolverControllerDeadlock
 
-  # ----- Chains Controller Potential Deadlock ----
-  - interval: 1m
-    input_series:
-
-      # see https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/ for explanations of the expanding notation used for the values
-      # tekton chains controller is experiencing delays processing pipelineruns in tenant-1 started and should alert.  Also make sure the lack
-      # of issues in another app does not affect the value of the query
-      - series: 'watcher_workqueue_depth{container="tekton-chains-controller", app="tekton-chains-controller", source_cluster="cluster01"}'
-        values: '300+300x780'
-      - series: 'watcher_workqueue_depth{container="tekton-pipelines-controller", app="tekton-pipelines-controller", source_cluster="cluster01"}'
-        values: '0x780'
-
-    alert_rule_test:
-      - eval_time: 85m
-        alertname: ChainsControllerDeadlock
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-              slo: "true"
-              source_cluster: cluster01
-            exp_annotations:
-              summary: >-
-                Tekton chains controller appears to have stopped processing active pipelineruns.
-              description: >-
-                Tekton chains controller on cluster cluster01 has appeared deadlocked on 600 pipelinerun events.
-              alert_team_handle: <!subteam^S04PYECHCCU>
-              team: pipelines
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/sre/tekton-pipeline-related-deadlocks.md
-
-  - interval: 1m
-    input_series:
-
-      # see https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/ for explanations of the expanding notation used for the values
-      # tekton chains controller is experiencing some delays processing pipelineruns but not fast enough so it should not alert
-      - series: 'watcher_workqueue_depth{container="tekton-chains-controller", app="tekton-chains-controller", source_cluster="cluster01"}'
-        values: '1x780'
-
-    alert_rule_test:
-      - eval_time: 10m
-        alertname: ChainsControllerDeadlock
-
   # ----- Results Potential Deadlock ----
   - interval: 1m
     input_series:
@@ -408,4 +367,4 @@ tests:
 
     alert_rule_test:
       - eval_time: 10m
-        alertname: ChainsControllerDeadlock
+        alertname: PACControllerDeadlock

--- a/test/promql/tests/data_plane/pipeline_overhead_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_overhead_test.yaml
@@ -113,3 +113,44 @@ tests:
         values: '1x780'
       - series: 'pac_watcher_client_latency_bucket{le="+Inf", source_cluster="cluster02"}'
         values: '1x780'
+
+  # ----- Chains Controller Overhead Test----
+  - interval: 1m
+    input_series:
+
+      # see https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/ for explanations of the expanding notation used for the values
+      # tekton chains controller is experiencing delays processing pipelineruns in tenant-1 started and should alert.  Also make sure the lack
+      # of issues in another app does not affect the value of the query
+      - series: 'watcher_workqueue_depth{container="tekton-chains-controller", app="tekton-chains-controller", source_cluster="cluster01"}'
+        values: '300+300x780'
+      - series: 'watcher_workqueue_depth{container="tekton-pipelines-controller", app="tekton-pipelines-controller", source_cluster="cluster01"}'
+        values: '0x780'
+
+    alert_rule_test:
+      - eval_time: 75m
+        alertname: ChainsControllerOverhead
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo: "true"
+              source_cluster: cluster01
+            exp_annotations:
+              summary: >-
+                Tekton chains controller is experiencing high overhead in processing pipelineruns.
+              description: >-
+                Tekton chains controller on cluster cluster01 has recorded 600 pipelinerun events. This suggests potential performance degradation and a risk of an eventual deadlock condition.
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/sre/tekton-pipeline-related-deadlocks.md
+
+  - interval: 1m
+    input_series:
+
+      # see https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/ for explanations of the expanding notation used for the values
+      # tekton chains controller is experiencing some delays processing pipelineruns but not fast enough so it should not alert
+      - series: 'watcher_workqueue_depth{container="tekton-chains-controller", app="tekton-chains-controller", source_cluster="cluster01"}'
+        values: '1x780'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ChainsControllerOverhead


### PR DESCRIPTION
Changed alert name to ChainsControllerOverhead. Updated the alert conditions by increasing the threshold from 50 to 100 and reducing the required duration from 75m to 45m. This change aims to improve the alert's precision by reducing false positives and ensuring that only more critical cases trigger alerts. This change aims to improve precision by reducing false positives and ensuring that only critical cases trigger alerts.