### PR TITLE
chore: Kanary dashboard intial and default values

### DIFF
--- a/dashboards/grafana-dashboard-kanary-signal.configmap.yaml
+++ b/dashboards/grafana-dashboard-kanary-signal.configmap.yaml
@@ -569,8 +569,8 @@ data:
         "list": [
           {
             "current": {
-              "text": "rhtap-observatorium-stage",
-              "value": "PDCCF087A30F0737B"
+              "text": "rhtap-observatorium-production",
+              "value": "P22466E8E7855F1E0"
             },
             "description": "The datasource in which the kanary signal will be coming from.",
             "includeAll": false,
@@ -583,20 +583,14 @@ data:
             "type": "datasource"
           },
           {
+            "allValue": "",
+            "allowCustomValue": false,
             "current": {
               "text": [
-                "stone-prd-rh01",
-                "stone-prod-p01",
-                "stone-prod-p02",
-                "stone-stage-p01",
-                "stone-stg-rh01"
+                "All"
               ],
               "value": [
-                "stone-prd-rh01",
-                "stone-prod-p01",
-                "stone-prod-p02",
-                "stone-stage-p01",
-                "stone-stg-rh01"
+                "$__all"
               ]
             },
             "datasource": {
@@ -605,7 +599,7 @@ data:
             },
             "definition": "label_values(kanary_up,tested_cluster)",
             "description": "The cluster(s) that the kanary signal is monitoring",
-            "includeAll": false,
+            "includeAll": true,
             "label": "Kanary Clusters",
             "multi": true,
             "name": "kanary_clusters",
@@ -622,8 +616,8 @@ data:
           {
             "allowCustomValue": false,
             "current": {
-              "text": "rpm",
-              "value": "rpm"
+              "text": "container",
+              "value": "container"
             },
             "datasource": {
               "type": "prometheus",
@@ -653,5 +647,5 @@ data:
       "timezone": "browser",
       "title": "Kanary Signal Dashboard",
       "uid": "eeoimpx3yutq9f",
-      "version": 2
+      "version": 3
     }


### PR DESCRIPTION
This will make it so that the dashboard will by default have all clusters, the production datasource and the container kanary type selected.

Issue: [PVO11Y-4834](https://issues.redhat.com/browse/PVO11Y-4834)