### PR TITLE
chore(stoneintg-1325): add alert/tests for service response time

### DIFF
--- a/dashboards/grafana-dashboard-konflux-integration-service-slo.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-integration-service-slo.configmap.yaml
@@ -327,7 +327,7 @@ data:
             "type": "prometheus",
             "uid": "${Datasource}"
           },
-          "description": "Measures the duration from when a build PipelineRun completes until the corresponding Snapshot CR is marked as 'in progress'.",
+          "description": "Measures the duration from when a build PipelineRun completes. until the corresponding Snapshot CR is marked as 'in progress'. Spikes in the red zone are > 30 sec",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -436,7 +436,7 @@ data:
             "type": "prometheus",
             "uid": "${Datasource}"
           },
-          "description": "Success rate of requests under 30 sec",
+          "description": "90% of requests must take less than 30 sec. This panel displays the success rate. A violation occurs when the rate falls below the 90% threshold (below the red line)",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -535,7 +535,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum by (source_cluster) (rate(integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds_bucket{le=\"30\", source_cluster=~\"$cluster\"}[$__rate_interval])) / sum by (source_cluster) (rate(integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds_count{source_cluster=~\"$cluster\"}[$__rate_interval]))\n* 100",
+              "expr": "sum by (source_cluster) (rate(integration_svc_snapshot_created_to_pipelinerun_started_seconds_bucket{le=\"30\", source_cluster=~\"$cluster\"}[$__rate_interval])) / sum by (source_cluster) (rate(integration_svc_snapshot_created_to_pipelinerun_started_seconds_count{source_cluster=~\"$cluster\"}[$__rate_interval]))\n* 100",
               "instant": false,
               "legendFormat": "{{source_cluster}}",
               "range": true,
@@ -550,7 +550,7 @@ data:
             "type": "prometheus",
             "uid": "${Datasource}"
           },
-          "description": "Measure the time between ApplicationSnapshot creation to pipelineRun creation in a static env.",
+          "description": "Measure the time between ApplicationSnapshot creation to pipelineRun creation. Spikes in the red zone are > 5 sec",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -589,7 +589,7 @@ data:
                   "mode": "none"
                 },
                 "thresholdsStyle": {
-                  "mode": "off"
+                  "mode": "line+area"
                 }
               },
               "mappings": [],
@@ -597,7 +597,11 @@ data:
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "transparent"
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 5
                   }
                 ]
               },
@@ -655,7 +659,7 @@ data:
             "type": "prometheus",
             "uid": "${Datasource}"
           },
-          "description": "90% of requests must take less than 5sec",
+          "description": "90% of requests must take less than 5sec. This panel displays the success rate. A violation occurs when the rate falls below the 90% threshold (below the red line)",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -754,7 +758,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum by (source_cluster) (rate(integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds_bucket{le=\"5\", source_cluster=~\"$cluster\"}[$__rate_interval]))\n/sum by (source_cluster) (rate(integration_svc_snapshot_created_to_pipelinerun_with_static_env_started_seconds_count{source_cluster=~\"$cluster\"}[$__rate_interval]))\n* 100",
+              "expr": "sum by (source_cluster) (rate(integration_svc_snapshot_created_to_pipelinerun_started_seconds_bucket{le=\"5\", source_cluster=~\"$cluster\"}[$__rate_interval])) / sum by (source_cluster) (rate(integration_svc_snapshot_created_to_pipelinerun_started_seconds_count{source_cluster=~\"$cluster\"}[$__rate_interval])) * 100",
               "instant": false,
               "legendFormat": "{{source_cluster}}",
               "range": true,
@@ -769,7 +773,7 @@ data:
             "type": "prometheus",
             "uid": "${Datasource}"
           },
-          "description": "Measure release creation latency from end of testing to release created ",
+          "description": "Measure release creation latency from end of testing to release created. Spikes in the red zone are > 10 sec",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -808,7 +812,7 @@ data:
                   "mode": "none"
                 },
                 "thresholdsStyle": {
-                  "mode": "off"
+                  "mode": "line+area"
                 }
               },
               "mappings": [],
@@ -816,7 +820,11 @@ data:
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "transparent"
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 10
                   }
                 ]
               },
@@ -874,7 +882,7 @@ data:
             "type": "prometheus",
             "uid": "${Datasource}"
           },
