### PR TITLE
Pod exceeding cpu & memory requested alerts

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
@@ -49,3 +49,37 @@ spec:
           {{ $labels.source_cluster }} is not ready for more than 30 minutes.
         alert_routing_key: '{{ $labels.namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-PodNotReady.md
+
+    - alert: PodMemoryUsageExceedsRequested
+      expr: |
+        avg_over_time(container_memory_usage_bytes{namespace="appstudio-grafana"}[5m])
+        > on(namespace, pod, container, source_cluster)
+        kube_pod_container_resource_requests{resource="memory", namespace="appstudio-grafana"}
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        team: o11y
+        slo: "false"
+        summary: >-
+          Pod {{ $labels.pod }} memory usage is exceeding the requested resource.
+        description: >-
+          Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster
+          {{ $labels.source_cluster }} has been running above the requested memory resources.
+
+    - alert: PodCPUUsageExceedsRequested
+      expr: |
+        avg_over_time(container_cpu_usage_seconds_total{namespace="appstudio-grafana"}[5m])
+        > on(namespace, pod, container, source_cluster)
+        kube_pod_container_resource_requests{resource="cpu", namespace="appstudio-grafana"}
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        team: o11y
+        slo: "false"
+        summary: >-
+          Pod {{ $labels.pod }} cpu usage is exceeding the requested resource.
+        description: >-
+          Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster
+          {{ $labels.source_cluster }} has been running above the requested cpu resources.

--- a/test/promql/tests/data_plane/exceeding_requested_resources_test.yaml
+++ b/test/promql/tests/data_plane/exceeding_requested_resources_test.yaml
@@ -1,0 +1,60 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.pod_alerts.yaml
+
+tests:
+  - interval: 1m
+    input_series:
+
+      # CPU exceeding requested
+      - series: 'container_cpu_usage_seconds_total{namespace="appstudio-grafana", pod="prod-pod-1", container="test-container-1", source_cluster="cluster01"}'
+        values: '2x10'
+
+      - series: 'kube_pod_container_resource_requests{resource="cpu", namespace="appstudio-grafana", pod="prod-pod-1", container="test-container-1", source_cluster="cluster01"}'
+        values: '1x10'
+
+    alert_rule_test:
+      - alertname: PodCPUUsageExceedsRequested
+        eval_time: 10m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              namespace: appstudio-grafana
+              pod: prod-pod-1
+              container: test-container-1
+              source_cluster: cluster01
+            exp_annotations:
+              slo: false
+              team: o11y
+              summary: Pod prod-pod-1 cpu usage is exceeding the requested resource.
+              description: >-
+                Pod prod-pod-1 in namespace appstudio-grafana on cluster
+                cluster01 has been running above the requested cpu resources.
+  - interval: 1m
+    input_series:
+
+      # Memory exceeding requested
+      - series: 'container_memory_usage_bytes{namespace="appstudio-grafana", pod="prod-pod-2", container="test-container-2", source_cluster="cluster01"}'
+        values: '2x10'
+
+      - series: 'kube_pod_container_resource_requests{resource="memory", namespace="appstudio-grafana", pod="prod-pod-2", container="test-container-2", source_cluster="cluster01"}'
+        values: '1x10'
+
+    alert_rule_test:
+      - alertname: PodMemoryUsageExceedsRequested
+        eval_time: 10m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              namespace: appstudio-grafana
+              pod: prod-pod-2
+              container: test-container-2
+              source_cluster: cluster01
+            exp_annotations:
+              slo: false
+              team: o11y
+              summary: Pod prod-pod-2 memory usage is exceeding the requested resource.
+              description: >-
+                Pod prod-pod-2 in namespace appstudio-grafana on cluster
+                cluster01 has been running above the requested memory resources.


### PR DESCRIPTION
[PVO11Y-4645](https://issues.redhat.com/browse/PVO11Y-4645)

This is to warn of pods running above what they requested which puts them at the risk of being evicted in the case of cluster pressure, not only that but it also should signal a change in the behaviour of the pod and might require a revision of the requested resources.