### PR TITLE
KuebArchive: add basic SLO alerts

### DIFF
--- a/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
+++ b/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
@@ -2,2111 +2,2026 @@ apiVersion: v1
 data:
   rhtap-slo-dashboard.json: |-
     {
-        "annotations": {
-            "list": [
-                {
-                    "builtIn": 1,
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                    },
-                    "enable": true,
-                    "hide": true,
-                    "iconColor": "rgba(0, 211, 255, 1)",
-                    "name": "Annotations & Alerts",
-                    "target": {
-                        "limit": 100,
-                        "matchAny": false,
-                        "tags": [],
-                        "type": "dashboard"
-                    },
-                    "type": "dashboard"
-                }
-            ]
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Konflux Service Level Objectives",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 1026055,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 80,
+          "panels": [],
+          "title": "Integration Service SLOs",
+          "type": "row"
         },
-        "description": "Konflux Service Level Objectives",
-        "editable": true,
-        "fiscalYearStartMonth": 0,
-        "graphTooltip": 0,
-        "id": 934605,
-        "links": [],
-        "liveNow": false,
-        "panels": [
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "",
-                "gridPos": {
-                    "h": 3,
-                    "w": 20,
-                    "x": 0,
-                    "y": 0
-                },
-                "id": 31,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "This dashboard shows all SLOs for Konflux over a specified time window.\n\nSelect a datasource to switch between environments.",
-                    "mode": "markdown"
-                },
-                "pluginVersion": "10.4.1",
-                "transparent": true,
-                "type": "text"
+        {
+          "description": "The objective for the given time window.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 1
+          },
+          "id": 77,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
             },
