### PR TITLE
fix(stoneintg-1369): fix flapping alert by increasing measurement time

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.integration_service_build_pipeline_to_snapshot_in_progress_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.integration_service_build_pipeline_to_snapshot_in_progress_alerts.yaml
@@ -19,7 +19,7 @@ spec:
          ) / ignoring(le)
          increase(integration_svc_response_seconds_bucket{le="+Inf"}[5m])
         ) > 0.10
-      for: 10m
+      for: 20m
       labels:
         severity: critical
         slo: "true"
@@ -27,7 +27,7 @@ spec:
         summary: >-
           PipelineRunFinish to SnapshotInProgress time exceeded
         description: >
-          Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 10 minutes on cluster {{ $labels.source_cluster }}
+          Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 20 minutes on cluster {{ $labels.source_cluster }}
         alert_team_handle: <!subteam^S05M4AG8CJH>
         team: integration
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md

--- a/test/promql/tests/data_plane/integration_service_build_pipeline_to_snapshot_in_progress_test.yaml
+++ b/test/promql/tests/data_plane/integration_service_build_pipeline_to_snapshot_in_progress_test.yaml
@@ -10,16 +10,16 @@ tests:
   input_series:
     # Simulating data from Cluster 1
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service",  source_cluster="cluster01"}'
-      values: '0+10x15'  # 10 requests took less than 30s
+      values: '0+10x25'  # 10 requests took less than 30s
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster01"}'
-      values: '0+100x15'  # 100 total occurrences in cluster1
+      values: '0+100x25'  # 100 total occurrences in cluster1
     # Simulating data from Cluster 2
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+95x15'  # 95 requests took less than 30s
+      values: '0+95x25'  # 95 requests took less than 30s
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+100x15'  # 100 total occurrences in cluster2
+      values: '0+100x25'  # 100 total occurrences in cluster2
   alert_rule_test:
-    - eval_time: 15m
+    - eval_time: 25m
       alertname: PipelineRunToSnapshotExceeded
       exp_alerts:
         - exp_labels:
@@ -30,7 +30,7 @@ tests:
           exp_annotations:
             summary: PipelineRunFinish to SnapshotInProgress time exceeded
             description: >
-              Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 10 minutes on cluster cluster01
+              Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 20 minutes on cluster cluster01
             alert_team_handle: <!subteam^S05M4AG8CJH>
             team: integration
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
@@ -40,16 +40,16 @@ tests:
   input_series:
     # Simulating data from Cluster 01
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster01"}'
-      values: '0+10x15'  # 10 requests took less than 30s
+      values: '0+10x25'  # 10 requests took less than 30s
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster01"}'
-      values: '0+100x15'  # 100 total occurrences in cluster1
+      values: '0+100x25'  # 100 total occurrences in cluster1
     # Simulating data from Cluster 2
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+10x15'  # 10 requests took less than 30s
+      values: '0+10x25'  # 10 requests took less than 30s
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+100x15'  # 100 total occurrences in cluster2
+      values: '0+100x25'  # 100 total occurrences in cluster2
   alert_rule_test:
-    - eval_time: 15m
+    - eval_time: 25m
       alertname: PipelineRunToSnapshotExceeded
       exp_alerts:
         - exp_labels:
@@ -60,7 +60,7 @@ tests:
           exp_annotations:
             summary: PipelineRunFinish to SnapshotInProgress time exceeded
             description: >
-              Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 10 minutes on cluster cluster01
+              Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 20 minutes on cluster cluster01
             alert_team_handle: <!subteam^S05M4AG8CJH>
             team: integration
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
@@ -72,7 +72,7 @@ tests:
           exp_annotations:
             summary: PipelineRunFinish to SnapshotInProgress time exceeded
             description: >
-              Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 10 minutes on cluster cluster02
+              Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 20 minutes on cluster cluster02
             alert_team_handle: <!subteam^S05M4AG8CJH>
             team: integration
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
@@ -82,16 +82,16 @@ tests:
   input_series:
     # Simulating data from Cluster 1 for 9% above 30s
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster01"}'
-      values: '0+91x15'  # 91 requests took less than 30s
+      values: '0+91x25'  # 91 requests took less than 30s
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster01"}'
-      values: '0+100x15'  # 100 total occurrences in cluster1
+      values: '0+100x25'  # 100 total occurrences in cluster1
 
     # Simulating data from Cluster 2 for 4% above 30s, alert should not trigger
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+96x15'  # 96 requests took less than 30s
+      values: '0+96x25'  # 96 requests took less than 30s
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+100x15'  # 100 total occurrences in cluster2
+      values: '0+100x25'  # 100 total occurrences in cluster2
   alert_rule_test:
-    - eval_time: 15m
+    - eval_time: 25m
       alertname: PipelineRunToSnapshotExceeded
       exp_alerts: []  # No alerts are expected in this scenario


### PR DESCRIPTION
The buildPLR to snapshot marked as in progress SLO for Integration Service is flapping on p02 and rh01, self resolves very quickly. Changing measurement time to 20 mins to prevent flapping.
https://issues.redhat.com/browse/STONEINTG-1369

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
