### PR TITLE
chore: rename kanary exporter service and deployment names

### DIFF
--- a/config/exporters/monitoring/kanary/base/kanary-exporter-service.yaml
+++ b/config/exporters/monitoring/kanary/base/kanary-exporter-service.yaml
@@ -44,7 +44,7 @@ kind: Service
 metadata:
   labels:
     app: kanary-exporter
-  name: exporter-service
+  name: kanary-exporter-service
   namespace: appstudio-kanary-exporter
 spec:
   ports:
@@ -57,7 +57,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: exporter-service-deployment
+  name: kanary-exporter-service-deployment
   namespace: appstudio-kanary-exporter
 spec:
   replicas: 1


### PR DESCRIPTION
The reason behind this is to be able to distinguish between the dsexporter and the kanaryexporter using the job label in the metric.