### PR TITLE
KFLUXINFRA-2207: modified MPC grafana dashboard

### DIFF
--- a/dashboards/grafana-dashboard-mpc.configmap.yaml
+++ b/dashboards/grafana-dashboard-mpc.configmap.yaml
@@ -29,29 +29,16 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 1026357,
+      "id": 1081716,
       "links": [],
       "panels": [
-        {
-          "collapsed": true,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 0
-          },
-          "id": 38,
-          "panels": [],
-          "title": "Building blocks",
-          "type": "row"
-        },
         {
           "collapsed": false,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 1
+            "y": 0
           },
           "id": 23,
           "panels": [],
@@ -85,7 +72,7 @@ data:
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 2
+            "y": 1
           },
           "id": 34,
           "options": {
@@ -160,7 +147,7 @@ data:
             "h": 9,
             "w": 11,
             "x": 12,
-            "y": 2
+            "y": 1
           },
           "id": 29,
           "options": {
@@ -228,7 +215,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 11
+            "y": 10
           },
           "id": 1,
           "options": {
@@ -333,7 +320,7 @@ data:
             "h": 8,
             "w": 11,
             "x": 12,
-            "y": 11
+            "y": 10
           },
           "id": 37,
           "options": {
@@ -367,28 +354,84 @@ data:
           "type": "timeseries"
         },
         {
-          "collapsed": false,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 19
+          "description": "all the MPC related alerts",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
           },
-          "id": 18,
-          "panels": [],
-          "title": "Running Tasks",
-          "type": "row"
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 43,
+          "options": {
+            "alertInstanceLabelFilter": "",
+            "alertName": "MultiPlatform",
+            "dashboardAlerts": false,
+            "datasource": "rhtap-observatorium-production",
+            "groupBy": [],
+            "groupMode": "default",
+            "maxItems": 20,
+            "showInactiveAlerts": false,
+            "sortOrder": 1,
+            "stateFilter": {
+              "error": true,
+              "firing": true,
+              "noData": false,
+              "normal": false,
+              "pending": true
+            },
+            "viewMode": "list"
+          },
+          "pluginVersion": "11.6.3",
+          "title": "MPC Alert List",
+          "type": "alertlist"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "P22466E8E7855F1E0"
           },
-          "description": "The number of currently running tasks on each platform",
+          "description": "the size of platform machines pool by platform and source cluster",
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
@@ -407,10 +450,87 @@ data:
             "overrides": []
           },
           "gridPos": {
+            "h": 8,
+            "w": 11,
+            "x": 12,
+            "y": 18
+          },
+          "id": 42,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P22466E8E7855F1E0"
+              },
+              "editorMode": "code",
+              "expr": "sum by (platform, source_cluster) (\n  multi_platform_controller_platform_pool_size{source_cluster=~\"$cluster\", platform=~\"$platform\"}\n)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Platform Pool Size",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 26
+          },
+          "id": 18,
+          "panels": [],
+          "title": "Running Tasks",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P22466E8E7855F1E0"
+          },
+          "description": "the number of currently running tasks on each platform",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red"
+                  },
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
             "h": 14,
             "w": 22,
             "x": 1,
-            "y": 20
+            "y": 27
           },
           "id": 19,
           "options": {
@@ -453,7 +573,7 @@ data:
             "type": "prometheus",
             "uid": "P22466E8E7855F1E0"
           },
-          "description": "Average per-second rate of increase or decrease in the number of running tasks over a 5-minute period.",
+          "description": "average per-second rate of increase or decrease in the number of running tasks over a 5-minute period.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -512,7 +632,7 @@ data:
             "h": 9,
             "w": 11,
             "x": 1,
-            "y": 34
+            "y": 41
           },
           "id": 20,
           "options": {
@@ -609,7 +729,7 @@ data:
             "h": 9,
             "w": 11,
             "x": 12,
-            "y": 34
+            "y": 41
           },
           "id": 21,
           "options": {
@@ -648,7 +768,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 43
+            "y": 50
           },
           "id": 24,
           "panels": [],
@@ -660,11 +780,44 @@ data:
             "type": "prometheus",
             "uid": "P22466E8E7855F1E0"
           },
-          "description": "he number of tasks waiting for an executor to be available to run",
+          "description": "the number of tasks waiting for an executor to be available to run",
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
@@ -682,25 +835,20 @@ data:
             "h": 14,
             "w": 22,
             "x": 1,
