### PR TITLE
feat(KFLUXUI-613): add dashboard for Konflux UI pods availability

### DIFF
--- a/dashboards/grafana-dashboard-konflux-ui-pods-availability.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ui-pods-availability.configmap.yaml
@@ -158,7 +158,7 @@ data:
             },
             "expression": "$Konflux_UI_pods_available/$Target_Konflux_UI_pods",
             "hide": false,
-            "refId": "A",
+            "refId": "rate_pods_available",
             "type": "math"
           }
         ],
@@ -255,7 +255,7 @@ data:
             },
             "expression": "$Konflux_UI_pods_available/$Target_Konflux_UI_pods",
             "hide": false,
-            "refId": "A",
+            "refId": "rate_pods_available",
             "type": "math"
           }
         ],
@@ -752,8 +752,8 @@ data:
     "timepicker": {},
     "timezone": "UTC",
     "title": "Konflux UI Pods availability",
-    "uid": "eesq3uvkpntvka", // Need to change
-    "version": 20
+    "uid": "eesq3uvkpntvka", //Need to change
+    "version": 21
   }
 kind: ConfigMap
 metadata:

--- a/dashboards/grafana-dashboard-konflux-ui-pods-availability.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ui-pods-availability.configmap.yaml
@@ -203,7 +203,7 @@ data:
           "orientation": "auto",
           "reduceOptions": {
             "calcs": [
-              "last"
+              "lastNotNull"
             ],
             "fields": "",
             "values": false
@@ -447,7 +447,7 @@ data:
             "values": false
           },
           "showThresholdLabels": false,
-          "showThresholdMarkers": true,
+          "showThresholdMarkers": false,
           "sizing": "auto"
         },
         "pluginVersion": "11.6.3",
@@ -685,7 +685,7 @@ data:
             "values": false
           },
           "showThresholdLabels": false,
-          "showThresholdMarkers": true,
+          "showThresholdMarkers": false,
           "sizing": "auto"
         },
         "pluginVersion": "11.6.3",
@@ -752,8 +752,8 @@ data:
     "timepicker": {},
     "timezone": "UTC",
     "title": "Konflux UI Pods availability",
-    "uid": "eesq3uvkpntvka", //Need to change
-    "version": 21
+    "uid": "eesq3uvbvctvky",
+    "version": 25
   }
 kind: ConfigMap
 metadata:

--- a/dashboards/grafana-dashboard-konflux-ui-pods-availability.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ui-pods-availability.configmap.yaml
@@ -34,7 +34,7 @@ data:
         },
         "id": 2,
         "panels": [],
-        "title": "General",
+        "title": "General Konflux UI Pod availability",
         "type": "row"
       },
       {
@@ -499,6 +499,244 @@ data:
         ],
         "title": "Konflux UI Proxy Pod availability (Actual/Target)",
         "type": "gauge"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 18
+        },
+        "id": 7,
+        "panels": [],
+        "title": "Konflux UI Dex pods availability",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P22466E8E7855F1E0"
+        },
+        "description": "Rate between running dex pods available over the expected amount of replica pods along the time.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "green"
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 10,
+          "x": 0,
+          "y": 19
+        },
+        "id": 8,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P22466E8E7855F1E0"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\", deployment=\"dex\"})",
+            "fullMetaSearch": false,
+            "hide": true,
+            "includeNullMetadata": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "Konflux_UI_dex_pods_available",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P22466E8E7855F1E0"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\", deployment=\"dex\"})",
+            "fullMetaSearch": false,
+            "hide": true,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "Target_Konflux_UI_dex_pods",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "name": "Expression",
+              "type": "__expr__",
+              "uid": "__expr__"
+            },
+            "expression": "$Konflux_UI_dex_pods_available/$Target_Konflux_UI_dex_pods",
+            "hide": false,
+            "refId": "rate_dex_pods_available",
+            "type": "math"
+          }
+        ],
+        "title": "Konflux UI Dex Pods availability over the time (Actual/Target)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P22466E8E7855F1E0"
+        },
+        "description": "Rate between running dex pods available over the expected amount of replica pods.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "green"
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 10,
+          "x": 10,
+          "y": 19
+        },
+        "id": 9,
+        "options": {
+          "minVizHeight": 75,
+          "minVizWidth": 75,
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true,
+          "sizing": "auto"
+        },
+        "pluginVersion": "11.6.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P22466E8E7855F1E0"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\", deployment=\"dex\"})",
+            "fullMetaSearch": false,
+            "hide": true,
+            "includeNullMetadata": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "Konflux_UI_dex_pods_available",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P22466E8E7855F1E0"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\", deployment=\"dex\"})",
+            "fullMetaSearch": false,
+            "hide": true,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "Target_Konflux_UI_dex_pods",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "name": "Expression",
+              "type": "__expr__",
+              "uid": "__expr__"
+            },
+            "expression": "$Konflux_UI_dex_pods_available/$Target_Konflux_UI_dex_pods",
+            "hide": false,
+            "refId": "rate_dex_pods_available",
+            "type": "math"
+          }
+        ],
+        "title": "Konflux UI Dex Pod availability (Actual/Target)",
+        "type": "gauge"
       }
     ],
     "preload": false,
