### PR TITLE
chore(SRVKP-7879): Add konflux_up prometheus signals for each Openshift Pipelines component

### DIFF
--- a/rhobs/recording/pipelines_availability_recording_rules.yaml
+++ b/rhobs/recording/pipelines_availability_recording_rules.yaml
@@ -1,0 +1,41 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-pipelines-availability
+  labels:
+    tenant: rhtap
+
+spec:
+  groups:
+    - name: pipelines_availability
+      interval: 1m
+      rules:
+        # Deployments
+        - record: konflux_up
+          expr: |
+            clamp_max(
+              label_replace(
+                label_replace(
+                  floor(
+                    kube_deployment_status_replicas_available{
+                      namespace=~"openshift-pipelines|tekton-results"
+                    } / clamp_min(kube_deployment_spec_replicas{namespace=~"openshift-pipelines|tekton-results"}, 1)
+                  ), "check", "replicas-available", "",""
+                ), "service", "$1", "deployment","(.*)"
+              ), 1
+            )
+
+        # Stateful Sets
+        - record: konflux_up
+          expr: |
+            clamp_max(
+              label_replace(
+                label_replace(
+                  floor(
+                    kube_statefulset_status_replicas_available{
+                      namespace=~"openshift-pipelines|tekton-results"
+                    } / clamp_min(kube_statefulset_replicas{namespace=~"openshift-pipelines|tekton-results"},1)
+                  ), "check", "replicas-available", "",""
+                ), "service", "$1", "statefulset","(.*)"
+              ), 1
+            )