-            "y": 44
+            "y": 51
           },
           "id": 25,
           "options": {
-            "minVizHeight": 75,
-            "minVizWidth": 75,
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
             },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
-            "sizing": "auto",
-            "text": {
-              "titleSize": 8
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "11.6.3",
@@ -718,14 +866,14 @@ data:
             }
           ],
           "title": "Current waiting Tasks by Platform",
-          "type": "gauge"
+          "type": "timeseries"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "P22466E8E7855F1E0"
           },
-          "description": "Average per-second rate of increase or decrease in the number of waiting tasks over a 5-minute period.",
+          "description": "average per-second rate of increase or decrease in the number of waiting tasks over a 5-minute period.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -784,7 +932,7 @@ data:
             "h": 9,
             "w": 11,
             "x": 1,
-            "y": 58
+            "y": 65
           },
           "id": 26,
           "options": {
@@ -881,7 +1029,7 @@ data:
             "h": 9,
             "w": 11,
             "x": 12,
-            "y": 58
+            "y": 65
           },
           "id": 27,
           "options": {
@@ -920,7 +1068,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 67
+            "y": 74
           },
           "id": 14,
           "panels": [],
@@ -990,7 +1138,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 68
+            "y": 75
           },
           "id": 15,
           "options": {
@@ -1020,7 +1168,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Average Task Run Time Excluding Wait and Allocation Time (30m Window)",
+          "title": "Average Task Run Time Excluding Wait and Allocation Time in Seconds (30m Window)",
           "type": "timeseries"
         },
         {
@@ -1028,7 +1176,7 @@ data:
             "type": "prometheus",
             "uid": "P22466E8E7855F1E0"
           },
-          "description": "Calculates the value that 95% of tasks finished faster than.",
+          "description": "the value that 95% of tasks finished faster than.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1087,7 +1235,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 68
+            "y": 75
           },
           "id": 16,
           "options": {
@@ -1117,7 +1265,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "95th Percentile of Total Task Run Time (5m Window)",
+          "title": "95th Percentile of Total Task Run Time in Seconds (5m Window)",
           "type": "timeseries"
         },
         {
@@ -1125,7 +1273,7 @@ data:
             "type": "prometheus",
             "uid": "P22466E8E7855F1E0"
           },
-          "description": "The number of tasks completed per second, aggregated by platform.",
+          "description": "the number of tasks completed per second, aggregated by platform.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1184,7 +1332,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 6,
-            "y": 76
+            "y": 83
           },
           "id": 17,
           "options": {
@@ -1223,7 +1371,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 84
+            "y": 91
           },
           "id": 10,
           "panels": [],
@@ -1235,7 +1383,7 @@ data:
             "type": "prometheus",
             "uid": "P22466E8E7855F1E0"
           },
-          "description": "The average wait time for a host to become available, excluding the host allocation time",
+          "description": "the average wait time for a host to become available, excluding the host allocation time",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1294,7 +1442,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 85
+            "y": 92
           },
           "id": 11,
           "options": {
@@ -1324,7 +1472,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Average Task's Wait Time (5m Window)",
+          "title": "Average Task's Wait Time in Seconds (5m Window)",
           "type": "timeseries"
         },
         {
@@ -1391,7 +1539,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 85
+            "y": 92
           },
           "id": 12,
           "options": {
@@ -1415,13 +1563,13 @@ data:
                 "uid": "P22466E8E7855F1E0"
               },
               "editorMode": "code",
-              "expr": "sum by(platform) (rate(multi_platform_controller_wait_time_count{source_cluster=~\"$cluster\", platform=~\"$platform\"}[5m]))",
+              "expr": "sum by(platform) (rate(multi_platform_controller_wait_time_count{source_cluster=~\"$cluster\", platform=~\"$platform\"}[5m])) * 60",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Total Tasks Per Second Waiting (5m Avg)",
+          "title": "Total Tasks per Minute Waiting (5m Avg)",
           "type": "timeseries"
         },
         {
@@ -1488,7 +1636,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 7,
-            "y": 93
+            "y": 100
           },
           "id": 13,
           "options": {
@@ -1518,7 +1666,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Median Wait Time by Platform (30m Window)",
+          "title": "Median Wait Time in Seconds by Platform (30m Window)",
           "type": "timeseries"
         },
         {
@@ -1527,7 +1675,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 101
+            "y": 108
           },
           "id": 5,
           "panels": [],
@@ -1597,7 +1745,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 102
+            "y": 109
           },
           "id": 6,
           "options": {
@@ -1621,7 +1769,7 @@ data:
                 "uid": "P22466E8E7855F1E0"
               },
               "editorMode": "code",
