### PR TITLE
kueue: de-escalate flapping SLO alert

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -68,10 +68,9 @@ spec:
       labels:
         severity: critical
         component: kueue
-        slo: "true"
       annotations:
         summary: "High admission wait time in Kueue"
         description: "99th percentile admission wait time is {{ $value }}s, which is above 30 minutes in cluster {{ $labels.source_cluster }}"
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
-        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        alert_routing_key: infra
         team: konflux-infra

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -108,13 +108,12 @@ tests:
           - exp_labels:
               severity: critical
               component: kueue
-              slo: "true"
               source_cluster: c1
             exp_annotations:
               summary: "High admission wait time in Kueue"
               description: "99th percentile admission wait time is 2392.5s, which is above 30 minutes in cluster c1"
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
-              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              alert_routing_key: infra
               team: konflux-infra
 
   # Test positive case - no alerts should fire when everything is healthy


### PR DESCRIPTION
The alert "KueueHighAdmissionWaitTime" has become a flapping alert, causing a lot of noise and distraction for many.  It's apparent it needs to be re-worked, so while these changes are made, configure this alert to no longer have a SLO.

Part of https://issues.redhat.com/browse/KFLUXINFRA-2107.