--- a/test/promql/tests/recording/pipelines_service_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/pipelines_service_availability_recording_rules_test.yaml
@@ -1,0 +1,397 @@
+evaluation_interval: 1m
+
+rule_files:
+  - pipelines_availability_recording_rules.yaml
+
+tests:
+  - name: PipelinesComponentsUp
+    interval: 1m
+    input_series:
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipeline-metrics-exporter"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipeline-metrics-exporter"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipelines-as-code-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipelines-as-code-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipelines-as-code-watcher"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipelines-as-code-watcher"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipelines-as-code-webhook"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipelines-as-code-webhook"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-chains-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-chains-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-pipelines-webhook"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-pipelines-webhook"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tkn-cli-serve"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tkn-cli-serve"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-api"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-api"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-api-for-watcher"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-api-for-watcher"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-watcher"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-watcher"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_statefulset_replicas{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_statefulset_status_replicas_available{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_statefulset_replicas{namespace="openshift-pipelines", statefulset="tekton-pipelines-remote-resolvers"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_statefulset_status_replicas_available{namespace="openshift-pipelines", statefulset="tekton-pipelines-remote-resolvers"}'
+        values: '1 1 1 1 1'
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{deployment='pipeline-metrics-exporter', service='pipeline-metrics-exporter', check='replicas-available', namespace='openshift-pipelines'}
+            value: 1
+          - labels: konflux_up{deployment='pipelines-as-code-controller', service='pipelines-as-code-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 1
+          - labels: konflux_up{deployment='pipelines-as-code-watcher', service='pipelines-as-code-watcher', check='replicas-available', namespace='openshift-pipelines'}
+            value: 1
+          - labels: konflux_up{deployment='pipelines-as-code-webhook', service='pipelines-as-code-webhook', check='replicas-available', namespace='openshift-pipelines'}
+            value: 1
+          - labels: konflux_up{deployment='tekton-chains-controller', service='tekton-chains-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 1
+          - labels: konflux_up{deployment='tekton-events-controller', service='tekton-events-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 1
+          - labels: konflux_up{deployment='tekton-operator-proxy-webhook', service='tekton-operator-proxy-webhook', check='replicas-available', namespace='openshift-pipelines'}
+            value: 1
+          - labels: konflux_up{deployment='tekton-pipelines-webhook', service='tekton-pipelines-webhook', check='replicas-available', namespace='openshift-pipelines'}
+            value: 1
+          - labels: konflux_up{deployment='tkn-cli-serve', service='tkn-cli-serve', check='replicas-available', namespace='openshift-pipelines'}
+            value: 1
+          - labels: konflux_up{deployment='tekton-results-api', service='tekton-results-api', check='replicas-available', namespace='tekton-results'}
+            value: 1
+          - labels: konflux_up{deployment='tekton-results-api-for-watcher', service='tekton-results-api-for-watcher', check='replicas-available', namespace='tekton-results'}
+            value: 1
+          - labels: konflux_up{deployment='tekton-results-watcher', service='tekton-results-watcher', check='replicas-available', namespace='tekton-results'}
+            value: 1
+          - labels: konflux_up{deployment='tekton-results-retention-policy-agent', service='tekton-results-retention-policy-agent', check='replicas-available', namespace='tekton-results'}
+            value: 1
+          - labels: konflux_up{statefulset='tekton-pipelines-controller', service='tekton-pipelines-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 1
+          - labels: konflux_up{statefulset='tekton-pipelines-remote-resolvers', service='tekton-pipelines-remote-resolvers', check='replicas-available', namespace='openshift-pipelines'}
+            value: 1
+
+  - name: PipelinesComponentsFlapping
+    interval: 1m
+    input_series:
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipeline-metrics-exporter"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipeline-metrics-exporter"}'
+        values: '0 1 0 1 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipelines-as-code-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipelines-as-code-controller"}'
+        values: '0 1 0 1 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipelines-as-code-watcher"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipelines-as-code-watcher"}'
+        values: '0 1 0 1 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipelines-as-code-webhook"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipelines-as-code-webhook"}'
+        values: '0 1 0 1 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-chains-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-chains-controller"}'
+        values: '0 1 0 1 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
+        values: '0 1 0 1 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
+        values: '0 1 0 1 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-pipelines-webhook"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-pipelines-webhook"}'
+        values: '0 1 0 1 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tkn-cli-serve"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tkn-cli-serve"}'
+        values: '0 1 0 1 0'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-api"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-api"}'
+        values: '0 1 0 1 0'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-api-for-watcher"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-api-for-watcher"}'
+        values: '0 1 0 1 0'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-watcher"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-watcher"}'
+        values: '0 1 0 1 0'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
+        values: '0 1 0 1 0'
+      - series: 'kube_statefulset_replicas{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_statefulset_status_replicas_available{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
+        values: '0 1 0 1 0'
+      - series: 'kube_statefulset_replicas{namespace="openshift-pipelines", statefulset="tekton-pipelines-remote-resolvers"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_statefulset_status_replicas_available{namespace="openshift-pipelines", statefulset="tekton-pipelines-remote-resolvers"}'
+        values: '0 1 0 1 0'
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{deployment='pipeline-metrics-exporter', service='pipeline-metrics-exporter', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='pipelines-as-code-controller', service='pipelines-as-code-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='pipelines-as-code-watcher', service='pipelines-as-code-watcher', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='pipelines-as-code-webhook', service='pipelines-as-code-webhook', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-chains-controller', service='tekton-chains-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-events-controller', service='tekton-events-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-operator-proxy-webhook', service='tekton-operator-proxy-webhook', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-pipelines-webhook', service='tekton-pipelines-webhook', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tkn-cli-serve', service='tkn-cli-serve', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-results-api', service='tekton-results-api', check='replicas-available', namespace='tekton-results'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-results-api-for-watcher', service='tekton-results-api-for-watcher', check='replicas-available', namespace='tekton-results'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-results-watcher', service='tekton-results-watcher', check='replicas-available', namespace='tekton-results'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-results-retention-policy-agent', service='tekton-results-retention-policy-agent', check='replicas-available', namespace='tekton-results'}
+            value: 0
+          - labels: konflux_up{statefulset='tekton-pipelines-controller', service='tekton-pipelines-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{statefulset='tekton-pipelines-remote-resolvers', service='tekton-pipelines-remote-resolvers', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+
+  - name: PipelinesComponentsDown
+    interval: 1m
+    input_series:
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipeline-metrics-exporter"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipeline-metrics-exporter"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipelines-as-code-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipelines-as-code-controller"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipelines-as-code-watcher"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipelines-as-code-watcher"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipelines-as-code-webhook"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipelines-as-code-webhook"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-chains-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-chains-controller"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-pipelines-webhook"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-pipelines-webhook"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tkn-cli-serve"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tkn-cli-serve"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-api"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-api"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-api-for-watcher"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-api-for-watcher"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-watcher"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-watcher"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_statefulset_replicas{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_statefulset_status_replicas_available{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_statefulset_replicas{namespace="openshift-pipelines", statefulset="tekton-pipelines-remote-resolvers"}'
+        values: '1 1 1 1 1'
+      - series: 'kube_statefulset_status_replicas_available{namespace="openshift-pipelines", statefulset="tekton-pipelines-remote-resolvers"}'
+        values: '0 0 0 0 0'
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{deployment='pipeline-metrics-exporter', service='pipeline-metrics-exporter', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='pipelines-as-code-controller', service='pipelines-as-code-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='pipelines-as-code-watcher', service='pipelines-as-code-watcher', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='pipelines-as-code-webhook', service='pipelines-as-code-webhook', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-chains-controller', service='tekton-chains-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-events-controller', service='tekton-events-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-operator-proxy-webhook', service='tekton-operator-proxy-webhook', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-pipelines-webhook', service='tekton-pipelines-webhook', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tkn-cli-serve', service='tkn-cli-serve', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-results-api', service='tekton-results-api', check='replicas-available', namespace='tekton-results'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-results-api-for-watcher', service='tekton-results-api-for-watcher', check='replicas-available', namespace='tekton-results'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-results-watcher', service='tekton-results-watcher', check='replicas-available', namespace='tekton-results'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-results-retention-policy-agent', service='tekton-results-retention-policy-agent', check='replicas-available', namespace='tekton-results'}
+            value: 0
+          - labels: konflux_up{statefulset='tekton-pipelines-controller', service='tekton-pipelines-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{statefulset='tekton-pipelines-remote-resolvers', service='tekton-pipelines-remote-resolvers', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+
+  - name: PipelinesComponentsDisabled
+    interval: 1m
+    input_series:
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipeline-metrics-exporter"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipeline-metrics-exporter"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipelines-as-code-controller"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipelines-as-code-controller"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipelines-as-code-watcher"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipelines-as-code-watcher"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="pipelines-as-code-webhook"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="pipelines-as-code-webhook"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-chains-controller"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-chains-controller"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-pipelines-webhook"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-pipelines-webhook"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tkn-cli-serve"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tkn-cli-serve"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-api"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-api"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-api-for-watcher"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-api-for-watcher"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-watcher"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-watcher"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_statefulset_replicas{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_statefulset_status_replicas_available{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_statefulset_replicas{namespace="openshift-pipelines", statefulset="tekton-pipelines-remote-resolvers"}'
+        values: '0 0 0 0 0'
+      - series: 'kube_statefulset_status_replicas_available{namespace="openshift-pipelines", statefulset="tekton-pipelines-remote-resolvers"}'
+        values: '0 0 0 0 0'
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{deployment='pipeline-metrics-exporter', service='pipeline-metrics-exporter', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='pipelines-as-code-controller', service='pipelines-as-code-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='pipelines-as-code-watcher', service='pipelines-as-code-watcher', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='pipelines-as-code-webhook', service='pipelines-as-code-webhook', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-chains-controller', service='tekton-chains-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-events-controller', service='tekton-events-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-operator-proxy-webhook', service='tekton-operator-proxy-webhook', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-pipelines-webhook', service='tekton-pipelines-webhook', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tkn-cli-serve', service='tkn-cli-serve', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-results-api', service='tekton-results-api', check='replicas-available', namespace='tekton-results'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-results-api-for-watcher', service='tekton-results-api-for-watcher', check='replicas-available', namespace='tekton-results'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-results-watcher', service='tekton-results-watcher', check='replicas-available', namespace='tekton-results'}
+            value: 0
+          - labels: konflux_up{deployment='tekton-results-retention-policy-agent', service='tekton-results-retention-policy-agent', check='replicas-available', namespace='tekton-results'}
+            value: 0
+          - labels: konflux_up{statefulset='tekton-pipelines-controller', service='tekton-pipelines-controller', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0
+          - labels: konflux_up{statefulset='tekton-pipelines-remote-resolvers', service='tekton-pipelines-remote-resolvers', check='replicas-available', namespace='openshift-pipelines'}
+            value: 0


### PR DESCRIPTION
Add a `konflux_up` signal based on the number of available replicas for each of the Openshift Pipelines components required by Konflux:
- pipeline-metrics-exporter
- pipeline-metrics-exporter
- pipelines-as-code-controller
- pipelines-as-code-watcher
- pipelines-as-code-webhook
- tekton-chains-controller
- tekton-events-controller
- tekton-operator-proxy-webhook
- tekton-pipelines-controller
- tekton-pipelines-remote-resolvers
- tekton-pipelines-webhook
- tekton-results-api
- tekton-results-api-for-watcher
- tekton-results-retention-policy-agent
- tekton-results-watcher
- tkn-cli-serve


Note that the Tekton Results components are in a different namespace (`tekton-results`) and the components `tekton-pipelines-controller` and `tekton-pipelines-remote-resolvers` are StatefulSets instead of Deployments. There was no prior art for stateful sets in this directory, but I believe I've used equivalent metrics based on the [available metrics](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/workload/statefulset-metrics.md). 

Resolves https://issues.redhat.com/browse/SRVKP-7879