### PR TITLE
Kanary alerts rework

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kanary_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kanary_alerts.yaml
@@ -55,4 +55,16 @@ spec:
           team: o11y
           alert_routing_key: o11y
           summary: "Kanary Exporter is down in {{ $labels.source_cluster }}"
-          description: "Prometheus is unable to scrape metrics from the Kanary Exporter running in {{ $labels.source_cluster }}."
+          description: "The kanary exporter (running in {{ $labels.source_cluster }}) is unable to set the kanary metrics."
+
+      - alert: KanaryAbsentExporterMetrics
+        expr: absent(up{job="kanary-exporter-service"}) == 1
+        for: 5m
+        labels:
+          severity: warning
+          slo: "false"
+        annotations:
+          team: o11y
+          alert_routing_key: o11y
+          summary: "Kanary Exporter metrics are absent"
+          description: "Prometheus is unable to scrape metrics from the Kanary Exporter."

--- a/rhobs/alerting/data_plane/prometheus.kanary_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kanary_alerts.yaml
@@ -10,7 +10,11 @@ spec:
     interval: 1m
     rules:
       - alert: KanarySignalTriggered
-        expr: kanary_up == 0
+        # For slo alerts only use production metrics (tested_cluster) that are exported from a
+        # production cluster (source_clusterj) by the kanary exporter.
+        # We have a stage and production exporter, and both are pushing metrics for all konflux clusters to
+        # their respective datasource ('rhtap-observatorium-stage' and 'rhtap-observatorium-prod').
+        expr: kanary_up{tested_cluster=~".*prod.*", source_cluster=~".*prod.*"} == 0
         for: 1s
         labels:
           severity: critical
@@ -55,9 +59,11 @@ spec:
           team: o11y
           alert_routing_key: o11y
           summary: "Kanary Exporter is down in {{ $labels.source_cluster }}"
-          description: "The kanary exporter (running in {{ $labels.source_cluster }}) is unable to set the kanary metrics."
+          description: "Prometheus is unable to scrape metrics from the Kanary Exporter running in {{ $labels.source_cluster }}."
 
       - alert: KanaryAbsentExporterMetrics
+        # Consideration: the value returned by absent() does not return the source_cluster label.
+        # The environment can only be determined by looking at the source alertmanager in the alert's slack message.
         expr: absent(up{job="kanary-exporter-service"}) == 1
         for: 5m
         labels:
@@ -67,4 +73,4 @@ spec:
           team: o11y
           alert_routing_key: o11y
           summary: "Kanary Exporter metrics are absent"
-          description: "Prometheus is unable to scrape metrics from the Kanary Exporter."
+          description: "Metrics from the Kanary Exporter are absent."

--- a/rhobs/alerting/data_plane/prometheus.kanary_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kanary_alerts.yaml
@@ -24,6 +24,7 @@ spec:
           team: o11y
           summary: "Kanary signal has been triggered for cluster {{ $labels.tested_cluster }}"
           description: "The e2e load tests failed multiple times in a row for cluster {{ $labels.tested_cluster }}"
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-kanary.md
 
       - alert: KanaryDBError
         expr: kanary_error{reason="db_error"} == 1

--- a/test/promql/tests/data_plane/kanary_test.yaml
+++ b/test/promql/tests/data_plane/kanary_test.yaml
@@ -15,33 +15,6 @@ tests:
       - series: 'kanary_up{tested_cluster="cluster-2"}'
         values: '1x5 0x2 1x8'
 
