### PR TITLE
fix(SPRE-1542): Adding recording rule test and fix rule

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml
@@ -12,7 +12,14 @@ spec:
     rules:
     - alert: KonfluxAPIServerHighErrorRate
       expr: |
-        (sum by (source_cluster) (rate(apiserver_request_total[5m])) / sum by (source_cluster) (rate(apiserver_request_total[5m]))) * 100 > 5
+        (
+          sum by(source_cluster) (
+            code:apiserver_request_total:rate5m{code=~"429|5.."}
+          ) /
+          sum by(source_cluster) (
+            code:apiserver_request_total:rate5m{code!="0"}
+          )
+        ) * 100 > 5
       for: 5m
       labels:
         severity: critical

--- a/rhobs/recording/api_server_availability_recording_rules.yaml
+++ b/rhobs/recording/api_server_availability_recording_rules.yaml
@@ -12,4 +12,11 @@ spec:
       rules:
         - record: konflux_up
           expr: |
-            (sum by (source_cluster) (rate(apiserver_request_total{code=~"5..|429"}[5m])) / sum by (source_cluster) (rate(apiserver_request_total[5m]))) * 100 > 5
+            (
+              sum by (source_cluster) (
+                rate(apiserver_request_total{code=~"5..|429"}[5m])
+              ) /
+              sum by (source_cluster) (
+                rate(apiserver_request_total[5m])
+              )
+            ) * 100

--- a/rhobs/recording/api_server_availability_recording_rules.yaml
+++ b/rhobs/recording/api_server_availability_recording_rules.yaml
@@ -12,11 +12,13 @@ spec:
       rules:
         - record: konflux_up
           expr: |
-            (
-              sum by (source_cluster) (
-                rate(apiserver_request_total{code=~"5..|429"}[5m])
-              ) /
-              sum by (source_cluster) (
-                rate(apiserver_request_total[5m])
-              )
-            ) * 100
+            label_replace(
+              (
+                sum by(source_cluster) (
+                  code:apiserver_request_total:rate5m{code=~"429|5.."}
+                ) /
+                sum by(source_cluster) (
+                  code:apiserver_request_total:rate5m{code!="0"}
+                )
+              ) * 100, "service", "api-server", "", ""
+            )

--- a/test/promql/tests/data_plane/api_server_availability_test.yaml
+++ b/test/promql/tests/data_plane/api_server_availability_test.yaml
@@ -8,11 +8,11 @@ tests:
   - name: Test KonfluxAPIServerHighErrorRate
     interval: 1m # Correct placement and spelling of interval
     input_series:
-      - series: 'apiserver_request_total{code="503", job="kube-apiserver", source_cluster="kflux-prd-es01"}'
+      - series: 'code:apiserver_request_total:rate5m{code="503", source_cluster="kflux-prd-es01"}'
         values: '0+10x60'
-      - series: 'apiserver_request_total{code="429", job="kube-apiserver", source_cluster="kflux-prd-es01"}'
+      - series: 'code:apiserver_request_total:rate5m{code="429", source_cluster="kflux-prd-es01"}'
         values: '0+5x60'
-      - series: 'apiserver_request_total{code="200", job="kube-apiserver", source_cluster="kflux-prd-es01"}'
+      - series: 'code:apiserver_request_total:rate5m{code="200", source_cluster="kflux-prd-es01"}'
         values: '0+50x60'
 
     # This block tests the alert's state (PENDING/FIRING).

--- a/test/promql/tests/recording/api_server_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/api_server_availability_recording_rules_test.yaml
@@ -1,0 +1,23 @@
+evaluation_interval: 1m
+
+rule_files:
+  - api_server_availability_recording_rules.yaml
+
+tests:
+  # Start of a new test case. The interval and input series must be under this item.
+  - name: Test KonfluxAPIServerHighErrorRate
+    interval: 1m # Correct placement and spelling of interval
+    input_series:
+      - series: 'apiserver_request_total{code="503", job="kube-apiserver"}'
+        values: '0+4x60'
+      - series: 'apiserver_request_total{code="429", job="kube-apiserver"}'
+        values: '0+1x60'
+      - series: 'apiserver_request_total{code="200", job="kube-apiserver"}'
+        values: '0+95x60'
+
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 1m
+        exp_samples:
+          - labels: 'konflux_up'
+            value: 5

--- a/test/promql/tests/recording/api_server_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/api_server_availability_recording_rules_test.yaml
@@ -8,16 +8,16 @@ tests:
   - name: Test KonfluxAPIServerHighErrorRate
     interval: 1m # Correct placement and spelling of interval
     input_series:
-      - series: 'apiserver_request_total{code="503", job="kube-apiserver"}'
+      - series: 'code:apiserver_request_total:rate5m{code="503"}'
         values: '0+4x60'
-      - series: 'apiserver_request_total{code="429", job="kube-apiserver"}'
+      - series: 'code:apiserver_request_total:rate5m{code="429"}'
         values: '0+1x60'
-      - series: 'apiserver_request_total{code="200", job="kube-apiserver"}'
+      - series: 'code:apiserver_request_total:rate5m{code="200"}'
         values: '0+95x60'
 
     promql_expr_test:
       - expr: konflux_up
         eval_time: 1m
         exp_samples:
-          - labels: 'konflux_up'
+          - labels: '{__name__="konflux_up", service="api-server"}'
             value: 5


### PR DESCRIPTION
The recording rule had a threshold similar to the alert expression, and without a unit test it wasn't detected. This adds the test then fixes the rule.