### PR TITLE
Add alert for MPC platfrom instability

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml
@@ -50,3 +50,21 @@ spec:
           The multi-platform otp pod has been down for 5min in cluster {{ $labels.source_cluster }}
         alert_team_handle: <!subteam^S05Q1P4Q2TG>
         team: konflux-infra
+
+  - name: multi-platform-controller-platform-health
+    interval: 1m
+    rules:
+    - alert: MultiPlatformControllerPlatformUnhealthy
+      expr: |
+        multi_platform_controller_available == 0
+      for: 5m
+      labels:
+        severity: critical
+        slo: "true"
+      annotations:
+        summary: >-
+          Multi-platform controller platform {{ $labels.check }} health check failed in cluster {{ $labels.source_cluster }}
+        description: >
+          The multi-platform controller platform health check "{{ $labels.check }}" has been failing for 5min in cluster {{ $labels.source_cluster }}
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra

--- a/test/promql/tests/data_plane/multi_platform_alerts_test.yaml
+++ b/test/promql/tests/data_plane/multi_platform_alerts_test.yaml
@@ -53,3 +53,39 @@ tests:
                 The multi-platform otp pod has been down for 5min in cluster c3
               alert_team_handle: <!subteam^S05Q1P4Q2TG>
               team: konflux-infra
+
+  - interval: 1m
+    input_series:
+      - series: 'multi_platform_controller_available{check="s390x", source_cluster="c5"}'
+        values: '0 0 0 0 0'
+      - series: 'multi_platform_controller_available{check="ppc64le", source_cluster="c5"}'
+        values: '0 0 0 0 0'
+      - series: 'multi_platform_controller_available{check="amd64", source_cluster="c6"}'
+        values: '1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: MultiPlatformControllerPlatformUnhealthy
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              check: s390x
+              slo: "true"
+              source_cluster: c5
+            exp_annotations:
+              summary: Multi-platform controller platform s390x health check failed in cluster c5
+              description: >
+                The multi-platform controller platform health check "s390x" has been failing for 5min in cluster c5
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra
+          - exp_labels:
+              severity: critical
+              check: ppc64le
+              slo: "true"
+              source_cluster: c5
+            exp_annotations:
+              summary: Multi-platform controller platform ppc64le health check failed in cluster c5
+              description: >
+                The multi-platform controller platform health check "ppc64le" has been failing for 5min in cluster c5
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra


### PR DESCRIPTION
This PR adds an alert indicating MPC build  platform instability (i.e. high error/success rate).
It was initially part of `konflux_up` metric, but then replaced with just deploymennt availability, but we still need it.

Fixes:  https://issues.redhat.com/browse/KONFLUX-9191