-      # --- KanaryDBError Test Cases ---
-      # Cluster 3: db_error goes to 1 and stays, should trigger alert
-      - series: 'kanary_error{tested_cluster="cluster-3", reason="db_error"}'
-        values: '0x5 1x10'
-
-      # Cluster 4: db_error goes to 1 but recovers, should NOT trigger alert (because for: 0m means immediate)
-      - series: 'kanary_error{tested_cluster="cluster-4", reason="db_error"}'
-        values: '0x5 1x2 0x8'
-
-      # --- KanaryMissingTestResults Test Cases ---
-      # Cluster 5: no_test_results goes to 1 and stays, should trigger alert
-      - series: 'kanary_error{tested_cluster="cluster-5", reason="no_test_results"}'
-        values: '0x5 1x10'
-
-      # Cluster 6: no_test_results goes to 1 but recovers, should NOT trigger alert (because for: 0m means immediate)
-      - series: 'kanary_error{tested_cluster="cluster-6", reason="no_test_results"}'
-        values: '0x5 1x2 0x8'
-
-      # --- KanaryExporterDown Test Cases ---
-      # Cluster 7: Exporter goes down (up=0) and stays down for 5m+ 'for' duration, should trigger alert
-      - series: 'up{job="kanary-exporter-service", source_cluster="cluster-7"}'
-        values: '1x5 0x10'
-
-      # Cluster 8: Exporter goes down (up=0) but recovers before 'for' duration, should NOT trigger alert
-      - series: 'up{job="kanary-exporter-service", source_cluster="cluster-8"}'
-        values: '1x5 0x4 1x6'
-
     alert_rule_test:
       - alertname: KanarySignalTriggered
         eval_time: 15m
@@ -56,6 +29,18 @@ tests:
               summary: "Kanary signal has been triggered for cluster cluster-1"
               description: "The e2e load tests failed multiple times in a row for cluster cluster-1"
 
+  - interval: 1m
+    input_series:
+      # --- KanaryDBError Test Cases ---
+      # Cluster 3: db_error goes to 1 and stays, should trigger alert
+      - series: 'kanary_error{tested_cluster="cluster-3", reason="db_error"}'
+        values: '0x5 1x10'
+
+      # Cluster 4: db_error goes to 1 but recovers, should NOT trigger alert (because for: 0m means immediate)
+      - series: 'kanary_error{tested_cluster="cluster-4", reason="db_error"}'
+        values: '0x5 1x2 0x8'
+
+    alert_rule_test:
       - alertname: KanaryDBError
         eval_time: 15m
         exp_alerts:
@@ -70,7 +55,18 @@ tests:
               summary: "Kanary signal processing failed due to a database error on cluster cluster-3"
               description: "Encountered a database error while processing the kanary signal for cluster cluster-3"
 
+  - interval: 1m
+    input_series:
+      # --- KanaryMissingTestResults Test Cases ---
+      # Cluster 5: no_test_results goes to 1 and stays, should trigger alert
+      - series: 'kanary_error{tested_cluster="cluster-5", reason="no_test_results"}'
+        values: '0x5 1x10'
 
+      # Cluster 6: no_test_results goes to 1 but recovers, should NOT trigger alert (because for: 0m means immediate)
+      - series: 'kanary_error{tested_cluster="cluster-6", reason="no_test_results"}'
+        values: '0x5 1x2 0x8'
+
+    alert_rule_test:
       - alertname: KanaryMissingTestResults
         eval_time: 15m
         exp_alerts:
@@ -85,6 +81,18 @@ tests:
               summary: "Missing recent e2e results for cluster cluster-5"
               description: "Could not find any recent e2e load test results for cluster cluster-5."
 
+  - interval: 1m
+    input_series:
+      # --- KanaryExporterDown Test Cases ---
+      # Cluster 7: Exporter goes down (up=0) and stays down for 5m+ 'for' duration, should trigger alert
+      - series: 'up{job="kanary-exporter-service", source_cluster="cluster-7"}'
+        values: '1x5 0x10'
+
+      # Cluster 8: Exporter goes down (up=0) but recovers before 'for' duration, should NOT trigger alert
+      - series: 'up{job="kanary-exporter-service", source_cluster="cluster-8"}'
+        values: '1x5 0x4 1x6'
+
+    alert_rule_test:
       - alertname: KanaryExporterDown
         eval_time: 15m
         exp_alerts:
@@ -97,4 +105,20 @@ tests:
               team: o11y
               alert_routing_key: o11y
               summary: "Kanary Exporter is down in cluster-7"
