### PR TITLE
MPC and MintMaker alerts

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
@@ -1,0 +1,53 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-mintmaker-controller-availability-alerting-rules
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: mintmaker-controller-availability
+    interval: 1m
+    rules:
+    - alert: MintMakerControllerDown
+      expr: |
+        konflux_up{
+          namespace="mintmaker",
+          check="replicas-available",
+          service="mintmaker-controller-manager"
+        } != 1
+      for: 5m
+      labels:
+        severity: critical
+        slo: "true"
+      annotations:
+        summary: >-
+          MintMaker controller is down in cluster {{ $labels.source_cluster }}
+        description: >
+          The MintMaker controller pod has been down for 5min in cluster {{ $labels.source_cluster }}
+        alert_team_handle: <!subteam^S078T8TMQP5>
+        team: mintmaker
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md
+
+  - name: mintmaker-cache-availability
+    interval: 1m
+    rules:
+    - alert: MintMakerCacheDown
+      expr: |
+        konflux_up{
+          namespace="mintmaker",
+          check="replicas-available",
+          service="redis"
+        } != 1
+      for: 5m
+      labels:
+        severity: critical
+        slo: "true"
+      annotations:
+        summary: >-
+          MintMaker cache is down in cluster {{ $labels.source_cluster }}
+        description: >
+          The MintMaker cache pod (redis) has been down for 5min in cluster {{ $labels.source_cluster }}
+        alert_team_handle: <!subteam^S078T8TMQP5>
+        team: mintmaker
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md

--- a/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml
@@ -1,0 +1,51 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-multiplatform-availability-alerting-rules
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: multi-platform-controller-availability
+    interval: 1m
+    rules:
+    - alert: MultiPlatformControllerDown
+      expr: |
+        konflux_up{
+          namespace="multi-platform-controller",
+          check="replicas-available",
+          service="multi-platform-controller"
+        } != 1
+      for: 5m
+      labels:
+        severity: critical
+        slo: "true"
+      annotations:
+        summary: >-
+          Multiplatform controller is down in cluster {{ $labels.source_cluster }}
+        description: >
+          The multi-platform-controller pod has been down for 5min in cluster {{ $labels.source_cluster }}
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+  - name: multi-platform-otp-availability
+    interval: 1m
+    rules:
+    - alert: MuiltiPlatformOTPDown
+      expr: |
+        konflux_up{
+          namespace="multi-platform-controller",
+          check="replicas-available",
+          service="multi-platform-otp-server"
+        } != 1
+      for: 5m
+      labels:
+        severity: critical
+        slo: "true"
+      annotations:
+        summary: >-
+          Multiplatform OTP is down in cluster {{ $labels.source_cluster }}
+        description: >
+          The multi-platform otp pod has been down for 5min in cluster {{ $labels.source_cluster }}
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra

--- a/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
+++ b/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
@@ -1,0 +1,57 @@
+evaluation_interval: 1m
+
+rule_files:
+  - 'prometheus.mintmaker_controller_up_alerts.yaml'
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="mintmaker-controller-manager", source_cluster="c1"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="mintmaker-controller-manager", source_cluster="c2"}'
+        values: '1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: MintMakerControllerDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: mintmaker
+              service: mintmaker-controller-manager
+              slo: "true"
+              source_cluster: c1
+            exp_annotations:
+              summary: MintMaker controller is down in cluster c1
+              description: >
+                The MintMaker controller pod has been down for 5min in cluster c1
+              alert_team_handle: <!subteam^S078T8TMQP5>
+              team: mintmaker
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md
+
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="redis", source_cluster="c3"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="redis", source_cluster="c4"}'
+        values: '1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: MintMakerCacheDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: mintmaker
+              service: redis
+              slo: "true"
+              source_cluster: c3
+            exp_annotations:
+              summary: MintMaker cache is down in cluster c3
+              description: >
+                The MintMaker cache pod (redis) has been down for 5min in cluster c3
+              alert_team_handle: <!subteam^S078T8TMQP5>
+              team: mintmaker
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md

--- a/test/promql/tests/data_plane/multi_platform_alerts_test.yaml
+++ b/test/promql/tests/data_plane/multi_platform_alerts_test.yaml
@@ -1,0 +1,55 @@
+evaluation_interval: 1m
+
+rule_files:
+  - 'prometheus.multi_platform_alerts.yaml'
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="multi-platform-controller", check="replicas-available", service="multi-platform-controller", source_cluster="c1"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="multi-platform-controller", check="replicas-available", service="multi-platform-controller", source_cluster="c2"}'
+        values: '1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: MultiPlatformControllerDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: multi-platform-controller
+              service: multi-platform-controller
+              slo: "true"
+              source_cluster: c1
+            exp_annotations:
+              summary: Multiplatform controller is down in cluster c1
+              description: >
+                The multi-platform-controller pod has been down for 5min in cluster c1
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra
+
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="multi-platform-controller", check="replicas-available", service="multi-platform-otp-server", source_cluster="c3"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="multi-platform-controller", check="replicas-available", service="multi-platform-otp-server", source_cluster="c4"}'
+        values: '1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: MuiltiPlatformOTPDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: multi-platform-controller
+              service: multi-platform-otp-server
+              slo: "true"
+              source_cluster: c3
+            exp_annotations:
+              summary: Multiplatform OTP is down in cluster c3
+              description: >
+                The multi-platform otp pod has been down for 5min in cluster c3
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra


### PR DESCRIPTION
Adding alerts rules for MintMaker and MPC konflux_up recordings
Adding unit tests for those alert rules
    
These are done using Prometheus yamls. This is part of an effort to  enhance Konflux observability, help in incident  response, and provide  a better user experience.

Signed-off-by: Mário Fernandes <mfoganho@redhat.com>

IMPORTANT: merge after https://github.com/redhat-appstudio/o11y/pull/552