@@ -515,7 +753,7 @@ data:
     "timezone": "UTC",
     "title": "Konflux UI Pods availability",
     "uid": "eesq3uvkpntvka", // Need to change
-    "version": 14
+    "version": 20
   }
 kind: ConfigMap
 metadata:

--- a/dashboards/grafana-dashboard-konflux-ui-pods-availability.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ui-pods-availability.configmap.yaml
@@ -1,91 +1,91 @@
 apiVersion: v1
 data:
  cluster-capacity-dashboard.json: |-
-   {
-      "annotations": {
-        "list": [
-          {
-            "builtIn": 1,
-            "datasource": {
-              "type": "grafana",
-              "uid": "-- Grafana --"
-            },
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "type": "dashboard"
-          }
-        ]
-      },
-      "editable": true,
-      "fiscalYearStartMonth": 0,
-      "graphTooltip": 0,
-      "id": 1026283,
-      "links": [],
-      "panels": [
+  {
+    "annotations": {
+      "list": [
         {
-          "collapsed": false,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 0
-          },
-          "id": 2,
-          "panels": [],
-          "title": "General",
-          "type": "row"
-        },
-        {
+          "builtIn": 1,
           "datasource": {
-            "type": "prometheus",
-            "uid": "P22466E8E7855F1E0"
+            "type": "grafana",
+            "uid": "-- Grafana --"
           },
-          "description": "Rate between running pods available over the expected amount of replica pods along the time.",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 1026283,
+    "links": [],
+    "panels": [
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 2,
+        "panels": [],
+        "title": "General",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P22466E8E7855F1E0"
+        },
+        "description": "Rate between running pods available over the expected amount of replica pods along the time.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
               },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
               },
-              "fieldMinMax": false,
-              "mappings": [],
-              "thresholds": {
-                "mode": "percentage",
-                "steps": [
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
                 {
                   "color": "green"
                 }
@@ -261,6 +261,244 @@ data:
         ],
         "title": "Konflux UI Pod availability (Actual/Target)",
         "type": "gauge"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 9
+        },
+        "id": 5,
+        "panels": [],
+        "title": "Konflux UI Proxy pods availability",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P22466E8E7855F1E0"
+        },
+        "description": "Rate between running proxy pods available over the expected amount of replica pods along the time.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "green"
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 10,
+          "x": 0,
+          "y": 10
+        },
+        "id": 4,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P22466E8E7855F1E0"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\", deployment=\"proxy\"})",
+            "fullMetaSearch": false,
+            "hide": true,
+            "includeNullMetadata": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "Konflux_UI_proxy_pods_available",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P22466E8E7855F1E0"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\", deployment=\"proxy\"})",
+            "fullMetaSearch": false,
+            "hide": true,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "Target_Konflux_UI_proxy_pods",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "name": "Expression",
+              "type": "__expr__",
+              "uid": "__expr__"
+            },
+            "expression": "$Konflux_UI_proxy_pods_available/$Target_Konflux_UI_proxy_pods",
+            "hide": false,
+            "refId": "rate_proxy_pods_available",
+            "type": "math"
+          }
+        ],
+        "title": "Konflux UI Proxy Pods availability over the time (Actual/Target)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P22466E8E7855F1E0"
+        },
+        "description": "Rate between running proxy pods available over the expected amount of replica pods.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "green"
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 10,
+          "x": 10,
+          "y": 10
+        },
+        "id": 6,
+        "options": {
+          "minVizHeight": 75,
+          "minVizWidth": 75,
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true,
+          "sizing": "auto"
+        },
+        "pluginVersion": "11.6.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P22466E8E7855F1E0"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\", deployment=\"proxy\"})",
+            "fullMetaSearch": false,
+            "hide": true,
+            "includeNullMetadata": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "Konflux_UI_proxy_pods_available",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P22466E8E7855F1E0"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\", deployment=\"proxy\"})",
+            "fullMetaSearch": false,
+            "hide": true,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "Target_Konflux_UI_proxy_pods",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "name": "Expression",
+              "type": "__expr__",
+              "uid": "__expr__"
+            },
+            "expression": "$Konflux_UI_proxy_pods_available/$Target_Konflux_UI_proxy_pods",
+            "hide": false,
+            "refId": "rate_proxy_pods_available",
+            "type": "math"
+          }
+        ],
+        "title": "Konflux UI Proxy Pod availability (Actual/Target)",
+        "type": "gauge"
       }
     ],
     "preload": false,
