### PR TITLE
fix(SPRE-1542) API Server code fix

### DIFF
--- a/rhobs/recording/api_server_availability_recording_rules.yaml
+++ b/rhobs/recording/api_server_availability_recording_rules.yaml
@@ -23,6 +23,6 @@ spec:
                 OR on(source_cluster) vector(0.000001)
               ) * 100, "service", "api-server", "", ""
             )
-            <= 5
+            <= bool 5
           labels:
             service: api-server

--- a/test/promql/tests/recording/api_server_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/api_server_availability_recording_rules_test.yaml
@@ -20,4 +20,4 @@ tests:
         eval_time: 1m
         exp_samples:
           - labels: '{__name__="konflux_up", service="api-server"}'
-            value: 5
+            value: 1


### PR DESCRIPTION
Based on https://issues.redhat.com/browse/SPRE-1542 the konflux_up signal works correctly but for some reason was not getting displayed into the availability exporter dashboard.
We have converted the values into boolean and that should do the trick.