-              "expr": "sum by(platform) (rate(multi_platform_controller_host_allocation_time_sum{source_cluster=~\"$cluster\", platform=~\"$platform\"}[5m])) / sum by(platform) (rate(multi_platform_controller_host_allocation_time_count{source_cluster=~\"$cluster\", platform=~\"$platform\"}[30m]))",
+              "expr": "sum by(platform) (rate(multi_platform_controller_host_allocation_time_sum{source_cluster=~\"$cluster\", platform=~\"$platform\"}[30m])) / sum by(platform) (rate(multi_platform_controller_host_allocation_time_count{source_cluster=~\"$cluster\", platform=~\"$platform\"}[30m]))",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -1693,7 +1841,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 102
+            "y": 109
           },
           "id": 7,
           "options": {
@@ -1788,8 +1936,8 @@ data:
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 6,
-            "y": 110
+            "x": 0,
+            "y": 117
           },
           "id": 9,
           "options": {
@@ -1813,122 +1961,13 @@ data:
                 "uid": "P22466E8E7855F1E0"
               },
               "editorMode": "code",
-              "expr": "sum by(platform) (rate(multi_platform_controller_host_allocation_time_count{source_cluster=~\"$cluster\", platform=~\"$platform\"}[5m]))",
+              "expr": "sum by(platform) (rate(multi_platform_controller_host_allocation_time_count{source_cluster=~\"$cluster\", platform=~\"$platform\"}[5m])) * 60",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Host Allocation Per Second By Platform",
-          "type": "timeseries"
-        },
-        {
-          "collapsed": false,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 118
-          },
-          "id": 2,
-          "panels": [],
-          "title": "Failures",
-          "type": "row"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "P22466E8E7855F1E0"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 119
-          },
-          "id": 3,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.3",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "P22466E8E7855F1E0"
-              },
-              "editorMode": "code",
-              "expr": "sum(changes(multi_platform_controller_host_allocation_failures{source_cluster=~\"$cluster\", platform=~\"$platform\"} [5m])) by (platform)",
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Total Host Allocation Failure State Changes Per Platform (5m Window)",
+          "title": "Average Host Allocations Per Minute by Platform (5m Rate)",
           "type": "timeseries"
         },
         {
@@ -1936,7 +1975,7 @@ data:
             "type": "prometheus",
             "uid": "P22466E8E7855F1E0"
           },
-          "description": "Count of all cleanup failures that occurred within the last 5 minutes",
+          "description": "number of host allocation failures that occurred in the last hour",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1995,9 +2034,9 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 119
+            "y": 117
           },
-          "id": 4,
+          "id": 3,
           "options": {
             "legend": {
               "calcs": [],
@@ -2019,21 +2058,34 @@ data:
                 "uid": "P22466E8E7855F1E0"
               },
               "editorMode": "code",
-              "expr": "sum(increase(multi_platform_controller_cleanup_failures{source_cluster=~\"$cluster\", platform=~\"$platform\"}[5m])) by (platform)",
+              "expr": "count by (platform) (\n  increase(\n    multi_platform_controller_host_allocation_failures{source_cluster=~\"$cluster\", platform=~\"$platform\"}[1h]\n  )\n  > 0\n)",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Total Controller Cleanup Per Platform (5m Window)",
+          "title": "Hosts with New Allocation Failures (Last 1h)",
           "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 125
+          },
+          "id": 39,
+          "panels": [],
+          "title": "Provisions",
+          "type": "row"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "P22466E8E7855F1E0"
           },
-          "description": "Count of all provisioning failures that occurred within the last 5 minutes",
+          "description": "count of all provisioning failures that occurred within the last 5 minutes",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2091,8 +2143,8 @@ data:
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 6,
-            "y": 127
+            "x": 0,
+            "y": 126
           },
           "id": 22,
           "options": {
@@ -2126,125 +2178,11 @@ data:
           "type": "timeseries"
         },
         {
-          "collapsed": false,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 135
-          },
-          "id": 30,
-          "panels": [],
-          "title": "Invalid Metrics",
-          "type": "row"
-        },
-        {
           "datasource": {
             "type": "prometheus",
             "uid": "P22466E8E7855F1E0"
           },
-          "description": "Always zero",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 136
-          },
-          "id": 31,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.3",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "P22466E8E7855F1E0"
-              },
-              "disableTextWrap": false,
-              "editorMode": "code",
-              "expr": "multi_platform_controller_cleanup_failures",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
-            }
-          ],
-          "title": "multi_platform_controller_cleanup_failures",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "P22466E8E7855F1E0"
-          },
-          "description": "Always zero",
+          "description": "count of all provisioning successes that occurred within the last 5 minutes",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2303,9 +2241,9 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 136
+            "y": 126
           },
