### PR TITLE
fix(PVO11Y-4804): Resolve Kanary Grafana dashboard UID conflict

### DIFF
--- a/dashboards/grafana-dashboard-kanary-signal.configmap.yaml
+++ b/dashboards/grafana-dashboard-kanary-signal.configmap.yaml
@@ -635,7 +635,7 @@ data:
       "timepicker": {},
       "timezone": "browser",
       "title": "Kanary Signal Dashboard",
-      "uid": "eeoimpx3yutq8f",
+      "uid": "eeoimpx3yutq9f",
       "version": 16,
       "weekStart": ""
     }


### PR DESCRIPTION
The dashboard was initially created on the grafana UI and the json file (with its uid) was used to push the dashboard using gitops under o11y/dashboards which was causing unexpected behavior, due to the duplication of the same uid.

The suspicion is that identical uids is causing grafana to have some form of "race condition".