-            {
-                "collapsed": false,
-                "gridPos": {
-                    "h": 1,
-                    "w": 24,
-                    "x": 0,
-                    "y": 3
-                },
-                "id": 80,
-                "panels": [],
-                "title": "Integration Service SLOs",
-                "type": "row"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The objective for the given time window.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 4
-                },
-                "id": 77,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>90% of requests must be within required response time</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Latency Service Response SLO",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The current measurement for the given time window.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "max": 1,
-                        "min": 0,
-                        "noValue": "-",
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "red",
-                                    "value": null
-                                },
-                                {
-                                    "color": "green",
-                                    "value": 90
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 4
-                },
-                "id": 78,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(integration_svc_response_seconds_bucket{le=\"30\"}[$__rate_interval])) by (job)\n/\nsum(rate(integration_svc_response_seconds_count[$__rate_interval]) > 0) by (job)",
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Measured",
-                "type": "gauge"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The objective for the given time window.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 11
-                },
-                "id": 83,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>90% of requests must be within required time</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Time to start Pipeline Run",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The current measurement for the given time window.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "max": 1,
-                        "min": 0,
-                        "noValue": "-",
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "red",
-                                    "value": null
-                                },
-                                {
-                                    "color": "green",
-                                    "value": 90
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 11
-                },
-                "id": 86,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(integration_svc_snapshot_created_to_pipelinerun_started_seconds_bucket{le=\"5\"}[$__rate_interval])) by (job)\n/\nsum(rate(integration_svc_snapshot_created_to_pipelinerun_started_seconds_count[$__rate_interval]) > 0) by (job)",
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Measured",
-                "type": "gauge"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The objective for the given time window.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 18
-                },
-                "id": 82,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>90% of requests must be within required time</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Latency of Release Creation",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The current measurement for the given time window.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "max": 1,
-                        "min": 0,
-                        "noValue": "-",
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "red",
-                                    "value": null
-                                },
-                                {
-                                    "color": "green",
-                                    "value": 90
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 18
-                },
-                "id": 84,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(integration_svc_release_latency_seconds_bucket{le=\"10\"}[$__rate_interval])) by (job) / sum(rate(integration_svc_release_latency_seconds_count[$__rate_interval])) by (job)",
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Measured",
-                "type": "gauge"
-            },
-            {
-                "collapsed": false,
-                "gridPos": {
-                    "h": 1,
-                    "w": 24,
-                    "x": 0,
-                    "y": 25
-                },
-                "id": 96,
-                "panels": [],
-                "title": "Release Service SLOs",
-                "type": "row"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Measure the time it takes for a Release to be marked as Validated.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 26
-                },
-                "id": 97,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>90% of the Releases should be validated below 5 seconds</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Release Validation SLO",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Measure the time it takes for a Release to be marked as Processed.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "max": 1,
-                        "min": 0,
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "red",
-                                    "value": null
-                                },
-                                {
-                                    "color": "green",
-                                    "value": 90
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 26
-                },
-                "id": 101,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [
-                            "mean"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum by (job) (rate(release_validation_duration_seconds_bucket{le=\"5\"}[$__rate_interval])) / sum by (job) (rate(release_validation_duration_seconds_count[$__rate_interval]) > 0)",
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Measured",
-                "type": "gauge"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Measure the time it takes for a Release to be marked as Processing",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 33
-                },
-                "id": 99,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>90% of the Releases should be pre-processed within 10 seconds</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Release Pre-Processing SLO",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Measure the time it takes for a Release to be marked as Processed.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "max": 1,
-                        "min": 0,
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "red",
-                                    "value": null
-                                },
-                                {
-                                    "color": "green",
-                                    "value": 90
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 33
-                },
-                "id": 100,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [
-                            "mean"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum by (job) (rate(release_pre_processing_duration_seconds_bucket{le=\"10\"}[$__rate_interval])) / sum by (job) (rate(release_pre_processing_duration_seconds_count[$__rate_interval]) > 0)",
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Measured",
-                "type": "gauge"
-            },
-            {
-                "collapsed": false,
-                "gridPos": {
-                    "h": 1,
-                    "w": 24,
-                    "x": 0,
-                    "y": 40
-                },
-                "id": 64,
-                "panels": [],
-                "title": "Pipeline SLOs",
-                "type": "row"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The rate that any of the pipeline controllers have restarted",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 41
-                },
-                "id": 104,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>The rate that any of the pipeline controllers have restarted</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Pipeline Controller Restarts",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The number of times any of the tekton controllers have restarted",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                },
-                                {
-                                    "color": "red",
-                                    "value": 5
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 41
-                },
-                "id": 105,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(kube_pod_container_status_restarts_total{namespace=\"openshift-pipelines\", pod=~\"tekton-.*|pipelines-as-code-.*\"}[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Controller Restart Rates",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The number of validated PipelineRuns not yet processed by the PipelineRun Controller.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 48
-                },
-                "id": 106,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>The number of validated PipelineRuns not yet processed by the PipelineRun Controller.</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked PipelineRuns",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The number of validated PipelineRuns not yet processed by the PipelineRun Controller.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                },
-                                {
-                                    "color": "red",
-                                    "value": 30
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 48
-                },
-                "id": 107,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(increase(pipelinerun_kickoff_not_attempted_count[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked PipelineRuns",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The rate of validated TaskRuns not yet processed by the TaskRuns Controller.  Negative numbers mean no TaskRuns Controller deadlocks despite Kubernetes throttling.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 55
-                },
-                "id": 108,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>The rate of validated TaskRuns not yet processed by the TaskRuns Controller.  Negative numbers mean no TaskRun Controller deadlocks despite Kubernetes throttling.</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked TaskRuns",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The rate of validated TaskRuns not yet processed by the TaskRuns Controller.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                },
-                                {
-                                    "color": "red",
-                                    "value": 30
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 55
-                },
-                "id": 109,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(taskrun_pod_create_not_attempted_or_pending_count[$__range])) - sum(rate(tekton_pipelines_controller_running_taskruns_throttled_by_quota[$__range])) - sum(rate(tekton_pipelines_controller_running_taskruns_throttled_by_node[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked TaskRuns",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The number of validated ResolutionRequests  not yet processed by the Resolver Controller.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 62
-                },
-                "id": 110,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>The number of validated ResolutionRequests not yet processed by the Resolver Controller.</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked ResolutionRequests",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The number of validated ResolutionRequests not yet processed by the Resolver Controller.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                },
-                                {
-                                    "color": "red",
-                                    "value": 30
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 62
-                },
-                "id": 111,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(increase(pending_resolutionrequest_count[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked ResolutionRequests",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Indicator whether Tekton Results is deadlocked",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 69
-                },
-                "id": 116,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>If there are PipelineRuns on the cluster, but no corresponding GRPC processed by Tekton Results, Tekton Results is possibly deadlocked </center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Results Deadlocked Part 1",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The rate of PipelineRuns existing on cluster for the poling interval",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 69
-                },
-                "id": 122,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(tekton_pipelines_controller_pipelinerun_count[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "PipelineRun Total Rate - Results Deadlock Part 1",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Indicator whether Tekton Results is deadlocked",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 76
-                },
-                "id": 119,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>If there are PipelineRuns on the cluster, but no corresponding GRPC processed by Tekton Results, Tekton Results is possibly deadlocked </center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Results Deadlocked Part 2",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The rate of PipelineRun related GRPC API calls made against Tekton Results",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 76
-                },
-                "id": 118,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(grpc_server_handled_total{job='tekton-results-api', grpc_service=~'tekton.results.*'}[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Tekton Results GRPC Rate - Results Deadlock Part 2",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "Tekton Results API Success Rate",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 83
-                },
-                "id": 121,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>Tekton Results API Success Rate </center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Results Success Rate",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The success rate of API calls made to Tekton Results",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "max": 1,
-                        "min": 0,
-                        "noValue": "-",
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "red",
-                                    "value": null
-                                },
-                                {
-                                    "color": "green",
-                                    "value": 75
-                                }
-                            ]
-                        },
-                        "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 83
-                },
-                "id": 120,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(rate(grpc_server_handled_total{job='tekton-results-api', grpc_service=~'tekton.results.*', grpc_code='OK'}[$__range])) / sum(rate(grpc_server_handled_total{job='tekton-results-api', grpc_service=~'tekton.results.*'}[$__range]))",
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Tekton Results API Success",
-                "type": "gauge"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The rate of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 90
-                },
-                "id": 112,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>The rate of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked Chains",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The rate of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                },
-                                {
-                                    "color": "red",
-                                    "value": 50
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 90
-                },
-                "id": 113,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(delta(watcher_workqueue_depth{container='tekton-chains-controller',app='tekton-chains-controller'}[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked Chains",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The number of PipelineRuns/TaskRuns still needing processing by Tekton PAC Controller",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 97
-                },
-                "id": 123,
-                "options": {
-                    "code": {
-                        "language": "plaintext",
-                        "showLineNumbers": false,
-                        "showMiniMap": false
-                    },
-                    "content": "<h1><center>The number of PipelineRuns/TaskRuns still needing processing by Tekton PAC Controller</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked PAC",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The number of PipelineRuns/TaskRuns still needing processing by Tekton PAC Controller",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [
-                            {
-                                "options": {
-                                    "match": "null",
-                                    "result": {
-                                        "text": "N/A"
-                                    }
-                                },
-                                "type": "special"
-                            }
-                        ],
-                        "noValue": "No data",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                },
-                                {
-                                    "color": "red",
-                                    "value": 50
-                                }
-                            ]
-                        },
-                        "unit": "none"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 97
-                },
-                "id": 124,
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "showPercentChange": false,
-                    "textMode": "auto",
-                    "wideLayout": true
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "editorMode": "code",
-                        "expr": "sum(delta(pac_watcher_work_queue_depth[$__range]))",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true,
-                        "refId": "A"
-                    }
-                ],
-                "title": "Deadlocked PAC",
-                "type": "stat"
-            },
-            {
-                "collapsed": false,
-                "gridPos": {
-                    "h": 1,
-                    "w": 24,
-                    "x": 0,
-                    "y": 104
-                },
-                "id": 125,
-                "panels": [],
-                "title": "Project Controller SLOs",
-                "type": "row"
-                },
+            "content": "<h1><center>90% of requests must be within required response time</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Latency Service Response SLO",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The current measurement for the given time window.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
                 {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The objective for the given time window.",
-                "gridPos": {
-                    "h": 7,
-                    "w": 10,
-                    "x": 0,
-                    "y": 105
-                },
-                "id": 126,
-                "options": {
-                    "code": {
-                    "language": "plaintext",
-                    "showLineNumbers": false,
-                    "showMiniMap": false
-                    },
-                    "content": "<h1><center>100% of service replicas must be available within the measurment timeframe</center></h1>",
-                    "mode": "html"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                    },
-                    "refId": "A"
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
                     }