-          "description": "90% of requests must take less than 10 sec. Measure release creation latency from end of testing to release created ",
+          "description": "90% of requests must take less than 10 sec. This panel displays the success rate. A violation occurs when the rate falls below the 90% threshold (below the red line)",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1060,9 +1068,7 @@ data:
           },
           {
             "current": {
-              "text": [
-                "All"
-              ],
+              "text": "All",
               "value": [
                 "$__all"
               ]
@@ -1098,5 +1104,5 @@ data:
       "timezone": "browser",
       "title": "Konflux - Integration Service SLO",
       "uid": "cerzhj80cyvi8c",
-      "version": 2
+      "version": 51
     }

--- a/rhobs/alerting/data_plane/prometheus.integration_service_build_pipeline_to_snapshot_in_progress_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.integration_service_build_pipeline_to_snapshot_in_progress_alerts.yaml
@@ -1,0 +1,33 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-integration-service-build-pipeline-to-snapshot-in-progress
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: pipeline-to-snapshot-exceeded
+    interval: 1m
+    rules:
+    - alert: PipelineRunToSnapshotExceeded
+      expr: |
+        (
+          (
+          increase(integration_svc_response_seconds_bucket{le="+Inf"}[5m])
+          - ignoring(le)
+          increase(integration_svc_response_seconds_bucket{le="30"}[5m])
+         ) / ignoring(le)
+         increase(integration_svc_response_seconds_bucket{le="+Inf"}[5m])
+        ) > 0.10
+      for: 10m
+      labels:
+        severity: critical
+        slo: "true"
+      annotations:
+        summary: >-
+          PipelineRunFinish to SnapshotInProgress time exceeded
+        description: >
+          Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 10 minutes on cluster {{ $labels.source_cluster }}
+        alert_team_handle: <!subteam^S041261DDEW>
+        team: integration
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md

--- a/rhobs/alerting/data_plane/prometheus.integration_service_snapshot_created_to_pipelinerun_started_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.integration_service_snapshot_created_to_pipelinerun_started_alerts.yaml
@@ -25,11 +25,10 @@ spec:
         slo: "true"
       annotations:
         summary: >-
-          Latency from an application snapshot created to integration PLRs in static envs created
+          Latency from an application snapshot created to integration PLRs created
         description: >
-          Time from Snapshot created to integration PLRs in static envs created has been over
-          5s for {{ $value | humanizePercentage }} of requests (tolerance 10%) during the last 10 minutes on cluster
-          {{ $labels.source_cluster }}
+          Time from Snapshot created to integration PLRs created has been over
+          5s for more than 10% of requests during the last 10 minutes on cluster {{ $labels.source_cluster }}
         alert_team_handle: <!subteam^S05M4AG8CJH>
         team: integration
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/time_to_start_pipelinerun.md

--- a/test/promql/tests/data_plane/integration_service_build_pipeline_to_snapshot_in_progress_test.yaml
+++ b/test/promql/tests/data_plane/integration_service_build_pipeline_to_snapshot_in_progress_test.yaml
@@ -1,0 +1,97 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.integration_service_build_pipeline_to_snapshot_in_progress_alerts.yaml
+
+tests:
+
+# Scenario where one cluster crosses the 10% threshold and another does not
+- interval: 1m
+  input_series:
+    # Simulating data from Cluster 1
+    - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service",  source_cluster="cluster01"}'
+      values: '0+10x15'  # 10 requests took less than 30s
+    - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster01"}'
+      values: '0+100x15'  # 100 total occurrences in cluster1
+    # Simulating data from Cluster 2
+    - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster02"}'
+      values: '0+95x15'  # 95 requests took less than 30s
+    - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster02"}'
+      values: '0+100x15'  # 100 total occurrences in cluster2
+  alert_rule_test:
+    - eval_time: 15m
+      alertname: PipelineRunToSnapshotExceeded
+      exp_alerts:
+        - exp_labels:
+            severity: critical
+            slo: "true"
+            namespace: integration-service
+            source_cluster: cluster01
+          exp_annotations:
+            summary: PipelineRunFinish to SnapshotInProgress time exceeded
+            description: >
+              Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 10 minutes on cluster cluster01
+            alert_team_handle: <!subteam^S041261DDEW>
+            team: integration
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
+
+# Scenario where both clusters cross the 10% threshold, alert should trigger for both
+- interval: 1m
+  input_series:
+    # Simulating data from Cluster 01
+    - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster01"}'
+      values: '0+10x15'  # 10 requests took less than 30s
+    - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster01"}'
+      values: '0+100x15'  # 100 total occurrences in cluster1
+    # Simulating data from Cluster 2
+    - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster02"}'
+      values: '0+10x15'  # 10 requests took less than 30s
+    - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster02"}'
+      values: '0+100x15'  # 100 total occurrences in cluster2
+  alert_rule_test:
+    - eval_time: 15m
+      alertname: PipelineRunToSnapshotExceeded
+      exp_alerts:
+        - exp_labels:
+            severity: critical
+            slo: "true"
+            namespace: integration-service
+            source_cluster: cluster01
+          exp_annotations:
+            summary: PipelineRunFinish to SnapshotInProgress time exceeded
+            description: >
+              Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 10 minutes on cluster cluster01
+            alert_team_handle: <!subteam^S041261DDEW>
+            team: integration
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
+        - exp_labels:
+            severity: critical
+            slo: "true"
+            namespace: integration-service
+            source_cluster: cluster02
+          exp_annotations:
+            summary: PipelineRunFinish to SnapshotInProgress time exceeded
+            description: >
+              Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 10 minutes on cluster cluster02
+            alert_team_handle: <!subteam^S041261DDEW>
+            team: integration
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
+
+# Scenario where no alert is triggered as both clusters stay below the 10% threshold
+- interval: 1m
+  input_series:
+    # Simulating data from Cluster 1 for 9% above 30s
+    - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster01"}'
+      values: '0+91x15'  # 91 requests took less than 30s
+    - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster01"}'
+      values: '0+100x15'  # 100 total occurrences in cluster1
+
+    # Simulating data from Cluster 2 for 4% above 30s, alert should not trigger
+    - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster02"}'
+      values: '0+96x15'  # 96 requests took less than 30s
+    - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster02"}'
+      values: '0+100x15'  # 100 total occurrences in cluster2
+  alert_rule_test:
+    - eval_time: 15m
+      alertname: PipelineRunToSnapshotExceeded
+      exp_alerts: []  # No alerts are expected in this scenario

--- a/test/promql/tests/data_plane/integration_service_snapshot_created_to_pipelinerun_started_test.yaml
+++ b/test/promql/tests/data_plane/integration_service_snapshot_created_to_pipelinerun_started_test.yaml
@@ -19,7 +19,7 @@ tests:
         values: '0+100x15'  # 100 total occurrences per minute in cluster02
 
     alert_rule_test:
-      - eval_time: 14m
+      - eval_time: 15m
         alertname: IntegrationServiceSnapshotTimeToPLR
         exp_alerts:
           - exp_labels:
@@ -27,11 +27,10 @@ tests:
               slo: "true"
               source_cluster: cluster01
             exp_annotations:
-              summary: Latency from an application snapshot created to integration PLRs in static envs created
+              summary: Latency from an application snapshot created to integration PLRs created
               description: >
-                Time from Snapshot created to integration PLRs in static envs created has been over
-                5s for 90% of requests (tolerance 10%) during the last 10 minutes on cluster
-                cluster01
+                Time from Snapshot created to integration PLRs created has been over
+                5s for more than 10% of requests during the last 10 minutes on cluster cluster01
               alert_team_handle: <!subteam^S05M4AG8CJH>
               team: integration
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/time_to_start_pipelinerun.md
@@ -53,7 +52,7 @@ tests:
         values: '0+100x15'  # 100 total occurrences per minute in cluster02
 
     alert_rule_test:
-      - eval_time: 14m
+      - eval_time: 15m
         alertname: IntegrationServiceSnapshotTimeToPLR
         exp_alerts:
           - exp_labels:
@@ -61,11 +60,10 @@ tests:
               slo: "true"
               source_cluster: cluster01
             exp_annotations:
-              summary: Latency from an application snapshot created to integration PLRs in static envs created
+              summary: Latency from an application snapshot created to integration PLRs created
               description: >
-                Time from Snapshot created to integration PLRs in static envs created has been over
-                5s for 95% of requests (tolerance 10%) during the last 10 minutes on cluster
-                cluster01
+                Time from Snapshot created to integration PLRs created has been over
+                5s for more than 10% of requests during the last 10 minutes on cluster cluster01
               alert_team_handle: <!subteam^S05M4AG8CJH>
               team: integration
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/time_to_start_pipelinerun.md
@@ -74,11 +72,10 @@ tests:
               slo: "true"
               source_cluster: cluster02
             exp_annotations:
-              summary: Latency from an application snapshot created to integration PLRs in static envs created
+              summary: Latency from an application snapshot created to integration PLRs created
               description: >
-                Time from Snapshot created to integration PLRs in static envs created has been over
-                5s for 95% of requests (tolerance 10%) during the last 10 minutes on cluster
-                cluster02
+                Time from Snapshot created to integration PLRs created has been over
+                5s for more than 10% of requests during the last 10 minutes on cluster cluster02
               alert_team_handle: <!subteam^S05M4AG8CJH>
               team: integration
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/time_to_start_pipelinerun.md
@@ -100,6 +97,6 @@ tests:
         values: '0+100x15'  # 100 total occurrences per minute in cluster02
 
     alert_rule_test:
-      - eval_time: 14m
+      - eval_time: 15m
         alertname: IntegrationServiceSnapshotTimeToPLR
         exp_alerts: []  # No alerts are expected in this scenario


### PR DESCRIPTION
which is the measurement of build PLR completed to snapshot marked as in progress.
Add additional info to panels for clarity in violations Edit the snapshot created to PLR started to use the correct query (removing with_static_envs)
Fix error in test timing for same query, to 15mins

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