-          "id": 32,
+          "id": 40,
           "options": {
             "legend": {
               "calcs": [],
@@ -2326,18 +2264,14 @@ data:
                 "type": "prometheus",
                 "uid": "P22466E8E7855F1E0"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "multi_platform_controller_provisioning_failures",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "expr": "sum(increase(multi_platform_controller_provisioning_successes{source_cluster=~\"$cluster\", platform=~\"$platform\"}[5m])) by (platform)",
               "legendFormat": "__auto",
               "range": true,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
-          "title": "multi_platform_controller_provisioning_failures",
+          "title": "Total Provisioning Successes Per Platform (5m Window)",
           "type": "timeseries"
         },
         {
@@ -2345,7 +2279,86 @@ data:
             "type": "prometheus",
             "uid": "P22466E8E7855F1E0"
           },
-          "description": "It shouldn't be minus",
+          "description": "multi-platform controller provisioning success-failure rate",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red"
+                  },
+                  {
+                    "color": "green",
+                    "value": 90
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 6,
+            "y": 134
+          },
+          "id": 41,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P22466E8E7855F1E0"
+              },
+              "editorMode": "code",
+              "expr": "(\n  sum by (platform) (\n    increase(multi_platform_controller_provisioning_successes{source_cluster=~\"$cluster\", platform=~\"$platform\"}[30m])\n  )\n/\n  (\n    sum by (platform) (\n      increase(multi_platform_controller_provisioning_successes{source_cluster=~\"$cluster\", platform=~\"$platform\"}[30m])\n    )\n    +\n    sum by (platform) (\n      increase(multi_platform_controller_provisioning_failures{source_cluster=~\"$cluster\", platform=~\"$platform\"}[30m])\n    )\n  )\n)\n* 100\n> 0",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Provisioning Successes Rate Per Platform (30m Window)",
+          "type": "gauge"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 142
+          },
+          "id": 2,
+          "panels": [],
+          "title": "Cleanup Failures",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P22466E8E7855F1E0"
+          },
+          "description": "count of all cleanup failures that occurred within an hour window by platform",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2390,10 +2403,6 @@ data:
                 "steps": [
                   {
                     "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
                   }
                 ]
               }
@@ -2401,12 +2410,12 @@ data:
             "overrides": []
           },
           "gridPos": {
-            "h": 8,
+            "h": 10,
             "w": 12,
-            "x": 6,
-            "y": 144
+            "x": 0,
+            "y": 143
           },
-          "id": 33,
+          "id": 4,
           "options": {
             "legend": {
               "calcs": [],
@@ -2427,18 +2436,107 @@ data:
                 "type": "prometheus",
                 "uid": "P22466E8E7855F1E0"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "multi_platform_controller_running_tasks",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "expr": "sum by (platform)(\n  increase(\n    multi_platform_controller_cleanup_failures{source_cluster=~\"$cluster\", platform=~\"$platform\"}[1h]\n  )\n)",
               "legendFormat": "__auto",
               "range": true,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
-          "title": "multi_platform_controller_running_tasks",
+          "title": "Total Controller Cleanup Failures Events per Platform (1h window)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P22466E8E7855F1E0"
+          },
+          "description": "the average rate of cleanup failures per minute within a 5 minutes window by platform\n",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 143
+          },
+          "id": 44,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P22466E8E7855F1E0"
+              },
+              "editorMode": "code",
+              "expr": "sum by (platform) (\n  rate(\n    multi_platform_controller_cleanup_failures{source_cluster=~\"$cluster\", platform=~\"$platform\"}[5m]\n  )\n) * 60",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Average Cleanup Failures Per Minute by Platform (5m Rate)",
           "type": "timeseries"
         }
       ],


### PR DESCRIPTION
## What

1.  Added 2 new metrics
2. Removed the invalid metrics row
3. Fixed typos
4. Added descriptions
5. Added alert list

## Why
To make the MPC dashboard clearer, more usable, and comprehensive across all existing metrics.

> [!NOTE] 
sometimes `multi_platform_controller_running_tasks` returns negative values but it's because that after pod restarts the counter values don't carry the right value of the counter, it's been handled in KFLUXINFRA-2350