### PR TITLE
fix(PVO11Y-4764): kanary alerts should fire after 1s

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kanary_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kanary_alerts.yaml
@@ -11,7 +11,7 @@ spec:
     rules:
       - alert: KanarySignalTriggered
         expr: kanary_up == 0
-        for: 0m
+        for: 1s
         labels:
           severity: critical
           slo: "true"
@@ -23,7 +23,7 @@ spec:
 
       - alert: KanaryDBError
         expr: kanary_error{reason="db_error"} == 1
-        for: 0m
+        for: 1s
         labels:
           severity: warning
           slo: "false"
@@ -35,7 +35,7 @@ spec:
 
       - alert: KanaryMissingTestResults
         expr: kanary_error{reason="no_test_results"} == 1
-        for: 0m
+        for: 1s
         labels:
           severity: warning
           slo: "false"


### PR DESCRIPTION
This is due to the fact that validation of the alert seems to require a value > 0 for the "for" rule spec.