### PR TITLE
fix: adjust label_replace for kubearchive

### DIFF
--- a/rhobs/recording/kubearchive_recording_rules.yaml
+++ b/rhobs/recording/kubearchive_recording_rules.yaml
@@ -13,9 +13,13 @@ spec:
         - record: konflux_up
           expr: |
             clamp_max(
-              label_replace(label_replace(
-                floor(avg(
-                  kube_deployment_status_replicas_available{namespace="product-kubearchive", deployment=~"kubearchive-.*"} / kube_deployment_spec_replicas
-                ))
-              , "check", "replicas-available", "", ""), "service","kubearchive", "", "")
-            , 1)
+              label_replace(
+                label_replace(
+                  floor(
+                    kube_deployment_status_replicas_available{
+                      namespace="product-kubearchive", deployment=~"kubearchive-.*"
+                    } / kube_deployment_spec_replicas
+                  ), "check", "replicas-available", "", ""
+                ), "service","$1", "deployment", "(.+)"
+              ), 1
+            )

--- a/test/promql/tests/recording/kubearchive_recording_rules.yaml
+++ b/test/promql/tests/recording/kubearchive_recording_rules.yaml
@@ -1,0 +1,79 @@
+evaluation_interval: 1m
+
+rule_files:
+  - kubearchive_availability_recording_rules.yaml
+
+tests:
+  - name: KubearchiveAvailabilityAllUpTest
+    interval: 1m
+    input_series:
+      - series: "kube_deployment_status_replicas_available{namespace='product-kubearchive', deployment='d1'}"
+        values: "3 3 3 3 3"
+      - series: "kube_deployment_spec_replicas{namespace='product-kubearchive', deployment='d1'}"
+        values: "3 3 3 3 3"
+
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{service='d1', check='replicas-available', namespace='product-kubearchive', deployment='d1'}
+            value: 1
+
+  - name: KubearchiveAvailabilitySomeUpTest
+    interval: 1m
+    input_series:
+      - series: "kube_deployment_status_replicas_available{namespace='product-kubearchive', deployment='d1'}"
+        values: "2 2 2 2 2"
+      - series: "kube_deployment_spec_replicas{namespace='product-kubearchive', deployment='d1'}"
+        values: "4 4 4 4 4"
+
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{service='d1', check='replicas-available', namespace='product-kubearchive', deployment='d1'}
+            value: 0
+
+  - name: KubearchiveAvailabilityMultipleDeploymentsTest
+    interval: 1m
+    input_series:
+      # should be up (c1)
+      - series: "kube_deployment_status_replicas_available{namespace='product-kubearchive', deployment='d1', source_cluster='c1'}"
+        values: "1 1 1 1 1"
+      - series: "kube_deployment_spec_replicas{namespace='product-kubearchive', deployment='d1', source_cluster='c1'}"
+        values: "1 1 1 1 1"
+
+      # should be down (c2)
+      - series: "kube_deployment_status_replicas_available{namespace='product-kubearchive', deployment='d1', source_cluster='c2'}"
+        values: "0 0 0 0 0"
+      - series: "kube_deployment_spec_replicas{namespace='product-kubearchive', deployment='d1', source_cluster='c2'}"
+        values: "1 1 1 1 1"
+
+      # should be up (another deployment from c1)
+      - series: "kube_deployment_status_replicas_available{namespace='product-kubearchive', deployment='d2', source_cluster='c1'}"
+        values: "2 2 2 2 2"
+      - series: "kube_deployment_spec_replicas{namespace='product-kubearchive', deployment='d2', source_cluster='c1'}"
+        values: "1 1 1 1 1"
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{service='d1', check='replicas-available', namespace='product-kubearchive', deployment='d1', source_cluster='c1'}
+            value: 1
+          - labels: konflux_up{service='d1', check='replicas-available', namespace='product-kubearchive', deployment='d1', source_cluster='c2'}
+            value: 0
+          - labels: konflux_up{service='d2', check='replicas-available', namespace='product-kubearchive', deployment='d2', source_cluster='c1'}
+            value: 1
+
+  - name: KubearchiveAbsent
+    interval: 1m
+    input_series:
+      - series: "kube_deployment_status_replicas_available{namespace='another-controller', deployment='d1'}"
+        values: "1 1 1 1 1"
+      - series: "kube_deployment_spec_replicas{namespace='another-controller', deployment='d1'}"
+        values: "1 1 1 1 1"
+
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples: []


### PR DESCRIPTION
It appears that the service name may have been set inconsistently compared to other rules (though I'm not convinced this would matter, as it appears to be ironing out the differences in kubearchive deployment names into a single 'kubearchive' from what I can see). I'm also removing the `floor(avg())` combination in favor of just `floor()` in the expression, since the average should be handled at a higher level (I think).

Finally, I wrote a basic test file for it which is derived from the namespace-lister test.