### PR TITLE
fix: redefine integration service SLO alert for consistent time window

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.integration_service_availability_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.integration_service_availability_alerts.yaml
@@ -24,7 +24,7 @@ spec:
             summary: >-
               Integration Service Availability SLO Violation
             description: >-
-              Integration service '{{ $labels.service }}' in namespace '{{ $labels.namespace }}' 
+              Integration service '{{ $labels.service }}' in namespace '{{ $labels.namespace }}'
               on {{ $labels.source_cluster }} has been down for 5min.
             alert_team_handle: <!subteam^S05M4AG8CJH>
             team: integration


### PR DESCRIPTION
The time windowing on the integration service SLO alert was set to 24 hours, which can lead to large lag times before detection as well as for resolution of the alert state. After some experimentation it's not 100% clear to me what the right windowing timeframe is, so for now I'm setting it to be consistent with the other alerts we have defined.

There was also what looked like a two-layer windowing being applied in the original alert, where the alert expression contained an average applied over 24 hours, but the alert itself was for a state that persisted for 10 minutes (<99% average availability for previous 24h sustained for 10m). This would be confusing to reason about in an actual outage, so using the alerting settings with a non-averaged expression would probably be better.