-                ],
-                "title": "Availability SLO",
-                "type": "text"
-                },
-                {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "description": "The current measurement for the given time window.",
-                "fieldConfig": {
-                    "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "mappings": [
-                        {
-                        "options": {
-                            "match": "null",
-                            "result": {
-                            "text": "N/A"
-                            }
-                        },
-                        "type": "special"
-                        }
-                    ],
-                    "max": 1,
-                    "min": 0,
-                    "noValue": "-",
-                    "thresholds": {
-                        "mode": "percentage",
-                        "steps": [
-                        {
-                            "color": "red",
-                            "value": null
-                        },
-                        {
-                            "color": "green",
-                            "value": 90
-                        }
-                        ]
-                    },
-                    "unit": "percentunit"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 7,
-                    "w": 5,
-                    "x": 10,
-                    "y": 105
-                },
-                "id": 127,
-                "maxDataPoints": 100,
-                "options": {
-                    "minVizHeight": 75,
-                    "minVizWidth": 75,
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                    "calcs": [],
-                    "fields": "",
-                    "values": false
-                    },
-                    "showThresholdLabels": false,
-                    "showThresholdMarkers": false,
-                    "sizing": "auto"
-                },
-                "pluginVersion": "10.4.1",
-                "targets": [
-                    {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                    },
-                    "editorMode": "code",
-                    "exemplar": false,
-                    "expr": "sum(kube_deployment_status_replicas_available{namespace=\"project-controller\"})\n/\nsum(kube_deployment_spec_replicas{namespace=\"project-controller\"})",
-                    "format": "time_series",
-                    "instant": true,
-                    "legendFormat": "__auto",
-                    "range": false,
-                    "refId": "A"
-                    }
-                ],
-                "title": "Measured",
-                "type": "gauge"
-                },
-                {
-                "collapsed": true,
-                "gridPos": {
-                    "h": 1,
-                    "w": 24,
-                    "x": 0,
-                    "y": 112
-                },
-                "id": 33,
-                "panels": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "description": "The objective for the given time window.",
-                        "gridPos": {
-                            "h": 7,
-                            "w": 10,
-                            "x": 0,
-                            "y": 56
-                        },
-                        "id": 10,
-                        "options": {
-                            "code": {
-                                "language": "plaintext",
-                                "showLineNumbers": false,
-                                "showMiniMap": false
-                            },
-                            "content": "<h1><center>SLO Definition</center></h1>",
-                            "mode": "html"
-                        },
-                        "pluginVersion": "10.4.1",
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "type": "prometheus",
-                                    "uid": "${datasource}"
-                                },
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "SLO",
-                        "type": "text"
-                    },
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "description": "The current measurement for the given time window.",
-                        "fieldConfig": {
-                            "defaults": {
-                                "color": {
-                                    "mode": "thresholds"
-                                },
-                                "mappings": [
-                                    {
-                                        "options": {
-                                            "match": "null",
-                                            "result": {
-                                                "text": "N/A"
-                                            }
-                                        },
-                                        "type": "special"
-                                    }
-                                ],
-                                "thresholds": {
-                                    "mode": "absolute",
-                                    "steps": [
-                                        {
-                                            "color": "green"
-                                        },
-                                        {
-                                            "color": "red",
-                                            "value": 80
-                                        }
-                                    ]
-                                },
-                                "unit": "none"
-                            },
-                            "overrides": []
-                        },
-                        "gridPos": {
-                            "h": 7,
-                            "w": 5,
-                            "x": 0,
-                            "y": 63
-                        },
-                        "id": 98,
-                        "maxDataPoints": 100,
-                        "options": {
-                            "colorMode": "none",
-                            "graphMode": "none",
-                            "justifyMode": "auto",
-                            "orientation": "horizontal",
-                            "reduceOptions": {
-                                "calcs": [
-                                    "mean"
-                                ],
-                                "fields": "",
-                                "values": false
-                            },
-                            "showPercentChange": false,
-                            "textMode": "auto",
-                            "wideLayout": true
-                        },
-                        "pluginVersion": "10.4.1",
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "type": "prometheus",
-                                    "uid": "${datasource}"
-                                },
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "Measured",
-                        "type": "stat"
-                    },
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "${datasource}"
-                        },
-                        "description": "The remaining error budget for the given time window.",
-                        "fieldConfig": {
-                            "defaults": {
-                                "color": {
-                                    "mode": "thresholds"
-                                },
-                                "mappings": [
-                                    {
-                                        "options": {
-                                            "match": "null",
-                                            "result": {
-                                                "text": "N/A"
-                                            }
-                                        },
-                                        "type": "special"
-                                    }
-                                ],
-                                "thresholds": {
-                                    "mode": "absolute",
-                                    "steps": [
-                                        {
-                                            "color": "green"
-                                        },
-                                        {
-                                            "color": "red",
-                                            "value": 80
-                                        }
-                                    ]
-                                },
-                                "unit": "none"
-                            },
-                            "overrides": []
-                        },
-                        "gridPos": {
-                            "h": 7,
-                            "w": 5,
-                            "x": 5,
-                            "y": 63
-                        },
-                        "id": 29,
-                        "maxDataPoints": 100,
-                        "options": {
-                            "colorMode": "none",
-                            "graphMode": "none",
-                            "justifyMode": "auto",
-                            "orientation": "horizontal",
-                            "reduceOptions": {
-                                "calcs": [
-                                    "mean"
-                                ],
-                                "fields": "",
-                                "values": false
-                            },
-                            "showPercentChange": false,
-                            "textMode": "auto",
-                            "wideLayout": true
-                        },
-                        "pluginVersion": "10.4.1",
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "type": "prometheus",
-                                    "uid": "${datasource}"
-                                },
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "Error Budget (%)",
-                        "type": "stat"
-                    }
-                ],
-                "title": "SLO Template",
-                "type": "row"
+                  },
+                  "type": "special"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "noValue": "-",
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "red"
+                  },
+                  {
+                    "color": "green",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 1
+          },
+          "id": 78,
+          "maxDataPoints": 100,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(integration_svc_response_seconds_bucket{le=\"30\"}[$__rate_interval])) by (job)\n/\nsum(rate(integration_svc_response_seconds_count[$__rate_interval]) > 0) by (job)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
             }
-        ],
-        "refresh": "1h",
-        "schemaVersion": 39,
-        "tags": [],
-        "templating": {
-            "list": [
+          ],
+          "title": "Measured",
+          "type": "gauge"
+        },
+        {
+          "description": "The objective for the given time window.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 8
+          },
+          "id": 83,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>90% of requests must be within required time</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Time to start Pipeline Run",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The current measurement for the given time window.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
                 {
-                    "current": {
-                        "selected": true,
-                        "text": "rhtap-observatorium-production",
-                        "value": "rhtap-observatorium-production"
-                    },
-                    "hide": 0,
-                    "includeAll": false,
-                    "multi": false,
-                    "name": "datasource",
-                    "options": [],
-                    "query": "prometheus",
-                    "queryValue": "",
-                    "refresh": 1,
-                    "regex": "/^rhtap-/",
-                    "skipUrlSync": false,
-                    "type": "datasource"
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
                 }