-              description: "Prometheus is unable to scrape metrics from the Kanary Exporter running in cluster-7."
+              description: "The kanary exporter (running in cluster-7) is unable to set the kanary metrics."
+
+  - interval: 1m
+    input_series: []
+    alert_rule_test:
+      - alertname: KanaryAbsentExporterMetrics
+        eval_time: 15m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: kanary-exporter-service
+              slo: "false"
+            exp_annotations:
+              team: o11y
+              alert_routing_key: o11y
+              summary: "Kanary Exporter metrics are absent"
+              description: "Prometheus is unable to scrape metrics from the Kanary Exporter."

--- a/test/promql/tests/data_plane/kanary_test.yaml
+++ b/test/promql/tests/data_plane/kanary_test.yaml
@@ -27,6 +27,7 @@ tests:
             exp_annotations:
               team: o11y
               alert_team_handle: '<@U03S3DRLPH6> <@U067S2N67N3>'
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-kanary.md
               summary: "Kanary signal has been triggered for cluster prod-cluster-1"
               description: "The e2e load tests failed multiple times in a row for cluster prod-cluster-1"
 

--- a/test/promql/tests/data_plane/kanary_test.yaml
+++ b/test/promql/tests/data_plane/kanary_test.yaml
@@ -7,12 +7,12 @@ tests:
   - interval: 1m
     input_series:
       # --- KanarySignalTriggered Test Cases ---
-      # Cluster 1: kanary_up goes to 0 and stays, should trigger alert
-      - series: 'kanary_up{tested_cluster="cluster-1"}'
+      # Prod cluster: kanary_up goes to 0 and stays, should trigger alert
+      - series: 'kanary_up{tested_cluster="prod-cluster-1", source_cluster="stone-prod-p01"}'
         values: '1x5 0x10'
 
-      # Cluster 2: kanary_up goes to 0 but recovers, should NOT trigger alert (because for: 0m means immediate)
-      - series: 'kanary_up{tested_cluster="cluster-2"}'
+      # Prod cluster: kanary_up goes to 0 but recovers, should NOT trigger alert (because for: 0m means immediate)
+      - series: 'kanary_up{tested_cluster="prod-cluster-2", source_cluster="stone-prod-p02"}'
         values: '1x5 0x2 1x8'
 
     alert_rule_test:
@@ -21,13 +21,14 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: critical
-              tested_cluster: cluster-1
+              tested_cluster: prod-cluster-1
+              source_cluster: stone-prod-p01
               slo: "true"
             exp_annotations:
               team: o11y
               alert_team_handle: '<@U03S3DRLPH6> <@U067S2N67N3>'
-              summary: "Kanary signal has been triggered for cluster cluster-1"
-              description: "The e2e load tests failed multiple times in a row for cluster cluster-1"
+              summary: "Kanary signal has been triggered for cluster prod-cluster-1"
+              description: "The e2e load tests failed multiple times in a row for cluster prod-cluster-1"
 
   - interval: 1m
     input_series:
@@ -105,7 +106,7 @@ tests:
               team: o11y
               alert_routing_key: o11y
               summary: "Kanary Exporter is down in cluster-7"
-              description: "The kanary exporter (running in cluster-7) is unable to set the kanary metrics."
+              description: "Prometheus is unable to scrape metrics from the Kanary Exporter running in cluster-7."
 
   - interval: 1m
     input_series: []
@@ -121,4 +122,4 @@ tests:
               team: o11y
               alert_routing_key: o11y
               summary: "Kanary Exporter metrics are absent"
-              description: "Prometheus is unable to scrape metrics from the Kanary Exporter."
+              description: "Metrics from the Kanary Exporter are absent."


### PR DESCRIPTION
What was done:
- A new alert for absence of kanary metrics from the exporter
- Refactor the tests of the alerts
- Modify the alerts to differentiate between the production and staging clusters
- SOP Reference to the kanary SLO alert added