### PR TITLE
KFLUXINFRA-2089: Kueue ignore code 400 in webhook metric

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -26,7 +26,7 @@ spec:
     - alert: KueueMutatingWebhookLowSuccessRate
       expr: |
         100 * sum by (instance, source_cluster) (increase(apiserver_admission_webhook_request_total{
-          name="pipelinerun-kueue-defaulter.tekton-kueue.io", code=~"2.."
+          name="pipelinerun-kueue-defaulter.tekton-kueue.io", code=~"2..|400"
         }[10m]))
         /
         sum by (instance, source_cluster) (increase(apiserver_admission_webhook_request_total{

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -37,6 +37,8 @@ tests:
       # Low success rate scenario - 95% success (should trigger alert)
       - series: 'apiserver_admission_webhook_request_total{name="pipelinerun-kueue-defaulter.tekton-kueue.io", code="200", instance="i1", source_cluster="c1"}'
         values: '0 95 190 285 380 475'
+      - series: 'apiserver_admission_webhook_request_total{name="pipelinerun-kueue-defaulter.tekton-kueue.io", code="400", instance="i1", source_cluster="c1"}'
+        values: '0 1 2 3 4 5'
       - series: 'apiserver_admission_webhook_request_total{name="pipelinerun-kueue-defaulter.tekton-kueue.io", code="500", instance="i1", source_cluster="c1"}'
         values: '0 5 10 15 20 25'
 


### PR DESCRIPTION
Status 400 is returned when a malformed request is sent to the webhook. This can happen because of user configuration and because of that it's out of scope of this alert (which is about queuing).