### PR TITLE
fix: changes severity to high

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
@@ -49,7 +49,7 @@ spec:
         ) < 0.90
       for: 15m
       labels:
-        severity: critical
+        severity: high
         slo: "true"
       annotations:
         summary: >-

--- a/test/promql/tests/data_plane/release_service_test.yaml
+++ b/test/promql/tests/data_plane/release_service_test.yaml
@@ -20,7 +20,7 @@ tests:
         alertname: ReleaseServicePreProcessingDurationSeconds
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: high
               slo: "true"
               job: "release"
               source_cluster: "cluster01"


### PR DESCRIPTION
https://issues.redhat.com/browse/RELEASE-1875

this PR changes the severity of the SLO for
ReleasePreProcessing to `high` as the alert is flapping and needs adjusts.

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [x] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
