### PR TITLE
add initial alerting rules for kyverno

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kyverno_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kyverno_alerts.yaml
@@ -20,7 +20,7 @@ spec:
         annotations:
           summary: Kyverno has reported that not all the deployments pods are up and running for the last 5 minutes.
           description: "The Kyverno Deployment '{{ $labels.deployment }}' in namespace '{{ $labels.namespace }}' on cluster '{{ $labels.source_cluster }}' is unhealthy."
-          alert_routing_key: infra
+          alert_team_handle: <!subteam^S05Q1P4Q2TG>
           team: konflux-infra
           # kyverno/README.md currently in progress.
           runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kyverno/README.md

--- a/test/promql/tests/data_plane/kyverno_test.yaml
+++ b/test/promql/tests/data_plane/kyverno_test.yaml
@@ -34,7 +34,7 @@ tests:
               summary: Kyverno has reported that not all the deployments pods are up and running for the last 5 minutes.
               description: "The Kyverno Deployment 'kyverno-admission-controller' in namespace 'konflux-kyverno' on cluster 'stone-stg-rh01' is unhealthy."
               team: konflux-infra
-              alert_routing_key: infra
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kyverno/README.md
       - eval_time: 6m
         alertname: KyvernoDeploymentDown
@@ -49,7 +49,7 @@ tests:
               summary: Kyverno has reported that not all the deployments pods are up and running for the last 5 minutes.
               description: "The Kyverno Deployment 'kyverno-admission-controller' in namespace 'konflux-kyverno' on cluster 'stone-stg-rh01' is unhealthy."
               team: konflux-infra
-              alert_routing_key: infra
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kyverno/README.md
   # Scenario 2: Deployment is down for less than 5 minutes, alert should NOT fire.
   - interval: 1m


### PR DESCRIPTION
This PR adds the KyvernoDeploymentDown alert, designed to trigger if Kyverno deployments in the konflux-kyverno namespace are not fully operational.