### PR TITLE
Update README.md to fix broken docs link in SOPs

### DIFF
--- a/exporters/dsexporter/README.md
+++ b/exporters/dsexporter/README.md
@@ -8,7 +8,7 @@ another system/component.
 ## Availability Exporter
 
 In the context of the Konflux ecosystem, the `dsexporter` serves as an 
-[Availability Exporter](https://gitlab.cee.redhat.com/konflux/docs/documentation/-/blob/main/o11y/monitoring/availability_exporters.md),
+[Availability Exporter](https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/monitoring/availability_exporters.md),
 contributing to the evaluation of the availability of each component within the system.
 By exposing this metric, it allows for monitoring and analyzing the 
 workload and performance of the associated service.


### PR DESCRIPTION
The old link pointed at a repo that didn't have the availability_exporters.md any more. I've updated it to point to the doc in our SOP documentation instead.