@@ -276,8 +514,8 @@ data:
     "timepicker": {},
     "timezone": "UTC",
     "title": "Konflux UI Pods availability",
-    "uid": "eesq3uvkpntvka", // Need to change this
-    "version": 10
+    "uid": "eesq3uvkpntvka", // Need to change
+    "version": 14
   }
 kind: ConfigMap
 metadata:

--- a/dashboards/grafana-dashboard-konflux-ui-pods-availability.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ui-pods-availability.configmap.yaml
@@ -25,11 +25,24 @@ data:
       "links": [],
       "panels": [
         {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 2,
+          "panels": [],
+          "title": "General",
+          "type": "row"
+        },
+        {
           "datasource": {
             "type": "prometheus",
             "uid": "P22466E8E7855F1E0"
           },
-          "description": "Rate between running pods available over the expected amount of replica pods.",
+          "description": "Rate between running pods available over the expected amount of replica pods along the time.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -73,20 +86,20 @@ data:
               "thresholds": {
                 "mode": "percentage",
                 "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "percentunit"
+                {
+                  "color": "green"
+                }
+              ]
             },
-            "overrides": []
+            "unit": "percentunit"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-          "y": 0
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 10,
+          "x": 0,
+          "y": 1
         },
         "id": 1,
         "options": {
@@ -94,7 +107,7 @@ data:
             "calcs": [],
             "displayMode": "list",
             "placement": "bottom",
-            "showLegend": true
+            "showLegend": false
           },
           "tooltip": {
             "hideZeros": false,
@@ -149,8 +162,105 @@ data:
             "type": "math"
           }
         ],
-        "title": "Konflux UI Pod availability (Actual/Target)",
+        "title": "Konflux UI Pod availability over the time (Actual/Target)",
         "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P22466E8E7855F1E0"
+        },
+        "description": "Rate between running pods available over the expected amount of replica pods.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "green"
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 10,
+          "x": 10,
+          "y": 1
+        },
+        "id": 3,
+        "options": {
+          "minVizHeight": 75,
+          "minVizWidth": 75,
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "last"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": false,
+          "sizing": "auto"
+        },
+        "pluginVersion": "11.6.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P22466E8E7855F1E0"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\"})",
+            "fullMetaSearch": false,
+            "hide": true,
+            "includeNullMetadata": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "Konflux_UI_pods_available",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P22466E8E7855F1E0"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\"})",
+            "fullMetaSearch": false,
+            "hide": true,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "Target_Konflux_UI_pods",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "name": "Expression",
+              "type": "__expr__",
+              "uid": "__expr__"
+            },
+            "expression": "$Konflux_UI_pods_available/$Target_Konflux_UI_pods",
+            "hide": false,
+            "refId": "A",
+            "type": "math"
+          }
+        ],
+        "title": "Konflux UI Pod availability (Actual/Target)",
+        "type": "gauge"
       }
     ],
     "preload": false,
