### PR TITLE
feat(KFLUXUI-605): add dashboards for stage

### DIFF
--- a/dashboards/grafana-dashboard-konflux-ui-endpoint-availability.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ui-endpoint-availability.configmap.yaml
@@ -25,11 +25,24 @@ data:
       "links": [],
       "panels": [
         {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "panels": [],
+          "title": "Production Clusters",
+          "type": "row"
+        },
+        {
           "datasource": {
             "type": "prometheus",
             "uid": "P22466E8E7855F1E0"
           },
-          "description": "Konflux UI proxy endpoint availability over the time.",
+          "description": "Konflux UI proxy endpoint availability over the time on prod cluster.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -92,7 +105,7 @@ data:
             "h": 19,
             "w": 12,
             "x": 0,
-            "y": 0
+            "y": 1
           },
           "id": 2,
           "options": {
@@ -133,7 +146,7 @@ data:
           "datasource": {
             "uid": "P22466E8E7855F1E0"
           },
-          "description": "Konflux UI proxy endpoint availability per cluster.",
+          "description": "Konflux UI proxy endpoint availability per prod cluster.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -162,7 +175,7 @@ data:
             "h": 19,
             "w": 6,
             "x": 12,
-            "y": 0
+            "y": 1
           },
           "id": 1,
           "options": {
@@ -196,6 +209,197 @@ data:
           ],
           "title": "Endpoint available per cluster",
           "type": "gauge"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 20
+          },
+          "id": 5,
+          "panels": [],
+          "title": "Stage clusters",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PDCCF087A30F0737B"
+          },
+          "description": "Konflux UI proxy endpoint availability over the time on stage cluster.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 19,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PDCCF087A30F0737B"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "count by(source_cluster) (kube_endpoint_address{namespace=\"konflux-ui\"})",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "enpoints",
+              "useBackend": false
+            }
+          ],
+          "title": "Endpoint availability over time",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PDCCF087A30F0737B"
+          },
+          "description": "Konflux UI proxy endpoint availability per stage cluster.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "fieldMinMax": false,
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 99
+                  }
+                ]
+              },
+              "unit": "bool_on_off"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 19,
+            "w": 6,
+            "x": 12,
+            "y": 21
+          },
+          "id": 6,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PDCCF087A30F0737B"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "group by(source_cluster) (kube_endpoint_address{namespace=\"konflux-ui\"})",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "endpoint_available",
+              "useBackend": false
+            }
+          ],
+          "title": "Endpoint available per cluster",
+          "type": "gauge"
         }
       ],
       "preload": false,
@@ -212,7 +416,7 @@ data:
       "timezone": "UTC",
       "title": "Endpoint availability",
       "uid": "festqphktfbmax",
-      "version": 11
+      "version": 14
     }
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Duplicate prod dashboards for stage as well. This way we can watch both endpoints availability in both environments

Jira KFLUXUI-605

[Grafana](https://grafana.stage.devshift.net/goto/2R-h6pwNg?orgId=1) dashboard

### Screenshot
<img width="1343" height="914" alt="image" src="https://github.com/user-attachments/assets/55166b0c-46cb-4eb4-bd19-034ffc2a2d29" />
