### PR TITLE
fix(KFLUXVNGD-319): make project-controller alarm less sensitive

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.project_controller_up_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.project_controller_up_alerts.yaml
@@ -16,7 +16,7 @@ spec:
           check="replicas-available",
           service="project-controller-controller-manager"
         } != 1
-      for: 2m
+      for: 10m
       labels:
         severity: critical
         slo: "true"

--- a/test/promql/tests/data_plane/project_controller_up_test.yaml
+++ b/test/promql/tests/data_plane/project_controller_up_test.yaml
@@ -7,12 +7,12 @@ tests:
   - interval: 1m
     input_series:
       - series: 'konflux_up{namespace="project-controller", check="replicas-available", service="project-controller-controller-manager", source_cluster="c1"}'
-        values: '0 0 0 0 0'
+        values: '0x15'
       - series: 'konflux_up{namespace="project-controller", check="replicas-available", service="project-controller-controller-manager", source_cluster="c2"}'
-        values: '1 1 1 1 1'
+        values: '1x15'
 
     alert_rule_test:
-      - eval_time: 5m
+      - eval_time: 12m
         alertname: ProjectControllerDown
         exp_alerts:
           - exp_labels:


### PR DESCRIPTION
The alert is firing every once in a while and till now was always resolving itself. Given this and the nature of the work done with this controller (very sporadic and not very time sensitive) we can make the alert less sensitive.