### PR TITLE
feat(/SPRE-1597): CPU Usage refinement

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.node_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.node_alerts.yaml
@@ -38,8 +38,9 @@ spec:
               Master Node High Memory Usage.
             description: >-
               Memory Usage is {{$value}}% on master node {{ $labels.instance }} in cluster {{ $labels.source_cluster }}.
+            alert_team_handle: >-
+              <!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/node_alerts.md
-            alert_routing_key: perfandspreandinfra
 
         # Infra Node Alerts
         - alert: InfraNodeHighCPU

--- a/rhobs/alerting/data_plane/prometheus.node_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.node_alerts.yaml
@@ -1,0 +1,70 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-node-cluster-alerting
+  labels:
+    tenant: rhtap
+spec:
+
+  groups:
+    - name: node_cluster_alerts
+      interval: 1m
+      rules:
+        # Master Node Alerts 
+        - alert: MasterNodeHighCPU
+          expr: |
+            (100 * avg(1 - rate(node_cpu_seconds_total{mode="idle"}[5m])) by (instance, source_cluster)
+            and on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )) > 95
+          for: 10m
+          labels:
+            severity: high
+          annotations:
+            summary: >-
+              Master Node High CPU Usage.
+            description: >-
+              CPU Usage is {{$value}}% on master node {{ $labels.instance }} in cluster {{ $labels.source_cluster }}.
+            alert_routing_key: perfandspreandinfra
+            
+        - alert: MasterNodeHighMemory
+          expr: |
+            (avg by (source_cluster,instance) (100 * ((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes))
+            and on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )) > 90
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              Master Node High Memory Usage.
+            description: >-
+              Memory Usage is {{$value}}% on master node {{ $labels.instance }} in cluster {{ $labels.source_cluster }}.
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/node_alerts.md
+            alert_routing_key: perfandspreandinfra
+  
+        # Infra Node Alerts
+        - alert: InfraNodeHighCPU
+          expr: |
+            (100 * avg(1 - rate(node_cpu_seconds_total{mode="idle"}[5m])) by (instance, source_cluster)
+            and on (instance) label_replace( kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)" )) > 95
+          for: 10m
+          labels:
+            severity: high
+          annotations:
+            summary: >-
+              Infra Node High CPU Usage.
+            description: >-
+              CPU Usage is {{$value}}% on infra node {{ $labels.instance }} in cluster {{ $labels.source_cluster }}.
+            alert_routing_key: perfandspreandinfra
+  
+        - alert: InfraNodeHighMemory
+          expr: |
+            (avg by (source_cluster,instance) (100 * ((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes))
+            and on (instance) label_replace( kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)" )) > 90
+          for: 10m
+          labels:
+            severity: high
+          annotations:
+            summary: >-
+              Infra Node High Memory Usage.
+            description: >-
+              Infra Memory Usage is {{$value}}% on infra node {{ $labels.instance }} in cluster {{ $labels.source_cluster }}.
+            alert_routing_key: perfandspreandinfra

--- a/rhobs/alerting/data_plane/prometheus.node_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.node_alerts.yaml
@@ -10,7 +10,7 @@ spec:
     - name: node_cluster_alerts
       interval: 1m
       rules:
-        # Master Node Alerts 
+        # Master Node Alerts
         - alert: MasterNodeHighCPU
           expr: |
             (100 * avg(1 - rate(node_cpu_seconds_total{mode="idle"}[5m])) by (instance, source_cluster)
@@ -24,7 +24,7 @@ spec:
             description: >-
               CPU Usage is {{$value}}% on master node {{ $labels.instance }} in cluster {{ $labels.source_cluster }}.
             alert_routing_key: perfandspreandinfra
-            
+
         - alert: MasterNodeHighMemory
           expr: |
             (avg by (source_cluster,instance) (100 * ((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes))
@@ -39,7 +39,7 @@ spec:
               Memory Usage is {{$value}}% on master node {{ $labels.instance }} in cluster {{ $labels.source_cluster }}.
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/node_alerts.md
             alert_routing_key: perfandspreandinfra
-  
+
         # Infra Node Alerts
         - alert: InfraNodeHighCPU
           expr: |
@@ -54,7 +54,7 @@ spec:
             description: >-
               CPU Usage is {{$value}}% on infra node {{ $labels.instance }} in cluster {{ $labels.source_cluster }}.
             alert_routing_key: perfandspreandinfra
-  
+
         - alert: InfraNodeHighMemory
           expr: |
             (avg by (source_cluster,instance) (100 * ((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes))

--- a/rhobs/alerting/data_plane/prometheus.node_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.node_alerts.yaml
@@ -32,6 +32,7 @@ spec:
           for: 10m
           labels:
             severity: critical
+            slo: "true"
           annotations:
             summary: >-
               Master Node High Memory Usage.

--- a/rhobs/alerting/data_plane/prometheus.performance_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.performance_alerts.yaml
@@ -79,16 +79,17 @@ spec:
         # Node based Alerts
         - alert: NodeHighCPU
           expr: |
-            (100 * avg(1 - rate(node_cpu_seconds_total{mode="idle"}[5m])) by (instance, source_cluster)) > 95
+            count by (source_cluster) ((100 * avg(1 - rate(node_cpu_seconds_total{mode="idle"}[5m])) by (instance, source_cluster)) > 95) > 2
           for: 10m
           labels:
             severity: high
           annotations:
-            summary: >-
-              Node High CPU Usage.
-            description: >-
-              CPU Usage is {{$value}}% on node {{ $labels.instance }} in cluster {{ $labels.source_cluster }}.
-            alert_routing_key: perfandspreandinfra
+            # Use | for multiline, which often helps avoid unexpected quotes
+            # Or ensure you *don't* put quotes around the templated string if using >-
+            # The error implies Prometheus is adding quotes, so let's expect them.
+            summary: "Instances with high CPU in {{ $labels.source_cluster }}"
+            description: "More than 2 instances in cluster {{ $labels.source_cluster }} have had CPU usage above 95% for the last 5 minutes."
+            alert_routing_key: perfandspreandinfra # This is an annotation!
 
         - alert: NodeHighMemory
           expr: |

--- a/test/promql/tests/data_plane/node_alerts_test.yaml
+++ b/test/promql/tests/data_plane/node_alerts_test.yaml
@@ -58,6 +58,7 @@ tests:
               severity: critical
               instance: instance1
               source_cluster: cluster01
+              slo: "true"
             exp_annotations:
               summary: "Master Node High Memory Usage."
               description: "Memory Usage is 98% on master node instance1 in cluster cluster01."

--- a/test/promql/tests/data_plane/node_alerts_test.yaml
+++ b/test/promql/tests/data_plane/node_alerts_test.yaml
@@ -1,0 +1,146 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.node_alerts.yaml
+
+tests:
+  # Master Node Tests
+  - name: Test High CPU Usage on Master Node
+  - interval: 1m
+    input_series:
+      # Node is running with 100% CPU usage, so it will be alerted.
+      - series: 'node_cpu_seconds_total{instance="instance1", mode="idle", source_cluster="cluster01"}'
+        values: '0.01+0x15'
+      - series: 'node_cpu_seconds_total{instance="instance2", mode="idle", source_cluster="cluster01"}'
+        values: '0.85+0x10'
+      - series: 'kube_node_role{node="instance1", role="master"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: MasterNodeHighCPU
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              instance: instance1
+              source_cluster: cluster01
+            exp_annotations:
+              summary: "Master Node High CPU Usage."
+              description: "CPU Usage is 100% on master node instance1 in cluster cluster01."
+              alert_routing_key: perfandspreandinfra
+  - interval: 1m
+    input_series:
+      - series: 'node_cpu_seconds_total{instance="instance1", mode="idle", source_cluster="cluster01"}'
+        values: '0.75-0.1x10'
+      - series: 'node_cpu_seconds_total{instance="instance2", mode="idle", source_cluster="cluster01"}'
+        values: '0.85+0x10'
+      - series: 'kube_node_role{node="instance1", role="master"}'
+        values: '1+0x10'
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: MasterNodeHighCPU
+
+  - name: Test High Memory Usage on Master Node
+  - interval: 1m
+    input_series:
+      # Node is running with 98% memory usage, so it will be alerted.
+      - series: 'node_memory_MemTotal_bytes{instance="instance1", source_cluster="cluster01"}'
+        values: '100+0x9'
+      - series: 'node_memory_MemAvailable_bytes{instance="instance1", source_cluster="cluster01"}'
+        values: '2+0x9'
+      - series: 'kube_node_role{node="instance1", role="master"}'
+        values: '1+0x9'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: MasterNodeHighMemory
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: instance1
+              source_cluster: cluster01
+            exp_annotations:
+              summary: "Master Node High Memory Usage."
+              description: "Memory Usage is 98% on master node instance1 in cluster cluster01."
+              alert_routing_key: perfandspreandinfra
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/node_alerts.md
+
+  - interval: 1m
+    input_series:
+      - series: 'node_memory_MemTotal_bytes{instance="instance2", source_cluster="cluster01"}'
+        values: '100x9'
+      - series: 'node_memory_MemAvailable_bytes{instance="instance2", source_cluster="cluster01"}'
+        values: '98x9'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: MasterNodeHighMemory
+  # Infra Node Tests
+  - name: Test High CPU Usage on Infra Node
+  - interval: 1m
+    input_series:
+      # Node is running with 100% CPU usage, so it will be alerted.
+      - series: 'node_cpu_seconds_total{instance="instance1", mode="idle", source_cluster="cluster01"}'
+        values: '0.01+0x15'
+      - series: 'node_cpu_seconds_total{instance="instance2", mode="idle", source_cluster="cluster01"}'
+        values: '0.85+0x10'
+      - series: 'kube_node_role{node="instance1", role="infra"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: InfraNodeHighCPU
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              instance: instance1
+              source_cluster: cluster01
+            exp_annotations:
+              summary: "Infra Node High CPU Usage."
+              description: "CPU Usage is 100% on infra node instance1 in cluster cluster01."
+              alert_routing_key: perfandspreandinfra
+  - interval: 1m
+    input_series:
+      - series: 'node_cpu_seconds_total{instance="instance1", mode="idle", source_cluster="cluster01"}'
+        values: '0.75-0.1x10'
+      - series: 'node_cpu_seconds_total{instance="instance2", mode="idle", source_cluster="cluster01"}'
+        values: '0.85+0x10'
+      - series: 'kube_node_role{node="instance1", role="infra"}'
+        values: '1+0x10'
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: InfraNodeHighCPU
+
+  - name: Test High Memory Usage on Master Node
+  - interval: 1m
+    input_series:
+      # Node is running with 98% memory usage, so it will be alerted.
+      - series: 'node_memory_MemTotal_bytes{instance="instance1", source_cluster="cluster01"}'
+        values: '100+0x9'
+      - series: 'node_memory_MemAvailable_bytes{instance="instance1", source_cluster="cluster01"}'
+        values: '2+0x9'
+      - series: 'kube_node_role{node="instance1", role="infra"}'
+        values: '1+0x9'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: InfraNodeHighMemory
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              instance: instance1
+              source_cluster: cluster01
+            exp_annotations:
+              summary: "Infra Node High Memory Usage."
+              description: "Infra Memory Usage is 98% on infra node instance1 in cluster cluster01."
+              alert_routing_key: perfandspreandinfra
+
+  - interval: 1m
+    input_series:
+      # Node is running under 90% memory usage, so it will not be alerted.
+      - series: 'node_memory_MemTotal_bytes{instance="instance2", source_cluster="cluster01"}'
+        values: '100x9'
+      - series: 'node_memory_MemAvailable_bytes{instance="instance2", source_cluster="cluster01"}'
+        values: '98x9'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: InfraNodeHighMemory

--- a/test/promql/tests/data_plane/node_alerts_test.yaml
+++ b/test/promql/tests/data_plane/node_alerts_test.yaml
@@ -62,7 +62,7 @@ tests:
             exp_annotations:
               summary: "Master Node High Memory Usage."
               description: "Memory Usage is 98% on master node instance1 in cluster cluster01."
-              alert_routing_key: perfandspreandinfra
+              alert_team_handle: '<!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>'
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/node_alerts.md
 
   - interval: 1m

--- a/test/promql/tests/data_plane/performance_test.yaml
+++ b/test/promql/tests/data_plane/performance_test.yaml
@@ -299,7 +299,9 @@ tests:
       - series: 'node_cpu_seconds_total{instance="instance1", mode="idle", source_cluster="cluster01"}'
         values: '0.01+0x15'
       - series: 'node_cpu_seconds_total{instance="instance2", mode="idle", source_cluster="cluster01"}'
-        values: '0.85+0x10'
+        values: '0.01+0x15'
+      - series: 'node_cpu_seconds_total{instance="instance3", mode="idle", source_cluster="cluster01"}'
+        values: '0.01+0x15'
 
     alert_rule_test:
       - eval_time: 15m
@@ -307,11 +309,10 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: high
-              instance: instance1
               source_cluster: cluster01
             exp_annotations:
-              summary: "Node High CPU Usage."
-              description: "CPU Usage is 100% on node instance1 in cluster cluster01."
+              summary: "Instances with high CPU in cluster01"
+              description: "More than 2 instances in cluster cluster01 have had CPU usage above 95% for the last 5 minutes."
               alert_routing_key: perfandspreandinfra
 
   - interval: 1m


### PR DESCRIPTION
As of today, the alert was triggered when each individual instance per cluster was failing.
This made the alert to be quite noisy and a single full instance is not a real indicator of an issue.
We have set the alert to fire when there is +2 instances per cluster full which still not 100% an indicator of an issue but that should reduce the amount of alerts we received until we define a proper SLO alert+SOP 