### PR TITLE
fix: Move Kanary alerts to non-slo

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kanary_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kanary_alerts.yaml
@@ -18,9 +18,11 @@ spec:
         for: 1s
         labels:
           severity: critical
+          # slo: "true" # Disabled until we can have more actionable information to support this
           slo: "false"
         annotations:
-          alert_team_handle: '<!subteam^S06V06A36F5>'
+          alert_routing_key: o11y
+          # alert_team_handle: '<!subteam^S06V06A36F5>'
           team: o11y
           summary: "Kanary signal for {{ $labels.type }} artifacts has been triggered for cluster {{ $labels.tested_cluster }}"
           description: "The e2e load tests for {{ $labels.type }} artifacts failed multiple times in a row for cluster {{ $labels.tested_cluster }}"

--- a/test/promql/tests/data_plane/kanary_test.yaml
+++ b/test/promql/tests/data_plane/kanary_test.yaml
@@ -27,7 +27,8 @@ tests:
               slo: "false"
             exp_annotations:
               team: o11y
-              alert_team_handle: '<!subteam^S06V06A36F5>'
+              alert_routing_key: o11y
+              # alert_team_handle: '<!subteam^S06V06A36F5>'
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alert-rule-kanary.md
               summary: "Kanary signal for container artifacts has been triggered for cluster prod-cluster-1"
               description: "The e2e load tests for container artifacts failed multiple times in a row for cluster prod-cluster-1"


### PR DESCRIPTION
These alerts are not actionable by an SRE, and they flap a lot. Without a LOT more SOP detail (and hopefully, a much finer-grained set of signals and/or tools to help us) this just amounts to noise on our PagerDuty alerts that leads us toward alert fatigue.