### PR TITLE
MintMaker cluster ram metrics

### DIFF
--- a/rhobs/recording/mintmaker_service_quality_recording_rules.yaml
+++ b/rhobs/recording/mintmaker_service_quality_recording_rules.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-mintmaker-service-quality
+  labels:
+    tenant: rhtap
+
+spec:
+  groups:
+    - name: mintmaker_cluster_ram_requested_perc
+      interval: 1m
+      rules:
+        - record: cluster_ram_requested_perc
+          expr: |
+            sum(kube_pod_container_resource_requests{resource='memory'})
+            /
+            sum(kube_node_status_allocatable{resource='memory'})
+
+    - name: mintmaker_node_memory_pressured_perc
+      interval: 1m
+      rules:
+        - record: node_memory_pressured_perc
+          expr: |
+            sum(kube_node_status_condition{condition="MemoryPressure", status="true"})
+            /
+            count(kube_node_info)

--- a/test/promql/tests/recording/mintmaker_service_quality_recording_rules_test.yaml
+++ b/test/promql/tests/recording/mintmaker_service_quality_recording_rules_test.yaml
@@ -1,0 +1,59 @@
+evaluation_interval: 1m
+
+rule_files:
+  - mintmaker_service_quality_recording_rules.yaml
+
+tests:
+  - name: MintMakerClusterRamRequestedHighTest
+    interval: 1m
+    input_series:
+      - series: "kube_pod_container_resource_requests{
+          container='affinity-assistant', namespace='managed-release-team-tenant', resource='memory', unit='byte'
+        }"
+        values: "104857600"
+      - series: "kube_pod_container_resource_requests{
+          container='alertmanager', namespace='openshift-monitoring', resource='memory', unit='byte'
+        }"
+        values: "41943040"
+      - series: "kube_node_status_allocatable{
+          container='kube-rbac-proxy-main', namespace='openshift-monitoring', node='ip-10-202-24-116.ec2.internal', resource='memory', unit='byte'
+        }"
+        values: "60523909120"
+      - series: "kube_node_status_allocatable{
+          container='kube-rbac-proxy-main', namespace='openshift-monitoring', node='ip-10-202-24-177.ec2.internal', resource='memory', unit='byte'
+        }"
+        values: "29605638144"
+
+    promql_expr_test:
+      - expr: cluster_ram_requested_perc
+        eval_time: 1m
+        exp_samples:
+          - labels: cluster_ram_requested_perc
+            value: 0.0016287737424221574
+
+  - name: MintMakerNodeMemoryPressuredTest
+    interval: 1m
+    input_series:
+      - series: "kube_node_info{
+          container='kube-rbac-proxy-maind-release-team-tenant', node='ip-10-202-24-116.ec2.internal'
+        }"
+        values: "1"
+      - series: "kube_node_info{
+          container='kube-rbac-proxy-maind-release-team-tenant', node='ip-10-202-24-177.ec2.internal'
+        }"
+        values: "1"
+      - series: "kube_node_status_condition{
+          condition='MemoryPressure', node='ip-10-202-24-116.ec2.internal', status='true'
+        }"
+        values: "0"
+      - series: "kube_node_status_condition{
+          condition='MemoryPressure', node='ip-10-202-24-177.ec2.internal', status='true'
+        }"
+        values: "1"
+
+    promql_expr_test:
+      - expr: node_memory_pressured_perc
+        eval_time: 1m
+        exp_samples:
+          - labels: node_memory_pressured_perc
+            value: 0.5


### PR DESCRIPTION
This commit introduces two observatility metrics that will be used in MintMaker's dashboard, and their tests.

The two metrics are related to cluster memory:
- cluster memory requested percentage (as in requested/available)
- percentage of nodes in MemoryPressured state

This is because, if the cluster is experiencing high memory demand, it will probably have issues when processing the MintMaker pipelineruns, and the service might degrade.