@@ -166,8 +276,8 @@ data:
     "timepicker": {},
     "timezone": "UTC",
     "title": "Konflux UI Pods availability",
-    "uid": "eesq3uvkpntvka", // Need to change this value!
-    "version": 2
+    "uid": "eesq3uvkpntvka", // Need to change this
+    "version": 10
   }
 kind: ConfigMap
 metadata:

--- a/dashboards/grafana-dashboard-konflux-ui-pods-availability.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ui-pods-availability.configmap.yaml
@@ -1,0 +1,178 @@
+apiVersion: v1
+data:
+ cluster-capacity-dashboard.json: |-
+   {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 1026283,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P22466E8E7855F1E0"
+          },
+          "description": "Rate between running pods available over the expected amount of replica pods.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "fieldMinMax": false,
+              "mappings": [],
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P22466E8E7855F1E0"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\"})",
+            "fullMetaSearch": false,
+            "hide": true,
+            "includeNullMetadata": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "Konflux_UI_pods_available",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P22466E8E7855F1E0"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\"})",
+            "fullMetaSearch": false,
+            "hide": true,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "Target_Konflux_UI_pods",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "name": "Expression",
+              "type": "__expr__",
+              "uid": "__expr__"
+            },
+            "expression": "$Konflux_UI_pods_available/$Target_Konflux_UI_pods",
+            "hide": false,
+            "refId": "A",
+            "type": "math"
+          }
+        ],
+        "title": "Konflux UI Pod availability (Actual/Target)",
+        "type": "timeseries"
+      }
+    ],
+    "preload": false,
+    "schemaVersion": 41,
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-5m",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "UTC",
+    "title": "Konflux UI Pods availability",
+    "uid": "eesq3uvkpntvka", // Need to change this value!
+    "version": 2
+  }
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-konflux-ui-pods-availability
+  labels:
+    grafana_dashboard: "true"
+  annotations:
+    grafana-folder: /grafana-dashboard-definitions/RHTAP

--- a/dashboards/grafana-dashboard-konflux-ui-pods-availability.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ui-pods-availability.configmap.yaml
@@ -1,760 +1,760 @@
 apiVersion: v1
 data:
- cluster-capacity-dashboard.json: |-
-  {
-    "annotations": {
-      "list": [
+  konflux-ui-pods-availability-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 1026283,
+      "links": [],
+      "panels": [
         {
-          "builtIn": 1,
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 2,
+          "panels": [],
+          "title": "General Konflux UI Pod availability",
+          "type": "row"
+        },
+        {
           "datasource": {
-            "type": "grafana",
-            "uid": "-- Grafana --"
+            "type": "prometheus",
+            "uid": "P22466E8E7855F1E0"
           },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "type": "dashboard"
+          "description": "Rate between running pods available over the expected amount of replica pods along the time.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "fieldMinMax": false,
+              "mappings": [],
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 10,
+            "x": 0,
+            "y": 1
+          },
+          "id": 1,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P22466E8E7855F1E0"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\"})",
+              "fullMetaSearch": false,
+              "hide": true,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "Konflux_UI_pods_available",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P22466E8E7855F1E0"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\"})",
+              "fullMetaSearch": false,
+              "hide": true,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "Target_Konflux_UI_pods",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "name": "Expression",
+                "type": "__expr__",
+                "uid": "__expr__"
+              },
+              "expression": "$Konflux_UI_pods_available/$Target_Konflux_UI_pods",
+              "hide": false,
+              "refId": "rate_pods_available",
+              "type": "math"
+            }
+          ],
+          "title": "Konflux UI Pod availability over the time (Actual/Target)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P22466E8E7855F1E0"
+          },
+          "description": "Rate between running pods available over the expected amount of replica pods.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "fieldMinMax": false,
+              "mappings": [],
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 10,
+            "x": 10,
+            "y": 1
+          },
+          "id": 3,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P22466E8E7855F1E0"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\"})",
+              "fullMetaSearch": false,
+              "hide": true,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "Konflux_UI_pods_available",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P22466E8E7855F1E0"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\"})",
+              "fullMetaSearch": false,
+              "hide": true,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "Target_Konflux_UI_pods",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "name": "Expression",
+                "type": "__expr__",
+                "uid": "__expr__"
+              },
+              "expression": "$Konflux_UI_pods_available/$Target_Konflux_UI_pods",
+              "hide": false,
+              "refId": "rate_pods_available",
+              "type": "math"
+            }
+          ],
+          "title": "Konflux UI Pod availability (Actual/Target)",
+          "type": "gauge"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 5,
+          "panels": [],
+          "title": "Konflux UI Proxy pods availability",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P22466E8E7855F1E0"
+          },
+          "description": "Rate between running proxy pods available over the expected amount of replica pods along the time.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "fieldMinMax": false,
+              "mappings": [],
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 10,
+            "x": 0,
+            "y": 10
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P22466E8E7855F1E0"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\", deployment=\"proxy\"})",
+              "fullMetaSearch": false,
+              "hide": true,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "Konflux_UI_proxy_pods_available",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P22466E8E7855F1E0"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\", deployment=\"proxy\"})",
+              "fullMetaSearch": false,
+              "hide": true,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "Target_Konflux_UI_proxy_pods",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "name": "Expression",
+                "type": "__expr__",
+                "uid": "__expr__"
+              },
+              "expression": "$Konflux_UI_proxy_pods_available/$Target_Konflux_UI_proxy_pods",
+              "hide": false,
+              "refId": "rate_proxy_pods_available",
+              "type": "math"
+            }
+          ],
+          "title": "Konflux UI Proxy Pods availability over the time (Actual/Target)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P22466E8E7855F1E0"
+          },
+          "description": "Rate between running proxy pods available over the expected amount of replica pods.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "fieldMinMax": false,
+              "mappings": [],
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 10,
+            "x": 10,
+            "y": 10
+          },
+          "id": 6,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P22466E8E7855F1E0"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\", deployment=\"proxy\"})",
+              "fullMetaSearch": false,
+              "hide": true,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "Konflux_UI_proxy_pods_available",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P22466E8E7855F1E0"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\", deployment=\"proxy\"})",
+              "fullMetaSearch": false,
+              "hide": true,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "Target_Konflux_UI_proxy_pods",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "name": "Expression",
+                "type": "__expr__",
+                "uid": "__expr__"
+              },
+              "expression": "$Konflux_UI_proxy_pods_available/$Target_Konflux_UI_proxy_pods",
+              "hide": false,
+              "refId": "rate_proxy_pods_available",
+              "type": "math"
+            }
+          ],
+          "title": "Konflux UI Proxy Pod availability (Actual/Target)",
+          "type": "gauge"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          },
+          "id": 7,
+          "panels": [],
+          "title": "Konflux UI Dex pods availability",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P22466E8E7855F1E0"
+          },
+          "description": "Rate between running dex pods available over the expected amount of replica pods along the time.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "fieldMinMax": false,
+              "mappings": [],
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 10,
+            "x": 0,
+            "y": 19
+          },
+          "id": 8,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P22466E8E7855F1E0"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\", deployment=\"dex\"})",
+              "fullMetaSearch": false,
+              "hide": true,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "Konflux_UI_dex_pods_available",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P22466E8E7855F1E0"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\", deployment=\"dex\"})",
+              "fullMetaSearch": false,
+              "hide": true,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "Target_Konflux_UI_dex_pods",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "name": "Expression",
+                "type": "__expr__",
+                "uid": "__expr__"
+              },
+              "expression": "$Konflux_UI_dex_pods_available/$Target_Konflux_UI_dex_pods",
+              "hide": false,
+              "refId": "rate_dex_pods_available",
+              "type": "math"
+            }
+          ],
+          "title": "Konflux UI Dex Pods availability over the time (Actual/Target)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P22466E8E7855F1E0"
+          },
+          "description": "Rate between running dex pods available over the expected amount of replica pods.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "fieldMinMax": false,
+              "mappings": [],
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 10,
+            "x": 10,
+            "y": 19
+          },
+          "id": 9,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P22466E8E7855F1E0"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\", deployment=\"dex\"})",
+              "fullMetaSearch": false,
+              "hide": true,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "Konflux_UI_dex_pods_available",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P22466E8E7855F1E0"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\", deployment=\"dex\"})",
+              "fullMetaSearch": false,
+              "hide": true,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "Target_Konflux_UI_dex_pods",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "name": "Expression",
+                "type": "__expr__",
+                "uid": "__expr__"
+              },
+              "expression": "$Konflux_UI_dex_pods_available/$Target_Konflux_UI_dex_pods",
+              "hide": false,
+              "refId": "rate_dex_pods_available",
+              "type": "math"
+            }
+          ],
+          "title": "Konflux UI Dex Pod availability (Actual/Target)",
+          "type": "gauge"
         }
