### PR TITLE
fix(SPRE-1623) Api server SOP + http error refinement"

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml
@@ -14,7 +14,7 @@ spec:
       expr: |
         (
           sum by(source_cluster) (
-            code:apiserver_request_total:rate5m{code=~"429|5.."}
+            code:apiserver_request_total:rate5m{code=~"5.."}
           ) /
           sum by(source_cluster) (
             code:apiserver_request_total:rate5m{code!="0"}
@@ -27,7 +27,7 @@ spec:
       annotations:
         summary: >-
           API Server 5XX error count in cluster {{ $labels.source_cluster }}
-        description: "API Server is experiencing 5% of 5XX/429 failures based on the total requests for 5min in cluster {{ $labels.source_cluster }}"
+        description: "API Server is experiencing 5% of 5XX failures based on the total requests for 5min in cluster {{ $labels.source_cluster }}"
         alert_team_handle: <!subteam^S05Q1P4Q2TG>
         team: konflux-infra
-        runbook_url: null
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/api_server_error_rate_alert.md

--- a/rhobs/recording/api_server_availability_recording_rules.yaml
+++ b/rhobs/recording/api_server_availability_recording_rules.yaml
@@ -15,7 +15,7 @@ spec:
             label_replace(
               (
                 sum by(source_cluster) (
-                  code:apiserver_request_total:rate5m{code=~"429|5.."}
+                  code:apiserver_request_total:rate5m{code=~"5.."}
                 ) /
                 sum by(source_cluster) (
                   code:apiserver_request_total:rate5m{code!="0"}

--- a/test/promql/tests/data_plane/api_server_availability_test.yaml
+++ b/test/promql/tests/data_plane/api_server_availability_test.yaml
@@ -27,7 +27,7 @@ tests:
               source_cluster: "kflux-prd-es01"
             exp_annotations:
               summary: "API Server 5XX error count in cluster kflux-prd-es01"
-              description: "API Server is experiencing 5% of 5XX/429 failures based on the total requests for 5min in cluster kflux-prd-es01"
+              description: "API Server is experiencing 5% of 5XX failures based on the total requests for 5min in cluster kflux-prd-es01"
               alert_team_handle: "<!subteam^S05Q1P4Q2TG>"
               team: konflux-infra
-              runbook_url: ""
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/api_server_error_rate_alert.md

--- a/test/promql/tests/recording/api_server_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/api_server_availability_recording_rules_test.yaml
@@ -9,9 +9,7 @@ tests:
     interval: 1m # Correct placement and spelling of interval
     input_series:
       - series: 'code:apiserver_request_total:rate5m{code="503"}'
-        values: '0+4x60'
-      - series: 'code:apiserver_request_total:rate5m{code="429"}'
-        values: '0+1x60'
+        values: '0+5x60'
       - series: 'code:apiserver_request_total:rate5m{code="200"}'
         values: '0+95x60'
 


### PR DESCRIPTION
Based on https://issues.redhat.com/browse/SPRE-1623 we have added a SOP to handle 5XX error code.
https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/api_server_error_rate_alert.md

As well as this, the error rate was triggered based on 429/5XX error codes and since this was causing some false positives, we have removed 429, for which we will just react to 5XX error code.