### PR TITLE
Add MPC infra alerts

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml
@@ -68,3 +68,37 @@ spec:
           The multi-platform controller platform health check "{{ $labels.check }}" has been failing for 5min in cluster {{ $labels.source_cluster }}
         alert_team_handle: <!subteam^S05Q1P4Q2TG>
         team: konflux-infra
+
+  - name: multi-platform-controller-metrics-health
+    interval: 30s
+    rules:
+    - alert: MultiPlatformControllerMetricsUnhealthy
+      expr: |
+        count by (source_cluster) (multi_platform_controller_running_tasks < 0 or multi_platform_controller_waiting_tasks < 0) > 0
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: >-
+          Multi-platform controller metrics are unhealthy in cluster {{ $labels.source_cluster }}
+        description: >-
+          The multi-platform controller Gauge metrics are showing negative values for the last 1 minute in cluster {{ $labels.source_cluster }}
+        alert_routing_key: infra
+        team: konflux-infra
+
+  - name: multi-platform-controller-provisioning-success-rate
+    interval: 1m
+    rules:
+    - alert: MultiPlatformControllerProvisioningSuccessRateTooLow
+      expr: |
+        (increase(multi_platform_controller_provisioning_successes[30m]) / (increase(multi_platform_controller_provisioning_successes[30m]) + increase(multi_platform_controller_provisioning_failures[30m]))) * 100 < 90
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: >-
+          Multi-platform controller provisioning success rate is too low in cluster {{ $labels.source_cluster }}
+        description: >-
+          The multi-platform controller provisioning success rate is less than 90% for the last 5 minutes in cluster {{ $labels.source_cluster }}
+        alert_routing_key: infra
+        team: konflux-infra

--- a/test/promql/tests/data_plane/multi_platform_alerts_test.yaml
+++ b/test/promql/tests/data_plane/multi_platform_alerts_test.yaml
@@ -89,3 +89,66 @@ tests:
                 The multi-platform controller platform health check "ppc64le" has been failing for 5min in cluster c5
               alert_team_handle: <!subteam^S05Q1P4Q2TG>
               team: konflux-infra
+  - interval: 30s
+    input_series:
+      - series: 'multi_platform_controller_running_tasks{source_cluster="c7"}'
+        values: '-1 -1 -1 -1'
+      - series: 'multi_platform_controller_waiting_tasks{source_cluster="c7"}'
+        values: '5 5 5 5'
+      - series: 'multi_platform_controller_running_tasks{source_cluster="c8"}'
+        values: '3 3 3 3'
+      - series: 'multi_platform_controller_waiting_tasks{source_cluster="c8"}'
+        values: '1 -1 -1 -1'
+      - series: 'multi_platform_controller_running_tasks{source_cluster="c9"}'
+        values: '1 -1 1 -1'
+      - series: 'multi_platform_controller_waiting_tasks{source_cluster="c9"}'
+        values: '1 -1 0 1'
+
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: MultiPlatformControllerMetricsUnhealthy
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              source_cluster: c7
+            exp_annotations:
+              summary: Multi-platform controller metrics are unhealthy in cluster c7
+              description: The multi-platform controller Gauge metrics are showing negative values for the last 1 minute in cluster c7
+              alert_routing_key: infra
+              team: konflux-infra
+          - exp_labels:
+              severity: warning
+              source_cluster: c8
+            exp_annotations:
+              summary: Multi-platform controller metrics are unhealthy in cluster c8
+              description: The multi-platform controller Gauge metrics are showing negative values for the last 1 minute in cluster c8
+              alert_routing_key: infra
+              team: konflux-infra
+
+  - interval: 1m
+    input_series:
+      - series: 'multi_platform_controller_provisioning_successes{source_cluster="c9"}'
+        values: '0+24x30 24+0x10'
+      - series: 'multi_platform_controller_provisioning_failures{source_cluster="c9"}'
+        values: '0+6x30 6+0x10'
+      - series: 'multi_platform_controller_provisioning_successes{source_cluster="c10"}'
+        values: '0+57x30 57+0x10'
+      - series: 'multi_platform_controller_provisioning_failures{source_cluster="c10"}'
+        values: '0+3x30 3+0x10'
+      - series: 'multi_platform_controller_provisioning_successes{source_cluster="c11"}'
+        values: '0+0x40'
+      - series: 'multi_platform_controller_provisioning_failures{source_cluster="c11"}'
+        values: '0+0x40'
+
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: MultiPlatformControllerProvisioningSuccessRateTooLow
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              source_cluster: c9
+            exp_annotations:
+              summary: Multi-platform controller provisioning success rate is too low in cluster c9
+              description: The multi-platform controller provisioning success rate is less than 90% for the last 5 minutes in cluster c9
+              alert_routing_key: infra
+              team: konflux-infra


### PR DESCRIPTION
## What
* Added Alert for invalid metrics - counters with negative values
* Added alert for low provision success rate (below 90%)
* Added tests for the two new alerts
## Why
* Until now a lot of metrics were invalid, this alert will help us to debug it and react faster
* A low success rate can indicate there's a problem with MPC