### PR TITLE
chore(SRVKP-7880): Add Pipelines SLO alerts for konflux_up signals

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -1,11 +1,339 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: rhtap-pipeline-alerting
+  name: rhtap-pipelines-availability-alerting-rules
   labels:
     tenant: rhtap
 spec:
   groups:
+    - name: pipeline-metrics-exporter-availability
+      interval: 1m
+      rules:
+      - alert: PipelineMetricsExporterDown
+        expr: |
+          konflux_up{
+            namespace="openshift-pipelines",
+            check="replicas-available",
+            service="pipeline-metrics-exporter",
+          } != 1
+        for: 5m
+        labels:
+          severity: high
+        annotations:
+          summary: >-
+            Pipeline metrics exporter is down in cluster {{ $labels.source_cluster }}
+          description: >
+            The Pipelines Metrics Exporter pod has been down for 5min in cluster {{ $labels.source_cluster }}
+          alert_team_handle: <!subteam^S04PYECHCCU>
+          team: pipelines
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+    - name: pipelines-as-code-controller-availability
+      interval: 1m
+      rules:
+      - alert: PipelinesAsCodeControllDown
+        expr: |
+          konflux_up{
+            namespace="openshift-pipelines",
+            check="replicas-available",
+            service="pipelines-as-code-controller",
+          } != 1
+        for: 5m
+        labels:
+          severity: critical
+          slo: "true"
+        annotations:
+          summary: >-
+            Pipelines as Code controller is down in cluster {{ $labels.source_cluster }}
+          description: >
+            The Pipelines as Code controller pod has been down for 5min in cluster {{ $labels.source_cluster }}
+          alert_team_handle: <!subteam^S04PYECHCCU>
+          team: pipelines
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+    - name: pipelines-as-code-watcher-availability
+      interval: 1m
+      rules:
+      - alert: PipelinesAsCodeWatcherDown
+        expr: |
+          konflux_up{
+            namespace="openshift-pipelines",
+            check="replicas-available",
+            service="pipelines-as-code-watcher",
+          } != 1
+        for: 5m
+        labels:
+          severity: critical
+          slo: "true"
+        annotations:
+          summary: >-
+            Pipelines as Code watcher is down in cluster {{ $labels.source_cluster }}
+          description: >
+            The Pipelines as Code watcher pod has been down for 5min in cluster {{ $labels.source_cluster }}
+          alert_team_handle: <!subteam^S04PYECHCCU>
+          team: pipelines
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+    - name: pipelines-as-code-webhook-availability
+      interval: 1m
+      rules:
+      - alert: PipelinesAsCodeWebhookDown
+        expr: |
+          konflux_up{
+            namespace="openshift-pipelines",
+            check="replicas-available",
+            service="pipelines-as-code-webhook",
+          } != 1
+        for: 5m
+        labels:
+          # Causes issues when creating new Repository CRs, onboarding new Components
+          severity: High
+        annotations:
+          summary: >-
+            Pipelines as Code webhook is down in cluster {{ $labels.source_cluster }}
+          description: >
+            The Pipelines as Code webhook pod has been down for 5min in cluster {{ $labels.source_cluster }}
+          alert_team_handle: <!subteam^S04PYECHCCU>
+          team: pipelines
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+    - name: tekton-chains-controller-availability
+      interval: 1m
+      rules:
+      - alert: TektonChainsControllerDown
+        expr: |
+          konflux_up{
+            namespace="openshift-pipelines",
+            check="replicas-available",
+            service="tekton-chains-controller",
+          } != 1
+        for: 5m
+        labels:
+          severity: critical
+          slo: "true"
+        annotations:
+          summary: >-
+            Tekton Chians controller is down in cluster {{ $labels.source_cluster }}
+          description: >
+            The Tekton Chains controller pod has been down for 5min in cluster {{ $labels.source_cluster }}
+          alert_team_handle: <!subteam^S04PYECHCCU>
+          team: pipelines
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+    - name: tekton-events-controller-availability
+      interval: 1m
+      rules:
+      - alert: TektonEventsControllerDown
+        expr: |
+          konflux_up{
+            namespace="openshift-pipelines",
+            check="replicas-available",
+            service="tekton-events-controller",
+          } != 1
+        for: 5m
+        labels:
+          severity: high
+        annotations:
+          summary: >-
+            Tekton Events controller is down in cluster {{ $labels.source_cluster }}
+          description: >
+            The Tekton Events controller pod has been down for 5min in cluster {{ $labels.source_cluster }}
+          alert_team_handle: <!subteam^S04PYECHCCU>
+          team: pipelines
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+    - name: tekton-operator-proxy-webhook-availability
+      interval: 1m
+      rules:
+      - alert: TektonOperatorProxyWebhookDown
+        expr: |
+          konflux_up{
+            namespace="openshift-pipelines",
+            check="replicas-available",
+            service="tekton-operator-proxy-webhook",
+          } != 1
+        for: 5m
+        labels:
+          severity: critical
+          slo: "true"
+        annotations:
+          summary: >-
+            Tekton Operator Proxy Webhook is down in cluster {{ $labels.source_cluster }}
+          description: >
+            The Tekton Operator Proxy webhook pod has been down for 5min in cluster {{ $labels.source_cluster }}
+          alert_team_handle: <!subteam^S04PYECHCCU>
+          team: pipelines
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+    - name: tekton-pipelines-webhook-availability
+      interval: 1m
+      rules:
+      - alert: TektonPipelinesWebhookDown
+        expr: |
+          konflux_up{
+            namespace="openshift-pipelines",
+            check="replicas-available",
+            service="tekton-pipelines-webhook",
+          } != 1
+        for: 5m
+        labels:
+          severity: critical
+          slo: "true"
+        annotations:
+          summary: >-
+            TektonPipelinesWebhook is down in cluster {{ $labels.source_cluster }}
+          description: >
+            The Tekton Pipelines webhook pod has been down for 5min in cluster {{ $labels.source_cluster }}
+          alert_team_handle: <!subteam^S04PYECHCCU>
+          team: pipelines
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+    - name: tkn-cli-serve-availability
+      interval: 1m
+      rules:
+      - alert: TektonCLIServeDown
+        expr: |
+          konflux_up{
+            namespace="openshift-pipelines",
+            check="replicas-available",
+            service="tkn-cli-serve",
+          } != 1
+        for: 5m
+        labels:
+          # No functional impact, just on users trying to use the CLI
+          severity: warning
+        annotations:
+          summary: >-
+            Tekton CLI Serve is down in cluster {{ $labels.source_cluster }}
+          description: >
+            The Tekton CLI Serve controller pod has been down for 5min in cluster {{ $labels.source_cluster }}
+          alert_team_handle: <!subteam^S04PYECHCCU>
+          team: pipelines
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+    - name: tekton-results-api-availability
+      interval: 1m
+      rules:
+      - alert: TektonResultsAPIReaderDown
+        expr: |
+          konflux_up{
+            namespace="tekton-results",
+            check="replicas-available",
+            service="tekton-results-api",
+          } != 1
+        for: 5m
+        labels:
+          severity: critical
+          slo: "true"
+        annotations:
+          summary: >-
+            Tekton Results API reader is down in cluster {{ $labels.source_cluster }}
+          description: >
+            The Tekton Results API pod (reader instance) has been down for 5min in cluster {{ $labels.source_cluster }}
+          alert_team_handle: <!subteam^S04PYECHCCU>
+          team: pipelines
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+    - name: tekton-results-api-for-watcher-availability
+      interval: 1m
+      rules:
+      - alert: TektonResultsAPIDown
+        expr: |
+          konflux_up{
+            namespace="tekton-results",
+            check="replicas-available",
+            service="tekton-results-api-for-watcher",
+          } != 1
+        for: 5m
+        labels:
+          severity: critical
+          slo: "true"
+        annotations:
+          summary: >-
+            Tekton Results API writer is down in cluster {{ $labels.source_cluster }}
+          description: >
+            The Tekton Results API pod (writer instance) has been down for 5min in cluster {{ $labels.source_cluster }}
+          alert_team_handle: <!subteam^S04PYECHCCU>
+          team: pipelines
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+    - name: tekton-results-watcher-availability
+      interval: 1m
+      rules:
+      - alert: TektonResultsWatcherDown
+        expr: |
+          konflux_up{
+            namespace="tekton-results",
+            check="replicas-available",
+            service="tekton-results-watcher",
+          } != 1
+        for: 5m
+        labels:
+          severity: critical
+          slo: "true"
+        annotations:
+          summary: >-
+            Tekton Results watcher is down in cluster {{ $labels.source_cluster }}
+          description: >
+            The Tekton Results watcher pod has been down for 5min in cluster {{ $labels.source_cluster }}
+          alert_team_handle: <!subteam^S04PYECHCCU>
+          team: pipelines
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+    - name: tekton-results-retention-policy-agent-availability
+      interval: 1m
+      rules:
+      - alert: TektonResultsRetentionPolicyAgentDown
+        expr: |
+          konflux_up{
+            namespace="tekton-results",
+            check="replicas-available",
+            service="tekton-results-retention-policy-agent",
+          } != 1
+        for: 5m
+        labels:
+          # Only affects record pruning
+          severity: warning
+        annotations:
+          summary: >-
+            Tekton Results Retention Policy Agent is down in cluster {{ $labels.source_cluster }}
+          description: >
+            The Tekton Results Retention Policy Agent pod has been down for 5min in cluster {{ $labels.source_cluster }}
+          alert_team_handle: <!subteam^S04PYECHCCU>
+          team: pipelines
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+    - name: tekton-pipelines-controller-availability
+      interval: 1m
+      rules:
+      - alert: TektonPipelinesControllerDown
+        expr: |
+          konflux_up{
+            namespace="openshift-pipelines",
+            check="replicas-available",
+            service="tekton-pipelines-controller",
+          } != 1
+        for: 5m
+        labels:
+          severity: critical
+          slo: "true"
+        annotations:
+          summary: >-
+            Tekton Pipelines Controller is down in cluster {{ $labels.source_cluster }}
+          description: >
+            Tekton Pipelines Controller pod has been down for 5min in cluster {{ $labels.source_cluster }}
+          alert_team_handle: <!subteam^S04PYECHCCU>
+          team: pipelines
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+    - name: tekton-pipelines-remote-resolvers-availability
+      interval: 1m
+      rules:
+      - alert: TektonPipelinesRemoteResolversDown
+        expr: |
+          konflux_up{
+            namespace="openshift-pipelines",
+            check="replicas-available",
+            service="tekton-pipelines-remote-resolvers",
+          } != 1
+        for: 5m
+        labels:
+          severity: critical
+          slo: "true"
+        annotations:
+          summary: >-
+            Tekton Pipelines Remote Resolvers is down in cluster {{ $labels.source_cluster }}
+          description: >
+            Tekton Pipelines Remote Resolvers pod has been down for 5min in cluster {{ $labels.source_cluster }}
+          alert_team_handle: <!subteam^S04PYECHCCU>
+          team: pipelines
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
     - name: pipeline_alerts
       interval: 1m
       rules:

--- a/test/promql/tests/data_plane/pipelines_up_test.yaml
+++ b/test/promql/tests/data_plane/pipelines_up_test.yaml
@@ -1,0 +1,456 @@
+evaluation_interval: 1m
+
+rule_files:
+  - 'prometheus.pipeline_alerts.yaml'
+
+tests:
+  - name: PipelinesAlertsGood
+    interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipeline-metrics-exporter", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipeline-metrics-exporter", source_cluster="c_down"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipelines-as-code-controller", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipelines-as-code-controller", source_cluster="c_down"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipelines-as-code-watcher", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipelines-as-code-watcher", source_cluster="c_down"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipelines-as-code-webhook", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipelines-as-code-webhook", source_cluster="c_down"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-chains-controller", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-chains-controller", source_cluster="c_down"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-events-controller", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-events-controller", source_cluster="c_down"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-operator-proxy-webhook", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-operator-proxy-webhook", source_cluster="c_down"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-pipelines-webhook", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-pipelines-webhook", source_cluster="c_down"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tkn-cli-serve", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tkn-cli-serve", source_cluster="c_down"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-api", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-api", source_cluster="c_down"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-api-for-watcher", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-api-for-watcher", source_cluster="c_down"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-watcher", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-watcher", source_cluster="c_down"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-retention-policy-agent", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-retention-policy-agent", source_cluster="c_down"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-pipelines-controller", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-pipelines-controller", source_cluster="c_down"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-pipelines-remote-resolvers", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-pipelines-remote-resolvers", source_cluster="c_down"}'
+        values: '1 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PipelineMetricsExporterDown
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: PipelinesAsCodeControllDown
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: PipelinesAsCodeWatcherDown
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: PipelinesAsCodeWebhookDown
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: TektonChainsControllerDown
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: TektonEventsControllerDown
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: TektonOperatorProxyWebhookDown
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: TektonPipelinesWebhookDown
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: TektonCLIServeDown
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: TektonResultsAPIReaderDown
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: TektonResultsAPIDown
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: TektonResultsWatcherDown
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: TektonResultsRetentionPolicyAgentDown
+        exp_alerts: []
+  - name: PipelinesAlertsFiring
+    interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipeline-metrics-exporter", check="replicas-available", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipeline-metrics-exporter", check="replicas-available", source_cluster="c_down"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipelines-as-code-controller", check="replicas-available", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipelines-as-code-controller", check="replicas-available", source_cluster="c_down"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipelines-as-code-watcher", check="replicas-available", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipelines-as-code-watcher", check="replicas-available", source_cluster="c_down"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipelines-as-code-webhook", check="replicas-available", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="pipelines-as-code-webhook", check="replicas-available", source_cluster="c_down"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-chains-controller", check="replicas-available", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-chains-controller", check="replicas-available", source_cluster="c_down"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-events-controller", check="replicas-available", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-events-controller", check="replicas-available", source_cluster="c_down"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-operator-proxy-webhook", check="replicas-available", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-operator-proxy-webhook", check="replicas-available", source_cluster="c_down"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-pipelines-webhook", check="replicas-available", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-pipelines-webhook", check="replicas-available", source_cluster="c_down"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tkn-cli-serve", check="replicas-available", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tkn-cli-serve", check="replicas-available", source_cluster="c_down"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-api", check="replicas-available", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-api", check="replicas-available", source_cluster="c_down"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-api-for-watcher", check="replicas-available", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-api-for-watcher", check="replicas-available", source_cluster="c_down"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-watcher", check="replicas-available", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-watcher", check="replicas-available", source_cluster="c_down"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-retention-policy-agent", check="replicas-available", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-retention-policy-agent", check="replicas-available", source_cluster="c_down"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-pipelines-controller", check="replicas-available", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-pipelines-controller", check="replicas-available", source_cluster="c_down"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-pipelines-remote-resolvers", check="replicas-available", source_cluster="c_up"}'
+        values: '1 1 1 1 1'
+      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-pipelines-remote-resolvers", check="replicas-available", source_cluster="c_down"}'
+        values: '0 0 0 0 0'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PipelineMetricsExporterDown
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              check: replicas-available
+              namespace: openshift-pipelines
+              service: pipeline-metrics-exporter
+              source_cluster: c_down
+            exp_annotations:
+              summary: Pipeline metrics exporter is down in cluster c_down
+              description: >
+                The Pipelines Metrics Exporter pod has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: PipelinesAsCodeControllDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: openshift-pipelines
+              service: pipelines-as-code-controller
+              slo: "true"
+              source_cluster: c_down
+            exp_annotations:
+              summary: Pipelines as Code controller is down in cluster c_down
+              description: >
+                The Pipelines as Code controller pod has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: PipelinesAsCodeWatcherDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: openshift-pipelines
+              service: pipelines-as-code-watcher
+              slo: "true"
+              source_cluster: c_down
+            exp_annotations:
+              summary: Pipelines as Code watcher is down in cluster c_down
+              description: >
+                The Pipelines as Code watcher pod has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: PipelinesAsCodeWebhookDown
+        exp_alerts:
+          - exp_labels:
+              severity: High
+              check: replicas-available
+              namespace: openshift-pipelines
+              service: pipelines-as-code-webhook
+              source_cluster: c_down
+            exp_annotations:
+              summary: Pipelines as Code webhook is down in cluster c_down
+              description: >
+                The Pipelines as Code webhook pod has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: TektonChainsControllerDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: openshift-pipelines
+              service: tekton-chains-controller
+              slo: "true"
+              source_cluster: c_down
+            exp_annotations:
+              summary: Tekton Chians controller is down in cluster c_down
+              description: >
+                The Tekton Chains controller pod has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: TektonEventsControllerDown
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              check: replicas-available
+              namespace: openshift-pipelines
+              service: tekton-events-controller
+              source_cluster: c_down
+            exp_annotations:
+              summary: Tekton Events controller is down in cluster c_down
+              description: >
+                The Tekton Events controller pod has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: TektonOperatorProxyWebhookDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: openshift-pipelines
+              service: tekton-operator-proxy-webhook
+              slo: "true"
+              source_cluster: c_down
+            exp_annotations:
+              summary: Tekton Operator Proxy Webhook is down in cluster c_down
+              description: >
+                The Tekton Operator Proxy webhook pod has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: TektonPipelinesWebhookDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: openshift-pipelines
+              service: tekton-pipelines-webhook
+              slo: "true"
+              source_cluster: c_down
+            exp_annotations:
+              summary: TektonPipelinesWebhook is down in cluster c_down
+              description: >
+                The Tekton Pipelines webhook pod has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: TektonCLIServeDown
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              check: replicas-available
+              namespace: openshift-pipelines
+              service: tkn-cli-serve
+              source_cluster: c_down
+            exp_annotations:
+              summary: Tekton CLI Serve is down in cluster c_down
+              description: >
+                The Tekton CLI Serve controller pod has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: TektonResultsAPIReaderDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: tekton-results
+              service: tekton-results-api
+              slo: "true"
+              source_cluster: c_down
+            exp_annotations:
+              summary: Tekton Results API reader is down in cluster c_down
+              description: >
+                The Tekton Results API pod (reader instance) has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: TektonResultsAPIDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: tekton-results
+              service: tekton-results-api-for-watcher
+              slo: "true"
+              source_cluster: c_down
+            exp_annotations:
+              summary: Tekton Results API writer is down in cluster c_down
+              description: >
+                The Tekton Results API pod (writer instance) has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: TektonResultsWatcherDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: tekton-results
+              service: tekton-results-watcher
+              slo: "true"
+              source_cluster: c_down
+            exp_annotations:
+              summary: Tekton Results watcher is down in cluster c_down
+              description: >
+                The Tekton Results watcher pod has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: TektonResultsRetentionPolicyAgentDown
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              check: replicas-available
+              namespace: tekton-results
+              service: tekton-results-retention-policy-agent
+              source_cluster: c_down
+            exp_annotations:
+              summary: Tekton Results Retention Policy Agent is down in cluster c_down
+              description: >
+                The Tekton Results Retention Policy Agent pod has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: TektonResultsWatcherDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: tekton-results
+              service: tekton-results-watcher
+              slo: "true"
+              source_cluster: c_down
+            exp_annotations:
+              summary: Tekton Results watcher is down in cluster c_down
+              description: >
+                The Tekton Results watcher pod has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: TektonResultsRetentionPolicyAgentDown
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              check: replicas-available
+              namespace: tekton-results
+              service: tekton-results-retention-policy-agent
+              source_cluster: c_down
+            exp_annotations:
+              summary: Tekton Results Retention Policy Agent is down in cluster c_down
+              description: >
+                The Tekton Results Retention Policy Agent pod has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: TektonPipelinesControllerDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: openshift-pipelines
+              service: tekton-pipelines-controller
+              slo: "true"
+              source_cluster: c_down
+            exp_annotations:
+              summary: Tekton Pipelines Controller is down in cluster c_down
+              description: >
+                Tekton Pipelines Controller pod has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
+      - eval_time: 5m
+        alertname: TektonPipelinesRemoteResolversDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: openshift-pipelines
+              service: tekton-pipelines-remote-resolvers
+              slo: "true"
+              source_cluster: c_down
+            exp_annotations:
+              summary: Tekton Pipelines Remote Resolvers is down in cluster c_down
+              description: >
+                Tekton Pipelines Remote Resolvers pod has been down for 5min in cluster c_down
+              alert_team_handle: <!subteam^S04PYECHCCU>
+              team: pipelines
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md


### PR DESCRIPTION
Add a Prometheus alert rule for every Pipelines component which is
depended on by Konflux based on that component's konflux_up signal

Resolves: https://issues.redhat.com/browse/SRVKP-7880

Depends on https://github.com/redhat-appstudio/o11y/pull/638