### PR TITLE
fix(SPRE-1542) Observability dashboard fix

### DIFF
--- a/rhobs/recording/api_server_availability_recording_rules.yaml
+++ b/rhobs/recording/api_server_availability_recording_rules.yaml
@@ -20,7 +20,9 @@ spec:
                 sum by(source_cluster) (
                   code:apiserver_request_total:rate5m{code!="0"}
                 )
+                OR on(source_cluster) vector(0.000001)
               ) * 100, "service", "api-server", "", ""
             )
+            <= 5
           labels:
             service: api-server


### PR DESCRIPTION
api_server konflux up alert is visibile on production but it is not on the observability exporter: https://grafana.app-sre.devshift.net/d/fdifr5mbapv5sb/availability-exporter-dashboard?orgId=1&from=now-5m&to=now&timezone=browser&var-Datasource=P22466E8E7855F1E0&var-service=api-server&var-check=$__all&var-cluster=$__all

We need to convert the error rate into:

konflux_up = 1 if the API server's 5-minute error rate is below 5%.
konflux_up = 0 if the API server's 5-minute error rate is 5% or above.