### PR TITLE
KFLUXINFRA-2098: KueueHighAdmissionWaitTime firing too often

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -63,7 +63,7 @@ spec:
         team: konflux-infra
 
     - alert: KueueHighAdmissionWaitTime
-      expr: histogram_quantile(0.99, sum(increase(kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue"}[10m])) by (le, source_cluster)) > 900
+      expr: histogram_quantile(0.99, sum(increase(kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue"}[10m])) by (le, source_cluster)) > 1800
       for: 5m
       labels:
         severity: critical
@@ -71,7 +71,7 @@ spec:
         slo: "true"
       annotations:
         summary: "High admission wait time in Kueue"
-        description: "99th percentile admission wait time is {{ $value }}s, which is above 15 minutes in cluster {{ $labels.source_cluster }}"
+        description: "99th percentile admission wait time is {{ $value }}s, which is above 30 minutes in cluster {{ $labels.source_cluster }}"
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
         alert_team_handle: <!subteam^S05Q1P4Q2TG>
         team: konflux-infra

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -89,14 +89,14 @@ tests:
   # Test KueueHighAdmissionWaitTime alert
   - interval: 1m
     input_series:
-      # High admission wait time buckets - should trigger alert (>900s = 15min)
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", le="300", source_cluster="c1"}'
-        values: '0 1 2 3 4 5'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", le="600", source_cluster="c1"}'
-        values: '0 1 2 3 4 5'
+      # High admission wait time buckets - should trigger alert (>1800s = 30min)
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", le="900", source_cluster="c1"}'
         values: '0 1 2 3 4 5'
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", le="1200", source_cluster="c1"}'
+        values: '0 1 2 3 4 5'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", le="1800", source_cluster="c1"}'
+        values: '0 1 2 3 4 5'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", le="2400", source_cluster="c1"}'
         values: '0 5 10 15 20 25'
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", le="+Inf", source_cluster="c1"}'
         values: '0 5 10 15 20 25'
@@ -112,7 +112,7 @@ tests:
               source_cluster: c1
             exp_annotations:
               summary: "High admission wait time in Kueue"
-              description: "99th percentile admission wait time is 1196.25s, which is above 15 minutes in cluster c1"
+              description: "99th percentile admission wait time is 2392.5s, which is above 30 minutes in cluster c1"
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
               alert_team_handle: <!subteam^S05Q1P4Q2TG>
               team: konflux-infra


### PR DESCRIPTION
KueueHighAdmissionWaitTime firing too often.
Increase admission wait time alert threshold to 30m.

The previous 15-minute threshold for the
KueueHighAdmissionWaitTime alert was too sensitive,
causing too many alerts from non-critical spikes.

This change increases the threshold to 30 minutes
(1800s).

* Updated the alert expression from `> 900`
  to `> 1800`.
* Modified the corresponding unit test with new
  input data to validate the 30-minute threshold
  correctly.