### PR TITLE
feat(SPRE-1521): PodNotReady MPC namespace removal

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
@@ -10,7 +10,7 @@ spec:
     interval: 1m
     rules:
     - alert: UnschedulablePods
-      expr: last_over_time(kube_pod_status_unschedulable{namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e)"}[5m]) == 1
+      expr: last_over_time(kube_pod_status_unschedulable{namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|multi-platform-.*)"}[5m]) == 1
       for: 30m
       labels:
         severity: warning
@@ -22,7 +22,7 @@ spec:
         alert_routing_key: '{{ $labels.namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-unschedualablePods.md
     - alert: CrashLoopBackOff
-      expr: max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e)"}[5m]) >= 1
+      expr: max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|multi-platform-.*)"}[5m]) >= 1
       for: 15m
       labels:
         severity: warning
@@ -36,7 +36,7 @@ spec:
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-crashLoopBackOff.md
     - alert: PodNotReady
       expr: |
-            kube_pod_status_phase{phase=~"Pending|Unknown|Failed", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci|mintmaker)"} == 1
+            kube_pod_status_phase{phase=~"Pending|Unknown|Failed", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci|mintmaker|multi-platform-.*)"} == 1
             unless ignoring (phase) (kube_pod_status_unschedulable == 1)
       for: 30m
       labels:


### PR DESCRIPTION
There is a huge amount of alerts reaching out to #konflux-misc-channel in relation to PodNotReady for MPC namespace, these are related with Provisioning/cleanup/update pods are not a real indicator that something is happening on MPC namespace (discussed with Infra Team).

We have decided to remove MPC namespace to reduce the noise, since the pods that we really want to monitor are already under konflux_up signal and there is an alert already for that.
@jdcasey @raks-tt 