### PR TITLE
PVO11Y-4772 - tweak to eliminate duplicate metrics

### DIFF
--- a/rhobs/recording/prometheus_availability_recording_rules.yaml
+++ b/rhobs/recording/prometheus_availability_recording_rules.yaml
@@ -11,19 +11,19 @@ spec:
 
       rules:
         - record: konflux_up
-          expr: clamp_max(sum without (pod)(prometheus_ready{job="prometheus-user-workload"}), 1)
+          expr: clamp_max(sum without (pod,instance)(prometheus_ready{job="prometheus-user-workload"}), 1)
           labels:
             service: prometheus
             check: prometheus_ready_user_workload
 
         - record: konflux_up
-          expr: clamp_max(sum without (pod)(prometheus_ready{job="prometheus-k8s"}), 1)
+          expr: clamp_max(sum without (pod,instance)(prometheus_ready{job="prometheus-k8s"}), 1)
           labels:
             service: prometheus
             check: prometheus_ready_openshift_monitoring
 
         - record: konflux_up
-          expr: clamp_max(sum without (pod)(prometheus_ready{job="prometheus-self"}), 1)
+          expr: clamp_max(sum without (pod,instance)(prometheus_ready{job="prometheus-self"}), 1)
           labels:
             service: prometheus
             check: prometheus_ready_federation


### PR DESCRIPTION
Remove instance label from the metrics to avoid duplicate metrics.