### PR TITLE
Added two new Prometheus alerts for kyverno

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kyverno_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kyverno_alerts.yaml
@@ -13,14 +13,42 @@ spec:
       - alert: KyvernoDeploymentDown
         expr: |
           kube_deployment_spec_replicas{namespace="konflux-kyverno"} != kube_deployment_status_replicas_ready{namespace="konflux-kyverno"}
-        for: 5m
+        for: 3m
         labels:
           severity: critical
           slo: "true"
         annotations:
-          summary: Kyverno has reported that not all the deployments pods are up and running for the last 5 minutes.
+          summary: Kyverno has reported that not all the deployments pods are up and running for the last 3 minutes.
           description: "The Kyverno Deployment '{{ $labels.deployment }}' in namespace '{{ $labels.namespace }}' on cluster '{{ $labels.source_cluster }}' is unhealthy."
           alert_team_handle: <!subteam^S05Q1P4Q2TG>
+          team: konflux-infra
+          # kyverno/README.md currently in progress.
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kyverno/README.md
+      - alert: KyvernoControllerRequeueErrors
+        expr: |
+          rate(kyverno_controller_requeue_total[1m]) > 0
+        for: 3m
+        labels:
+          severity: critical
+          slo: "true"
+        annotations:
+          summary: Kyverno internal controllers are encountering errors causing items to be re-queued.
+          description: "The Kyverno controller '{{ $labels.controller_name }}' on cluster '{{ $labels.source_cluster }}' is experiencing a consistent rate of requeue errors."
+          alert_team_handle: <!subteam^S05Q1P4Q2TG>
+          team: konflux-infra
+          # kyverno/README.md currently in progress.
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kyverno/README.md
+      - alert: KyvernoPolicyFailures
+        expr: |
+          increase(kyverno_policy_results_total{rule_result=~"fail|error"}[1m]) > 10
+        for: 3m
+        labels:
+          severity: warning
+          slo: "false"
+        annotations:
+          summary: Kyverno policies are failing or erroring out more often than usual.
+          description: "Kyverno policy '{{ $labels.policy_name }}' with rule '{{ $labels.rule_name }}' is encountering internal errors during evaluation or rejecting resources on instance '{{ $labels.instance }}' on cluster '{{ $labels.source_cluster }}'."
+          alert_routing_key: infra
           team: konflux-infra
           # kyverno/README.md currently in progress.
           runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kyverno/README.md

--- a/test/promql/tests/data_plane/kyverno_test.yaml
+++ b/test/promql/tests/data_plane/kyverno_test.yaml
@@ -6,7 +6,7 @@ rule_files:
 tests:
 # --- alerts for kyverno pods failures ---
 
-  # Scenario 1: Deployment is continuously down for 5 minutes, alert should fire.
+  # Scenario 1: Deployment is continuously down for 3 minutes, alert should fire.
   - interval: 1m
     input_series:
       - series: 'kube_deployment_spec_replicas{deployment="kyverno-admission-controller", namespace="konflux-kyverno", source_cluster="stone-stg-rh01"}'
@@ -18,10 +18,10 @@ tests:
       - series: 'kube_deployment_status_replicas_ready{deployment="kyverno-background-controller", namespace="konflux-kyverno", source_cluster="stone-stg-rh01"}'
         values: '1 1 1 1 1 1'
     alert_rule_test:
-      - eval_time: 4m
+      - eval_time: 2m
         alertname: KyvernoDeploymentDown
         exp_alerts: []
-      - eval_time: 5m
+      - eval_time: 3m
         alertname: KyvernoDeploymentDown
         exp_alerts:
           - exp_labels:
@@ -31,12 +31,12 @@ tests:
               namespace: konflux-kyverno
               source_cluster: stone-stg-rh01
             exp_annotations:
-              summary: Kyverno has reported that not all the deployments pods are up and running for the last 5 minutes.
+              summary: Kyverno has reported that not all the deployments pods are up and running for the last 3 minutes.
               description: "The Kyverno Deployment 'kyverno-admission-controller' in namespace 'konflux-kyverno' on cluster 'stone-stg-rh01' is unhealthy."
               team: konflux-infra
               alert_team_handle: <!subteam^S05Q1P4Q2TG>
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kyverno/README.md
-      - eval_time: 6m
+      - eval_time: 4m
         alertname: KyvernoDeploymentDown
         exp_alerts:
           - exp_labels:
@@ -46,22 +46,130 @@ tests:
               namespace: konflux-kyverno
               source_cluster: stone-stg-rh01
             exp_annotations:
-              summary: Kyverno has reported that not all the deployments pods are up and running for the last 5 minutes.
+              summary: Kyverno has reported that not all the deployments pods are up and running for the last 3 minutes.
               description: "The Kyverno Deployment 'kyverno-admission-controller' in namespace 'konflux-kyverno' on cluster 'stone-stg-rh01' is unhealthy."
               team: konflux-infra
               alert_team_handle: <!subteam^S05Q1P4Q2TG>
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kyverno/README.md
-  # Scenario 2: Deployment is down for less than 5 minutes, alert should NOT fire.
+  # Scenario 2: Deployment is down for less than 3 minutes, alert should NOT fire.
   - interval: 1m
     input_series:
       - series: 'kube_deployment_spec_replicas{deployment="kyverno-background-controller", namespace="konflux-kyverno", source_cluster="stone-stg-rh01"}'
         values: '1 1 1 1 1'
       - series: 'kube_deployment_status_replicas_ready{deployment="kyverno-background-controller", namespace="konflux-kyverno", source_cluster="stone-stg-rh01"}'
-        values: '0 0 1 1 1'
+        values: '0 0 1 0 1'
     alert_rule_test:
+      - eval_time: 2m
+        alertname: KyvernoDeploymentDown
+        exp_alerts: []
       - eval_time: 4m
         alertname: KyvernoDeploymentDown
         exp_alerts: []
+
+# --- alerts for kyverno controller requeue errors ---
+
+  # Scenario 1: Kyverno controller is continuously experiencing requeue errors for 3 minutes, alert should fire.
+  - interval: 1m
+    input_series:
+      - series: 'kyverno_controller_requeue_total{controller_name="certmanager-controller", source_cluster="stone-stg-rh01"}'
+        values: '0 1 2 3 4 4'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: KyvernoControllerRequeueErrors
+        exp_alerts: []
+      - eval_time: 4m
+        alertname: KyvernoControllerRequeueErrors
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo: "true"
+              controller_name: certmanager-controller
+              source_cluster: stone-stg-rh01
+            exp_annotations:
+              summary: Kyverno internal controllers are encountering errors causing items to be re-queued.
+              description: "The Kyverno controller 'certmanager-controller' on cluster 'stone-stg-rh01' is experiencing a consistent rate of requeue errors."
+              team: konflux-infra
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kyverno/README.md
       - eval_time: 5m
