### PR TITLE
Update MintMaker alert rules

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
@@ -15,7 +15,8 @@ spec:
         konflux_up{
           namespace="mintmaker",
           check="replicas-available",
-          service="mintmaker-controller-manager"
+          service="mintmaker-controller-manager",
+          source_cluster!="kflux-rhel-p01"
         } != 1
       for: 5m
       labels:
@@ -26,29 +27,6 @@ spec:
           MintMaker controller is down in cluster {{ $labels.source_cluster }}
         description: >
           The MintMaker controller pod has been down for 5min in cluster {{ $labels.source_cluster }}
-        alert_team_handle: <!subteam^S078T8TMQP5>
-        team: mintmaker
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md
-
-  - name: mintmaker-cache-availability
-    interval: 1m
-    rules:
-    - alert: MintMakerCacheDown
-      expr: |
-        konflux_up{
-          namespace="mintmaker",
-          check="replicas-available",
-          service="redis"
-        } != 1
-      for: 5m
-      labels:
-        severity: critical
-        slo: "true"
-      annotations:
-        summary: >-
-          MintMaker cache is down in cluster {{ $labels.source_cluster }}
-        description: >
-          The MintMaker cache pod (redis) has been down for 5min in cluster {{ $labels.source_cluster }}
         alert_team_handle: <!subteam^S078T8TMQP5>
         team: mintmaker
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md

--- a/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
+++ b/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
@@ -32,26 +32,13 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="redis", source_cluster="c3"}'
+      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="mintmaker-controller-manager", source_cluster="kflux-rhel-p01"}'
         values: '0 0 0 0 0'
-      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="redis", source_cluster="c4"}'
+      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="mintmaker-controller-manager", source_cluster="c4"}'
         values: '1 1 1 1 1'
 
     alert_rule_test:
       - eval_time: 5m
-        alertname: MintMakerCacheDown
+        alertname: MintMakerControllerDown
         exp_alerts:
-          - exp_labels:
-              severity: critical
-              check: replicas-available
-              namespace: mintmaker
-              service: redis
-              slo: "true"
-              source_cluster: c3
-            exp_annotations:
-              summary: MintMaker cache is down in cluster c3
-              description: >
-                The MintMaker cache pod (redis) has been down for 5min in cluster c3
-              alert_team_handle: <!subteam^S078T8TMQP5>
-              team: mintmaker
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md
+          


### PR DESCRIPTION
This commit introduces two changes to the MintMaker alerting rules:
- remove alerts for the cache pod (redis)
- manually ignore alerts for the `kflux-rhel-p01` cluster; this cluster is still being set up and its alerts are flaky and create lots of noise for the time being; we will manually disable them for now.s