### PR TITLE
Increase height of the top kanary panels

### DIFF
--- a/dashboards/grafana-dashboard-kanary-signal.configmap.yaml
+++ b/dashboards/grafana-dashboard-kanary-signal.configmap.yaml
@@ -79,7 +79,7 @@ data:
             "overrides": []
           },
           "gridPos": {
-            "h": 11,
+            "h": 15,
             "w": 12,
             "x": 0,
             "y": 1
@@ -158,7 +158,7 @@ data:
             "overrides": []
           },
           "gridPos": {
-            "h": 11,
+            "h": 15,
             "w": 12,
             "x": 12,
             "y": 1


### PR DESCRIPTION


### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---
Increase height of the top kanary panels

I want to be able to see the history trends for the kanary signals for all production clusters at the same time, but right now the panel is short enough that the data gets reduced to a single number if I select every prod cluster.

I didn't test that "15" was the right height. I just picked a number that was a little bit more than the current number to see how that fares.