-        alertname: KyvernoDeploymentDown
+        alertname: KyvernoControllerRequeueErrors
+        exp_alerts: []
+  # Scenario 2: Kyverno controller is experiencing requeue errors for less than 3 minutes, alert should NOT fire.
+  - interval: 1m
+    input_series:
+      - series: 'kyverno_controller_requeue_total{controller_name="certmanager-controller", source_cluster="stone-stg-rh01"}'
+        values: '0 1 0 0 0 0'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: KyvernoControllerRequeueErrors
+        exp_alerts: []
+      - eval_time: 4m
+        alertname: KyvernoControllerRequeueErrors
+        exp_alerts: []
+
+# --- alerts for kyverno policy failures ---
+
+  # Scenario 1: Kyverno policies are failing or erroring out more often than usual for 3 minutes, alert should fire.
+  - interval: 1m
+    input_series:
+      - series: 'kyverno_policy_results_total{policy_name="propagate-cost-management-labels",  rule_name="autogen-propagate-existing-cost-center-from-namespace", rule_result="error", instance="10.128.10.157:8000", source_cluster="stone-stg-rh01"}'
+        values: '0 10 35 70 105 120 120 135 160 180 191'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: KyvernoPolicyFailures
+        exp_alerts: []
+      - eval_time: 4m
+        alertname: KyvernoPolicyFailures
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: KyvernoPolicyFailures
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              policy_name: propagate-cost-management-labels
+              rule_name: autogen-propagate-existing-cost-center-from-namespace
+              instance: "10.128.10.157:8000"
+              source_cluster: stone-stg-rh01
+              rule_result: error
+            exp_annotations:
+              summary: Kyverno policies are failing or erroring out more often than usual.
+              description: "Kyverno policy 'propagate-cost-management-labels' with rule 'autogen-propagate-existing-cost-center-from-namespace' is encountering internal errors during evaluation or rejecting resources on instance '10.128.10.157:8000' on cluster 'stone-stg-rh01'."
+              team: konflux-infra
+              alert_routing_key: infra
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kyverno/README.md
+      - eval_time: 6m
+        alertname: KyvernoPolicyFailures
+        exp_alerts: []
+      - eval_time: 9m
+        alertname: KyvernoPolicyFailures
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: KyvernoPolicyFailures
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              policy_name: propagate-cost-management-labels
+              rule_name: autogen-propagate-existing-cost-center-from-namespace
+              instance: "10.128.10.157:8000"
+              source_cluster: stone-stg-rh01
+              rule_result: error
+            exp_annotations:
+              summary: Kyverno policies are failing or erroring out more often than usual.
+              description: "Kyverno policy 'propagate-cost-management-labels' with rule 'autogen-propagate-existing-cost-center-from-namespace' is encountering internal errors during evaluation or rejecting resources on instance '10.128.10.157:8000' on cluster 'stone-stg-rh01'."
+              team: konflux-infra
+              alert_routing_key: infra
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kyverno/README.md
+  # Scenario 2: Kyverno policies are failing or erroring out for less than 3 minutes, alert should NOT fire.
+  - interval: 1m
+    input_series:
+      - series: 'kyverno_policy_results_total{policy_name="propagate-cost-management-labels", policy_rule="autogen-propagate-existing-cost-center-from-namespace", rule_result="error", instance="10.128.10.157:8000", source_cluster="stone-stg-rh01"}'
+        values: '10 20 30 40 50 60'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: KyvernoPolicyFailures
+        exp_alerts: []
+      - eval_time: 4m
+        alertname: KyvernoPolicyFailures
         exp_alerts: []


### PR DESCRIPTION
# summary:
Add Kyverno Controller Requeue Errors and Policy Failures Alerts.
This PR introduces two new Prometheus alerts to enhance our monitoring of Kyverno's operational health and policy enforcement:

## 1. KyvernoControllerRequeueErrors (SLO Alert)
* **Trigger:** Kyverno internal controllers are encountering errors, causing items to be re-queued for 3 consecutive minutes.
* **PromQL Concept:** This alert uses `increase(kyverno_controller_requeue_total[1m]) > 0` with a `for: 3m` clause.
* **Runbook (in progress):** Refer to the updated Kyverno Runbook for troubleshooting: [https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kyverno/README.md](https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kyverno/README.md)

## 2. KyvernoPolicyFailures (Non-SLO Alert)
* **Trigger:** Kyverno policies are failing or erroring out more than usual (specifically, more than 10 new failures/errors per minute) for 3 consecutive minutes.
* **PromQL Concept:** This alert uses `increase(kyverno_policy_results_total{rule_result=~"fail|error"}[1m]) > 10` with a `for: 3m` clause.
* **Runbook (in progress):** Refer to the updated Kyverno Runbook for troubleshooting: [https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kyverno/README.md](https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kyverno/README.md)
