### PR TITLE
feat(/SPRE-1597): CPU Usage refinement

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.performance_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.performance_alerts.yaml
@@ -79,15 +79,13 @@ spec:
         # Node based Alerts
         - alert: NodeHighCPU
           expr: |
-            (100 * avg(1 - rate(node_cpu_seconds_total{mode="idle"}[5m])) by (instance, source_cluster)) > 95
+            count by (source_cluster) ((100 * avg(1 - rate(node_cpu_seconds_total{mode="idle"}[5m])) by (instance, source_cluster)) > 95) > 2
           for: 10m
           labels:
             severity: high
           annotations:
-            summary: >-
-              Node High CPU Usage.
-            description: >-
-              CPU Usage is {{$value}}% on node {{ $labels.instance }} in cluster {{ $labels.source_cluster }}.
+            summary: "Instances with high CPU in {{ $labels.source_cluster }}"
+            description: "More than 2 instances in cluster {{ $labels.source_cluster }} have had CPU usage above 95% for the last 5 minutes."
             alert_routing_key: perfandspreandinfra
 
         - alert: NodeHighMemory

--- a/test/promql/tests/data_plane/performance_test.yaml
+++ b/test/promql/tests/data_plane/performance_test.yaml
@@ -299,7 +299,9 @@ tests:
       - series: 'node_cpu_seconds_total{instance="instance1", mode="idle", source_cluster="cluster01"}'
         values: '0.01+0x15'
       - series: 'node_cpu_seconds_total{instance="instance2", mode="idle", source_cluster="cluster01"}'
-        values: '0.85+0x10'
+        values: '0.01+0x15'
+      - series: 'node_cpu_seconds_total{instance="instance3", mode="idle", source_cluster="cluster01"}'
+        values: '0.01+0x15'
 
     alert_rule_test:
       - eval_time: 15m
@@ -307,11 +309,10 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: high
-              instance: instance1
               source_cluster: cluster01
             exp_annotations:
-              summary: "Node High CPU Usage."
-              description: "CPU Usage is 100% on node instance1 in cluster cluster01."
+              summary: "Instances with high CPU in cluster01"
+              description: "More than 2 instances in cluster cluster01 have had CPU usage above 95% for the last 5 minutes."
               alert_routing_key: perfandspreandinfra
 
   - interval: 1m


### PR DESCRIPTION
As of today, the alert was triggered when each individual instance per cluster was failing.
This made the alert to be quite noisy and a single full instance is not a real indicator of an issue.
We have set the alert to fire when there is +2 instances per cluster full which still not 100% an indicator of an issue but that should reduce the amount of alerts we received until we define a proper SLO alert+SOP