### PR TITLE
fix(PVO11Y-4776): Update original cluster capacity UID reference

### DIFF
--- a/dashboards/grafana-dashboard-cluster-capacity.configmap.yaml
+++ b/dashboards/grafana-dashboard-cluster-capacity.configmap.yaml
@@ -2688,7 +2688,7 @@ data:
       },
       "timezone": "",
       "title": "Cluster Capacity",
-      "uid": "beiwi7m518ef49",
+      "uid": "beiwi7m518ef4b",
       "version": 109,
       "weekStart": ""
     }


### PR DESCRIPTION
-Update UID to keep reference of original dashboard UID.