### PR TITLE
MintMaker DUC alerting

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
@@ -54,3 +54,24 @@ spec:
         alert_team_handle: <!subteam^S078T8TMQP5>
         team: mintmaker
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md
+
+  - name: mintmaker-dependency-update-check-availability
+    interval: 1m
+    rules:
+    - alert: MintMakerDependencyUpdateCheckStale
+      # Alert if more than 4.5 hours have passed since last DUC creation
+      expr: |
+        (time() - max by (source_cluster) (mintmaker_dependency_update_check_creation_time{namespace="mintmaker"})) > 4.5 * 60 * 60
+      for: 5m
+      labels:
+        severity: warning
+        slo: "false"
+      annotations:
+        summary: >-
+          MintMaker dependency update check creation is stale in cluster {{ $labels.source_cluster }}
+        description: >
+          No new DependencyUpdateCheck resources have been created in the last 4.5 hours in cluster {{ $labels.source_cluster }}.
+          The last DUC was created more than 4.5 hours ago.
+        alert_team_handle: <!subteam^S078T8TMQP5>
+        team: mintmaker
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md

--- a/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
+++ b/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
@@ -79,3 +79,32 @@ tests:
       - eval_time: 5m
         alertname: MintMakerControllerDown
         exp_alerts: null
+
+  - interval: 1m
+    input_series:
+      # DUC created at test start time (timestamp 0), value stays constant
+      - series: 'mintmaker_dependency_update_check_creation_time{name="dependencyupdatecheck-old",namespace="mintmaker", source_cluster="c7"}'
+        values: '0+0x300'
+
+    alert_rule_test:
+      # Evaluate at 4.5 hours - should NOT fire yet (exactly at threshold)
+      - eval_time: 4h30m
+        alertname: MintMakerDependencyUpdateCheckStale
+        exp_alerts: []
+
+      # Evaluate at 4.5 hours + 5 minutes - should fire after 5m delay
+      - eval_time: 4h36m
+        alertname: MintMakerDependencyUpdateCheckStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              source_cluster: c7
+            exp_annotations:
+              summary: "MintMaker dependency update check creation is stale in cluster c7"
+              description: >
+                No new DependencyUpdateCheck resources have been created in the last 4.5 hours in cluster c7.
+                The last DUC was created more than 4.5 hours ago.
+              alert_team_handle: <!subteam^S078T8TMQP5>
+              team: mintmaker
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md


### PR DESCRIPTION
This commit implements an alert in case the DUC creation is not taking place as expected.

DUCs are a custom resource in MintMaker that acts as triggers. If they are not created at the expected times, we should fire a warning.

Assisted by: Cursor