-      ]
-    },
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "id": 1026283,
-    "links": [],
-    "panels": [
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "id": 2,
-        "panels": [],
-        "title": "General Konflux UI Pod availability",
-        "type": "row"
+      ],
+      "preload": false,
+      "schemaVersion": 41,
+      "tags": [],
+      "templating": {
+        "list": []
       },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P22466E8E7855F1E0"
-        },
-        "description": "Rate between running pods available over the expected amount of replica pods along the time.",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "barWidthFactor": 0.6,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "fieldMinMax": false,
-            "mappings": [],
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green"
-                }
-              ]
-            },
-            "unit": "percentunit"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 10,
-          "x": 0,
-          "y": 1
-        },
-        "id": 1,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "tooltip": {
-            "hideZeros": false,
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "11.6.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P22466E8E7855F1E0"
-            },
-            "disableTextWrap": false,
-            "editorMode": "builder",
-            "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\"})",
-            "fullMetaSearch": false,
-            "hide": true,
-            "includeNullMetadata": true,
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "Konflux_UI_pods_available",
-            "useBackend": false
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P22466E8E7855F1E0"
-            },
-            "disableTextWrap": false,
-            "editorMode": "builder",
-            "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\"})",
-            "fullMetaSearch": false,
-            "hide": true,
-            "includeNullMetadata": true,
-            "instant": false,
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "Target_Konflux_UI_pods",
-            "useBackend": false
-          },
-          {
-            "datasource": {
-              "name": "Expression",
-              "type": "__expr__",
-              "uid": "__expr__"
-            },
-            "expression": "$Konflux_UI_pods_available/$Target_Konflux_UI_pods",
-            "hide": false,
-            "refId": "rate_pods_available",
-            "type": "math"
-          }
-        ],
-        "title": "Konflux UI Pod availability over the time (Actual/Target)",
-        "type": "timeseries"
+      "time": {
+        "from": "now-5m",
+        "to": "now"
       },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P22466E8E7855F1E0"
