### PR TITLE
Increase alert time for MintMaker alerts

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
@@ -17,7 +17,7 @@ spec:
           check="replicas-available",
           service="mintmaker-controller-manager"
         } != 1
-      for: 5m
+      for: 15m
       labels:
         severity: critical
         slo: "true"
@@ -40,7 +40,7 @@ spec:
           check="replicas-available",
           service="redis"
         } != 1
-      for: 5m
+      for: 15m
       labels:
         severity: critical
         slo: "true"

--- a/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
+++ b/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
@@ -7,12 +7,12 @@ tests:
   - interval: 1m
     input_series:
       - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="mintmaker-controller-manager", source_cluster="c1"}'
-        values: '0 0 0 0 0'
+        values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
       - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="mintmaker-controller-manager", source_cluster="c2"}'
-        values: '1 1 1 1 1'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
 
     alert_rule_test:
-      - eval_time: 5m
+      - eval_time: 15m
         alertname: MintMakerControllerDown
         exp_alerts:
           - exp_labels:
@@ -33,12 +33,12 @@ tests:
   - interval: 1m
     input_series:
       - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="redis", source_cluster="c5"}'
-        values: '0 0 0 0 0'
+        values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
       - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="redis", source_cluster="c6"}'
-        values: '1 1 1 1 1'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
 
     alert_rule_test:
-      - eval_time: 5m
+      - eval_time: 15m
         alertname: MintMakerCacheDown
         exp_alerts:
           - exp_labels:


### PR DESCRIPTION
This commit changes the alert times from 5 to 15 minfor MintMaker availability, in order to make the alerts less flapping and more reliable.