-            ]
+              ],
+              "max": 1,
+              "min": 0,
+              "noValue": "-",
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "red"
+                  },
+                  {
+                    "color": "green",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 8
+          },
+          "id": 86,
+          "maxDataPoints": 100,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(integration_svc_snapshot_created_to_pipelinerun_started_seconds_bucket{le=\"5\"}[$__rate_interval])) by (job)\n/\nsum(rate(integration_svc_snapshot_created_to_pipelinerun_started_seconds_count[$__rate_interval]) > 0) by (job)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Measured",
+          "type": "gauge"
         },
-        "time": {
-            "from": "now-28d",
-            "to": "now"
+        {
+          "description": "The objective for the given time window.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 15
+          },
+          "id": 82,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>90% of requests must be within required time</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Latency of Release Creation",
+          "type": "text"
         },
-        "timepicker": {
-            "refresh_intervals": [
-                "5s",
-                "10s",
-                "30s",
-                "1m",
-                "5m",
-                "15m",
-                "30m",
-                "1h",
-                "2h",
-                "1d"
-            ],
-            "time_options": [
-                "5m",
-                "15m",
-                "1h",
-                "6h",
-                "12h",
-                "24h",
-                "2d",
-                "7d",
-                "30d"
-            ]
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The current measurement for the given time window.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "noValue": "-",
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "red"
+                  },
+                  {
+                    "color": "green",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 15
+          },
+          "id": 84,
+          "maxDataPoints": 100,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(integration_svc_release_latency_seconds_bucket{le=\"10\"}[$__rate_interval])) by (job) / sum(rate(integration_svc_release_latency_seconds_count[$__rate_interval])) by (job)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Measured",
+          "type": "gauge"
         },
-        "timezone": "",
-        "title": "Konflux SLOs",
-        "uid": "rhtap-slos",
-        "version": 13974,
-        "weekStart": ""
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 22
+          },
+          "id": 96,
+          "panels": [],
+          "title": "Release Service SLOs",
+          "type": "row"
+        },
+        {
+          "description": "Measure the time it takes for a Release to be marked as Validated.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 23
+          },
+          "id": 97,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>90% of the Releases should be validated below 5 seconds</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Release Validation SLO",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Measure the time it takes for a Release to be marked as Processed.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "red"
+                  },
+                  {
+                    "color": "green",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 23
+          },
+          "id": 101,
+          "maxDataPoints": 100,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(release_validation_duration_seconds_bucket{le=\"5\"}[$__rate_interval])) / sum by (job) (rate(release_validation_duration_seconds_count[$__rate_interval]) > 0)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Measured",
+          "type": "gauge"
+        },
+        {
+          "description": "Measure the time it takes for a Release to be marked as Processing",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 30
+          },
+          "id": 99,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>90% of the Releases should be pre-processed within 10 seconds</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Release Pre-Processing SLO",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Measure the time it takes for a Release to be marked as Processed.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "red"
+                  },
+                  {
+                    "color": "green",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 30
+          },
+          "id": 100,
+          "maxDataPoints": 100,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(release_pre_processing_duration_seconds_bucket{le=\"10\"}[$__rate_interval])) / sum by (job) (rate(release_pre_processing_duration_seconds_count[$__rate_interval]) > 0)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Measured",
+          "type": "gauge"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 37
+          },
+          "id": 64,
+          "panels": [],
+          "title": "Pipeline SLOs",
+          "type": "row"
+        },
+        {
+          "description": "The rate that any of the pipeline controllers have restarted",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 38
+          },
+          "id": 104,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The rate that any of the pipeline controllers have restarted</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Pipeline Controller Restarts",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of times any of the tekton controllers have restarted",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 5
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 38
+          },
+          "id": 105,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(kube_pod_container_status_restarts_total{namespace=\"openshift-pipelines\", pod=~\"tekton-.*|pipelines-as-code-.*\"}[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Controller Restart Rates",
+          "type": "stat"
+        },
+        {
+          "description": "The number of validated PipelineRuns not yet processed by the PipelineRun Controller.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 45
+          },
+          "id": 106,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The number of validated PipelineRuns not yet processed by the PipelineRun Controller.</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Deadlocked PipelineRuns",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of validated PipelineRuns not yet processed by the PipelineRun Controller.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 45
+          },
+          "id": 107,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(pipelinerun_kickoff_not_attempted_count[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Deadlocked PipelineRuns",
+          "type": "stat"
+        },
+        {
+          "description": "The rate of validated TaskRuns not yet processed by the TaskRuns Controller.  Negative numbers mean no TaskRuns Controller deadlocks despite Kubernetes throttling.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 52
+          },
+          "id": 108,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The rate of validated TaskRuns not yet processed by the TaskRuns Controller.  Negative numbers mean no TaskRun Controller deadlocks despite Kubernetes throttling.</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Deadlocked TaskRuns",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The rate of validated TaskRuns not yet processed by the TaskRuns Controller.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 52
+          },
+          "id": 109,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(taskrun_pod_create_not_attempted_or_pending_count[$__range])) - sum(rate(tekton_pipelines_controller_running_taskruns_throttled_by_quota[$__range])) - sum(rate(tekton_pipelines_controller_running_taskruns_throttled_by_node[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Deadlocked TaskRuns",
+          "type": "stat"
+        },
+        {
+          "description": "The number of validated ResolutionRequests  not yet processed by the Resolver Controller.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 59
+          },
+          "id": 110,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The number of validated ResolutionRequests not yet processed by the Resolver Controller.</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Deadlocked ResolutionRequests",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of validated ResolutionRequests not yet processed by the Resolver Controller.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 59
+          },
+          "id": 111,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(pending_resolutionrequest_count[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Deadlocked ResolutionRequests",
+          "type": "stat"
+        },
+        {
+          "description": "Indicator whether Tekton Results is deadlocked",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 66
+          },
+          "id": 116,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>If there are PipelineRuns on the cluster, but no corresponding GRPC processed by Tekton Results, Tekton Results is possibly deadlocked </center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Results Deadlocked Part 1",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The rate of PipelineRuns existing on cluster for the poling interval",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 66
+          },
+          "id": 122,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(tekton_pipelines_controller_pipelinerun_count[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "PipelineRun Total Rate - Results Deadlock Part 1",
+          "type": "stat"
+        },
+        {
+          "description": "Indicator whether Tekton Results is deadlocked",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 73
+          },
+          "id": 119,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>If there are PipelineRuns on the cluster, but no corresponding GRPC processed by Tekton Results, Tekton Results is possibly deadlocked </center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Results Deadlocked Part 2",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The rate of PipelineRun related GRPC API calls made against Tekton Results",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 73
+          },
+          "id": 118,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(grpc_server_handled_total{job='tekton-results-api', grpc_service=~'tekton.results.*'}[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Tekton Results GRPC Rate - Results Deadlock Part 2",
+          "type": "stat"
+        },
+        {
+          "description": "Tekton Results API Success Rate",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 80
+          },
+          "id": 121,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>Tekton Results API Success Rate </center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Results Success Rate",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The success rate of API calls made to Tekton Results",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "noValue": "-",
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "red"
+                  },
+                  {
+                    "color": "green",
+                    "value": 75
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 80
+          },
+          "id": 120,
+          "maxDataPoints": 100,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(grpc_server_handled_total{job='tekton-results-api', grpc_service=~'tekton.results.*', grpc_code='OK'}[$__range])) / sum(rate(grpc_server_handled_total{job='tekton-results-api', grpc_service=~'tekton.results.*'}[$__range]))",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Tekton Results API Success",
+          "type": "gauge"
+        },
+        {
+          "description": "The rate of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 87
+          },
+          "id": 112,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The rate of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Deadlocked Chains",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The rate of PipelineRuns/TaskRuns still needing processing by Tekton Chains Controller",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 50
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 87
+          },
+          "id": 113,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(delta(watcher_workqueue_depth{container='tekton-chains-controller',app='tekton-chains-controller'}[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Deadlocked Chains",
+          "type": "stat"
+        },
+        {
+          "description": "The number of PipelineRuns/TaskRuns still needing processing by Tekton PAC Controller",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 94
+          },
+          "id": 123,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>The number of PipelineRuns/TaskRuns still needing processing by Tekton PAC Controller</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Deadlocked PAC",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The number of PipelineRuns/TaskRuns still needing processing by Tekton PAC Controller",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "noValue": "No data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 50
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 94
+          },
+          "id": 124,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(delta(pac_watcher_work_queue_depth[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Deadlocked PAC",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 101
+          },
+          "id": 125,
+          "panels": [],
+          "title": "Project Controller SLOs",
+          "type": "row"
+        },
+        {
+          "description": "The objective for the given time window.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 102
+          },
+          "id": 126,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>100% of service replicas must be available within the measurment timeframe</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Availability SLO",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The current measurement for the given time window.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "noValue": "-",
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "red"
+                  },
+                  {
+                    "color": "green",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 10,
+            "y": 102
+          },
+          "id": 127,
+          "maxDataPoints": 100,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(kube_deployment_status_replicas_available{namespace=\"project-controller\"})\n/\nsum(kube_deployment_spec_replicas{namespace=\"project-controller\"})",
+              "format": "time_series",
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Measured",
+          "type": "gauge"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 109
+          },
+          "id": 128,
+          "panels": [],
+          "title": "KubeArchive SLOs",
+          "type": "row"
+        },
+        {
+          "description": "The objective for the given time window.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 110
+          },
+          "id": 129,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>100% of service replicas must be available within the measurment timeframe</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "Availability SLO",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The current measurement for the given time window.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "noValue": "-",
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "red"
+                  },
+                  {
+                    "color": "green",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 10,
+            "y": 110
+          },
+          "id": 130,
+          "maxDataPoints": 100,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "konflux_up{service=~\"kubearchive-.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "legendFormat": "{{service}}",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Measured",
+          "type": "gauge"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 117
+          },
+          "id": 33,
+          "panels": [],
+          "title": "SLO Template",
+          "type": "row"
+        },
+        {
+          "description": "The objective for the given time window.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 118
+          },
+          "id": 10,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><center>SLO Definition</center></h1>",
+            "mode": "html"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "SLO",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The current measurement for the given time window.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 0,
+            "y": 125
+          },
+          "id": 98,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Measured",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The remaining error budget for the given time window.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 5,
+            "y": 125
+          },
+          "id": 29,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Error Budget (%)",
+          "type": "stat"
+        }
+      ],
+      "preload": false,
+      "refresh": "1h",
+      "schemaVersion": 41,
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "text": "rhtap-observatorium-production",
+              "value": "P22466E8E7855F1E0"
+            },
+            "includeAll": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "/^rhtap-/",
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-28d",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Konflux SLOs hemartin",
+      "uid": "eeqlgjrl5d7ggf",
+      "version": 3
     }
 kind: ConfigMap
 metadata:

--- a/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml
@@ -1,0 +1,72 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-kubearchive-availability-alerting-rules
+  labels:
+    tenant: rhtap
+
+spec:
+  groups:
+    - name: kubearchive-operator-availability
+      interval: 1m
+      rules:
+        - alert: KubeArchiveOperatorDown
+          expr: |
+            konflux_up{
+              check="replicas-available",
+              service="kubearchive-operator"
+            } != 1
+          for: 5m
+          labels:
+            severity: critical
+            slo: "true"
+          annotations:
+            summary: >-
+              KubeArchive Operator pod is down in cluster {{ $labels.source_cluster }}
+            description: >
+              KubeArchive Operator pod has been down for 5min in cluster {{ $labels.source_cluster }}
+            alert_team_handle: <!subteam^S088TRDUGG0>
+            team: kubearchive
+            runbook_url: null
+    - name: kubearchive-api-availability
+      interval: 1m
+      rules:
+        - alert: KubeArchiveOperatorDown
+          expr: |
+            konflux_up{
+              check="replicas-available",
+              service="kubearchive-api-server"
+            } != 1
+          for: 5m
+          labels:
+            severity: critical
+            slo: "true"
+          annotations:
+            summary: >-
+              KubeArchive API Server pod is down in cluster {{ $labels.source_cluster }}
+            description: >
+              KubeArchive API Server pod has been down for 5min in cluster {{ $labels.source_cluster }}
+            alert_team_handle: <!subteam^S088TRDUGG0>
+            team: kubearchive
+            runbook_url: null
+    - name: kubearchive-sink-availability
+      interval: 1m
+      rules:
+        - alert: KubeArchiveSinkDown
+          expr: |
+            konflux_up{
+              check="replicas-available",
+              service="kubearchive-sink"
+            } != 1
+          for: 5m
+          labels:
+            severity: critical
+            slo: "true"
+          annotations:
+            summary: >-
+              KubeArchive Sink pod is down in cluster {{ $labels.source_cluster }}
+            description: >
+              KubeArchive Sink pod has been down for 5min in cluster {{ $labels.source_cluster }}
+            alert_team_handle: <!subteam^S088TRDUGG0>
+            team: kubearchive
+            runbook_url: null


### PR DESCRIPTION
* Created basic SLO alerts based on the `konflux_up` metric, will refine in the future.
* I added a new row with KubeArchive's SLO in the dashboard, but the diff got all screwed up. I just copied directly from the Grafana export window.