-        },
-        "description": "Rate between running pods available over the expected amount of replica pods.",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "fieldMinMax": false,
-            "mappings": [],
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green"
-                }
-              ]
-            },
-            "unit": "percentunit"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 10,
-          "x": 10,
-          "y": 1
-        },
-        "id": 3,
-        "options": {
-          "minVizHeight": 75,
-          "minVizWidth": 75,
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": false,
-          "sizing": "auto"
-        },
-        "pluginVersion": "11.6.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P22466E8E7855F1E0"
-            },
-            "disableTextWrap": false,
-            "editorMode": "builder",
-            "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\"})",
-            "fullMetaSearch": false,
-            "hide": true,
-            "includeNullMetadata": true,
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "Konflux_UI_pods_available",
-            "useBackend": false
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P22466E8E7855F1E0"
-            },
-            "disableTextWrap": false,
-            "editorMode": "builder",
-            "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\"})",
-            "fullMetaSearch": false,
-            "hide": true,
-            "includeNullMetadata": true,
-            "instant": false,
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "Target_Konflux_UI_pods",
-            "useBackend": false
-          },
-          {
-            "datasource": {
-              "name": "Expression",
-              "type": "__expr__",
-              "uid": "__expr__"
-            },
-            "expression": "$Konflux_UI_pods_available/$Target_Konflux_UI_pods",
-            "hide": false,
-            "refId": "rate_pods_available",
-            "type": "math"
-          }
-        ],
-        "title": "Konflux UI Pod availability (Actual/Target)",
-        "type": "gauge"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 9
-        },
-        "id": 5,
-        "panels": [],
-        "title": "Konflux UI Proxy pods availability",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P22466E8E7855F1E0"
-        },
-        "description": "Rate between running proxy pods available over the expected amount of replica pods along the time.",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "barWidthFactor": 0.6,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "fieldMinMax": false,
-            "mappings": [],
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green"
-                }
-              ]
-            },
-            "unit": "percentunit"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 10,
-          "x": 0,
-          "y": 10
-        },
-        "id": 4,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "tooltip": {
-            "hideZeros": false,
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "11.6.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P22466E8E7855F1E0"
-            },
-            "disableTextWrap": false,
-            "editorMode": "builder",
-            "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\", deployment=\"proxy\"})",
-            "fullMetaSearch": false,
-            "hide": true,
-            "includeNullMetadata": true,
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "Konflux_UI_proxy_pods_available",
-            "useBackend": false
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P22466E8E7855F1E0"
-            },
-            "disableTextWrap": false,
-            "editorMode": "builder",
-            "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\", deployment=\"proxy\"})",
-            "fullMetaSearch": false,
-            "hide": true,
-            "includeNullMetadata": true,
-            "instant": false,
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "Target_Konflux_UI_proxy_pods",
-            "useBackend": false
-          },
-          {
-            "datasource": {
-              "name": "Expression",
-              "type": "__expr__",
-              "uid": "__expr__"
-            },
-            "expression": "$Konflux_UI_proxy_pods_available/$Target_Konflux_UI_proxy_pods",
-            "hide": false,
-            "refId": "rate_proxy_pods_available",
-            "type": "math"
-          }
-        ],
-        "title": "Konflux UI Proxy Pods availability over the time (Actual/Target)",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P22466E8E7855F1E0"
-        },
-        "description": "Rate between running proxy pods available over the expected amount of replica pods.",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "fieldMinMax": false,
-            "mappings": [],
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green"
-                }
-              ]
-            },
-            "unit": "percentunit"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 10,
-          "x": 10,
-          "y": 10
-        },
-        "id": 6,
-        "options": {
-          "minVizHeight": 75,
-          "minVizWidth": 75,
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": false,
-          "sizing": "auto"
-        },
-        "pluginVersion": "11.6.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P22466E8E7855F1E0"
-            },
-            "disableTextWrap": false,
-            "editorMode": "builder",
-            "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\", deployment=\"proxy\"})",
-            "fullMetaSearch": false,
-            "hide": true,
-            "includeNullMetadata": true,
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "Konflux_UI_proxy_pods_available",
-            "useBackend": false
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P22466E8E7855F1E0"
-            },
-            "disableTextWrap": false,
-            "editorMode": "builder",
-            "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\", deployment=\"proxy\"})",
-            "fullMetaSearch": false,
-            "hide": true,
-            "includeNullMetadata": true,
-            "instant": false,
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "Target_Konflux_UI_proxy_pods",
-            "useBackend": false
-          },
-          {
-            "datasource": {
-              "name": "Expression",
-              "type": "__expr__",
-              "uid": "__expr__"
-            },
-            "expression": "$Konflux_UI_proxy_pods_available/$Target_Konflux_UI_proxy_pods",
-            "hide": false,
-            "refId": "rate_proxy_pods_available",
-            "type": "math"
-          }
-        ],
-        "title": "Konflux UI Proxy Pod availability (Actual/Target)",
-        "type": "gauge"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 18
-        },
-        "id": 7,
-        "panels": [],
-        "title": "Konflux UI Dex pods availability",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P22466E8E7855F1E0"
-        },
-        "description": "Rate between running dex pods available over the expected amount of replica pods along the time.",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "barWidthFactor": 0.6,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "fieldMinMax": false,
-            "mappings": [],
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green"
-                }
-              ]
-            },
-            "unit": "percentunit"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 10,
-          "x": 0,
-          "y": 19
-        },
-        "id": 8,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "tooltip": {
-            "hideZeros": false,
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "11.6.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P22466E8E7855F1E0"
-            },
-            "disableTextWrap": false,
-            "editorMode": "builder",
-            "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\", deployment=\"dex\"})",
-            "fullMetaSearch": false,
-            "hide": true,
-            "includeNullMetadata": true,
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "Konflux_UI_dex_pods_available",
-            "useBackend": false
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P22466E8E7855F1E0"
-            },
-            "disableTextWrap": false,
-            "editorMode": "builder",
-            "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\", deployment=\"dex\"})",
-            "fullMetaSearch": false,
-            "hide": true,
-            "includeNullMetadata": true,
-            "instant": false,
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "Target_Konflux_UI_dex_pods",
-            "useBackend": false
-          },
-          {
-            "datasource": {
-              "name": "Expression",
-              "type": "__expr__",
-              "uid": "__expr__"
-            },
-            "expression": "$Konflux_UI_dex_pods_available/$Target_Konflux_UI_dex_pods",
-            "hide": false,
-            "refId": "rate_dex_pods_available",
-            "type": "math"
-          }
-        ],
-        "title": "Konflux UI Dex Pods availability over the time (Actual/Target)",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P22466E8E7855F1E0"
-        },
-        "description": "Rate between running dex pods available over the expected amount of replica pods.",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "fieldMinMax": false,
-            "mappings": [],
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green"
-                }
-              ]
-            },
-            "unit": "percentunit"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 10,
-          "x": 10,
-          "y": 19
-        },
-        "id": 9,
-        "options": {
-          "minVizHeight": 75,
-          "minVizWidth": 75,
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": false,
-          "sizing": "auto"
-        },
-        "pluginVersion": "11.6.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P22466E8E7855F1E0"
-            },
-            "disableTextWrap": false,
-            "editorMode": "builder",
-            "expr": "count(kube_deployment_status_replicas_available{namespace=\"konflux-ui\", deployment=\"dex\"})",
-            "fullMetaSearch": false,
-            "hide": true,
-            "includeNullMetadata": true,
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "Konflux_UI_dex_pods_available",
-            "useBackend": false
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P22466E8E7855F1E0"
-            },
-            "disableTextWrap": false,
-            "editorMode": "builder",
-            "expr": "count(kube_deployment_spec_replicas{namespace=\"konflux-ui\", deployment=\"dex\"})",
-            "fullMetaSearch": false,
-            "hide": true,
-            "includeNullMetadata": true,
-            "instant": false,
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "Target_Konflux_UI_dex_pods",
-            "useBackend": false
-          },
-          {
-            "datasource": {
-              "name": "Expression",
-              "type": "__expr__",
-              "uid": "__expr__"
-            },
-            "expression": "$Konflux_UI_dex_pods_available/$Target_Konflux_UI_dex_pods",
-            "hide": false,
-            "refId": "rate_dex_pods_available",
-            "type": "math"
-          }
-        ],
-        "title": "Konflux UI Dex Pod availability (Actual/Target)",
-        "type": "gauge"
-      }
-    ],
-    "preload": false,
-    "schemaVersion": 41,
-    "tags": [],
-    "templating": {
-      "list": []
-    },
-    "time": {
-      "from": "now-5m",
-      "to": "now"
-    },
-    "timepicker": {},
-    "timezone": "UTC",
-    "title": "Konflux UI Pods availability",
-    "uid": "eesq3uvbvctvky",
-    "version": 25
-  }
+      "timepicker": {},
+      "timezone": "UTC",
+      "title": "Konflux UI Pods availability",
+      "uid": "eesq3uvbvctvky",
+      "version": 25
+    }
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-konflux-ui-pods-availability


### PR DESCRIPTION
Add dashboard to display pods' availability of Konflux UI application.

[Dashboard](https://grafana.stage.devshift.net/goto/_hkr6qUHR?orgId=1) in grafana.

### Screnshoot

<img width="1502" height="875" alt="image" src="https://github.com/user-attachments/assets/d00d2ab0-13cb-4548-89cc-5d605433b3b6" />
