### PR TITLE
Fix the expr for avg and stddev functions

### DIFF
--- a/rhobs/recording/api_server_availability_recording_rules.yaml
+++ b/rhobs/recording/api_server_availability_recording_rules.yaml
@@ -31,7 +31,7 @@ spec:
           expr: |
             (
               sum by(source_cluster) (
-                rate(apiserver_request_total{code=~"5.."}[10m])
+                rate(apiserver_request_total{code=~"5..|4.."}[10m])
               ) /
               sum by(source_cluster) (
                 rate(apiserver_request_total{code!="0"}[10m])
@@ -42,34 +42,12 @@ spec:
 
         - record: api_server:error_rate_30d_avg
           expr: |
-            avg_over_time(
-              (
-                (
-                  sum by(source_cluster) (
-                    rate(apiserver_request_total{code=~"5.."}[1h])
-                  ) /
-                  sum by(source_cluster) (
-                    rate(apiserver_request_total{code!="0"}[1h])
-                  )
-                ) * 100
-              )[30d:1h]
-            )
+            avg_over_time(api_server:error_rate_10m[30d])
           labels:
             service: api-server
 
         - record: api_server:error_rate_30d_stddev
           expr: |
-            stddev_over_time(
-              (
-                (
-                  sum by(source_cluster) (
-                    rate(apiserver_request_total{code=~"5.."}[1h])
-                  ) /
-                  sum by(source_cluster) (
-                    rate(apiserver_request_total{code!="0"}[1h])
-                  )
-                ) * 100
-              )[30d:1h]
-            )
+            stddev_over_time(api_server:error_rate_10m[30d])
           labels:
             service: api-server


### PR DESCRIPTION
### Description

Api server metrics are available to add a recording rule that is needed for alerts.
The current rule needed some adjustment to test.
This is part of jira PVO11Y-4934

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
