### PR TITLE
fix(PVO11Y-4840): Restore Konflux SLOs dashboard name and uid

### DIFF
--- a/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
+++ b/dashboards/grafana-dashboard-rhtap-slos.configmap.yaml
@@ -2019,8 +2019,8 @@ data:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "Konflux SLOs hemartin",
-      "uid": "eeqlgjrl5d7ggf",
+      "title": "Konflux SLOs",
+      "uid": "rhtap-slos",
       "version": 3
     }
 kind: ConfigMap


### PR DESCRIPTION
PR #652 accidentally changed the Konflux SLOs dashboard's name and uid which change the URL to the dashboard. Restore the original name and uid to restore the original URL to the dashboard.