### PR TITLE
chore(stoneintg-1326): change from team tag to IC tag

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.integration_service_build_pipeline_to_snapshot_in_progress_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.integration_service_build_pipeline_to_snapshot_in_progress_alerts.yaml
@@ -28,6 +28,6 @@ spec:
           PipelineRunFinish to SnapshotInProgress time exceeded
         description: >
           Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 10 minutes on cluster {{ $labels.source_cluster }}
-        alert_team_handle: <!subteam^S041261DDEW>
+        alert_team_handle: <!subteam^S05M4AG8CJH>
         team: integration
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md

--- a/test/promql/tests/data_plane/integration_service_build_pipeline_to_snapshot_in_progress_test.yaml
+++ b/test/promql/tests/data_plane/integration_service_build_pipeline_to_snapshot_in_progress_test.yaml
@@ -31,7 +31,7 @@ tests:
             summary: PipelineRunFinish to SnapshotInProgress time exceeded
             description: >
               Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 10 minutes on cluster cluster01
-            alert_team_handle: <!subteam^S041261DDEW>
+            alert_team_handle: <!subteam^S05M4AG8CJH>
             team: integration
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
 
@@ -61,7 +61,7 @@ tests:
             summary: PipelineRunFinish to SnapshotInProgress time exceeded
             description: >
               Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 10 minutes on cluster cluster01
-            alert_team_handle: <!subteam^S041261DDEW>
+            alert_team_handle: <!subteam^S05M4AG8CJH>
             team: integration
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
         - exp_labels:
@@ -73,7 +73,7 @@ tests:
             summary: PipelineRunFinish to SnapshotInProgress time exceeded
             description: >
               Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 10 minutes on cluster cluster02
-            alert_team_handle: <!subteam^S041261DDEW>
+            alert_team_handle: <!subteam^S05M4AG8CJH>
             team: integration
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
 


### PR DESCRIPTION
one alert tags the entire Integration Service team, change it to alert only the IC as with the other alerts

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
