### PR TITLE
feat(SPRE-1542): API Server konflux_up

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-api-server-availability-alerting-rules
+  labels:
+    tenant: rhtap
+
+spec:
+  groups:
+  - name: api_server_service_availability
+    interval: 1m
+    rules:
+    - alert: KonfluxAPIServerHighErrorRate
+      expr: |
+        (sum by (source_cluster) (rate(apiserver_request_total[5m])) / sum by (source_cluster) (rate(apiserver_request_total[5m]))) * 100 > 5
+      for: 5m
+      labels:
+        severity: critical
+        slo: "true"
+      annotations:
+        summary: >-
+          API Server 5XX error count in cluster {{ $labels.source_cluster }}
+        description: "API Server is experiencing 5% of 5XX/429 failures based on the total requests for 5min in cluster {{ $labels.source_cluster }}"
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+        runbook_url: null

--- a/rhobs/recording/api_server_availability_recording_rules.yaml
+++ b/rhobs/recording/api_server_availability_recording_rules.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-api-server-availability
+  labels:
+    tenant: rhtap
+
+spec:
+  groups:
+    - name: api_server_service_availability
+      interval: 1m
+      rules:
+        - record: konflux_up
+          expr: |
+            (sum by (source_cluster) (rate(apiserver_request_total{code=~"5..|429"}[5m])) / sum by (source_cluster) (rate(apiserver_request_total[5m]))) * 100 > 5

--- a/test/promql/tests/data_plane/api_server_availability_test.yaml
+++ b/test/promql/tests/data_plane/api_server_availability_test.yaml
@@ -1,0 +1,33 @@
+# `evaluation_interval` is not a valid top-level key.
+# `rule_files` is correct.
+rule_files:
+  - 'prometheus.api_server_alerts.yaml'
+
+tests:
+  # Start of a new test case. The interval and input series must be under this item.
+  - name: Test KonfluxAPIServerHighErrorRate
+    interval: 1m # Correct placement and spelling of interval
+    input_series:
+      - series: 'apiserver_request_total{code="503", job="kube-apiserver", source_cluster="kflux-prd-es01"}'
+        values: '0+10x60'
+      - series: 'apiserver_request_total{code="429", job="kube-apiserver", source_cluster="kflux-prd-es01"}'
+        values: '0+5x60'
+      - series: 'apiserver_request_total{code="200", job="kube-apiserver", source_cluster="kflux-prd-es01"}'
+        values: '0+50x60'
+
+    # This block tests the alert's state (PENDING/FIRING).
+    alert_rule_test:
+      # This checks for a FIRING alert. It must be checked AFTER the 'for' duration.
+      - eval_time: 7m # Check after the 'for: 5m' has elapsed.
+        alertname: KonfluxAPIServerHighErrorRate
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo: "true"
+              source_cluster: "kflux-prd-es01"
+            exp_annotations:
+              summary: "API Server 5XX error count in cluster kflux-prd-es01"
+              description: "API Server is experiencing 5% of 5XX/429 failures based on the total requests for 5min in cluster kflux-prd-es01"
+              alert_team_handle: "<!subteam^S05Q1P4Q2TG>"
+              team: konflux-infra
+              runbook_url: ""


### PR DESCRIPTION
Based on https://issues.redhat.com/browse/SPRE-1542 we have created the konflux_up signal for API_Server, alert rule and test.
Konflux_up signal consists on HTTP 5XX/429 count out of the total requests. konflux_up signal will fire out when the total of failures reaches 5% out of the total.