### PR TITLE
chore(KFLUXVNGD-334): smee konflux_up metric and alerting rule

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.smee_up_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.smee_up_alerts.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-smee-availability-alerting-rules
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: smee-availability
+    interval: 1m
+    rules:
+    - alert: SmeeDown
+      expr: |
+        konflux_up{
+          namespace=~"smee|smee-client",
+          check="replicas-available",
+        } != 1
+      for: 10m
+      labels:
+        severity: critical
+        slo: "true"
+      annotations:
+        summary: >-
+          {{ $labels.service }} is down on cluster {{ $labels.source_cluster }}
+        description: >
+          Some of the replicas of {{ $labels.service }} are down on namespace
+          {{ $labels.namespace }} in cluster {{ $labels.source_cluster }}
+        alert_team_handle: <!subteam^S07NDQV6A4D>
+        team: vanguard
+        runbook_url: TBD

--- a/rhobs/recording/smee_availability_recording_rules.yaml
+++ b/rhobs/recording/smee_availability_recording_rules.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-smee-availability
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: smee_availability
+      interval: 1m
+      rules:
+        # recorded value: 0 if spec is higher than available, 1 otherwise
+        # labels: check=replicas-available, service=<deployment-name>
+        - record: konflux_up
+          expr: |
+            clamp_max(
+              label_replace(
+                label_replace(
+                  floor(
+                    kube_deployment_status_replicas_available{
+                      namespace=~"smee|smee-client"
+                    } / kube_deployment_spec_replicas
+                  ), "check", "replicas-available", "",""
+                ), "service", "$1", "deployment","(.*)"
+              ), 1
+            )

--- a/test/promql/tests/data_plane/smee_up_test.yaml
+++ b/test/promql/tests/data_plane/smee_up_test.yaml
@@ -1,0 +1,48 @@
+evaluation_interval: 1m
+
+rule_files:
+  - 'prometheus.smee_up_alerts.yaml'
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="smee", check="replicas-available", service="smee", source_cluster="c1"}'
+        values: '0x15'
+      - series: 'konflux_up{namespace="smee-client", check="replicas-available", service="smee-client", source_cluster="c2"}'
+        values: '0x15'
+      - series: 'konflux_up{namespace="smee-client", check="replicas-available", service="smee-client", source_cluster="c3"}'
+        values: '1x15'
+
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: SmeeDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: smee
+              service: smee
+              slo: "true"
+              source_cluster: c1
+            exp_annotations:
+              summary: smee is down on cluster c1
+              description: >
+                Some of the replicas of smee are down on namespace smee in cluster c1
+              alert_team_handle: <!subteam^S07NDQV6A4D>
+              team: vanguard
+              runbook_url: TBD
+          - exp_labels:
+              severity: critical
+              check: replicas-available
+              namespace: smee-client
+              service: smee-client
+              slo: "true"
+              source_cluster: c2
+            exp_annotations:
+              summary: smee-client is down on cluster c2
+              description: >
+                Some of the replicas of smee-client are down on namespace smee-client
+                in cluster c2
+              alert_team_handle: <!subteam^S07NDQV6A4D>
+              team: vanguard
+              runbook_url: TBD


### PR DESCRIPTION
This change adds a recording rule to capture the konflux_up metric for both smee server and client. It then uses that metric for an alerting rule.

The metric is based on a new liveness probe that triggers a live test for the smee client/server for verifying that smee is still serving properly.

See: https://github.com/konflux-ci/smee-sidecar