### PR TITLE
Temporarily disable MintMaker alerts from stone-prod-p02

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
@@ -15,7 +15,8 @@ spec:
         konflux_up{
           namespace="mintmaker",
           check="replicas-available",
-          service="mintmaker-controller-manager"
+          service="mintmaker-controller-manager",
+          source_cluster!="stone-prod-p02"
         } != 1
       for: 5m
       labels:
@@ -38,7 +39,8 @@ spec:
         konflux_up{
           namespace="mintmaker",
           check="replicas-available",
-          service="redis"
+          service="redis",
+          source_cluster!="stone-prod-p02"
         } != 1
       for: 5m
       labels:

--- a/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
+++ b/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
@@ -55,3 +55,27 @@ tests:
               alert_team_handle: <!subteam^S078T8TMQP5>
               team: mintmaker
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md
+
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="mintmaker-controller-manager", source_cluster="stone-prod-p02"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="mintmaker-controller-manager", source_cluster="c7"}'
+        values: '1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: MintMakerControllerDown
+        exp_alerts: null
+
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="redis", source_cluster="stone-prod-p02"}'
+        values: '0 0 0 0 0'
+      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="redis", source_cluster="c8"}'
+        values: '1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: MintMakerControllerDown
+        exp_alerts: null


### PR DESCRIPTION
The alerts from this cluster are firig verry frequently and we are conducting an investigation. We will disable the alerts from this cluster momentarily, to avoid unnecessary smapping of the alerting channel.

Once we figure a solution, we will undo these changes and reenable the alerts.