### PR TITLE
chore(KFLUXINFRA-2356): Fix SOP link

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.backup_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.backup_alerts.yaml
@@ -14,7 +14,7 @@ spec:
         summary: OADP experienced backup failures for schedule {{ $labels.schedule }}
         description: OADP had {{ $value | humanize }} backup failure(s) over the last hour for schedule {{ $labels.schedule }}.
         alert_routing_key: spreandinfra
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/backup/backup-failed.md
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/disaster-recovery/cluster/oadp-alerts.md
       expr: increase(velero_backup_failure_total[1h]) > 0
       for: 5m
       labels:
@@ -25,7 +25,7 @@ spec:
         summary: OADP experienced issues with schedule backup not running {{ $labels.schedule }} in {{ $labels.source_cluster }}.
         description: OADP schedule backups not running over the last 25 hours for schedule {{ $labels.schedule }} in cluster {{ $labels.source_cluster }}.
         alert_routing_key: spreandinfra
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/backup/backup-failed.md
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/disaster-recovery/cluster/oadp-alerts.md
       expr: time() - velero_backup_last_successful_timestamp{schedule="backup-tenants"} > 3600*25
       for: 5m
       labels:
@@ -36,7 +36,7 @@ spec:
         summary: OADP experienced increase in partial failures for schedule backup {{ $labels.schedule }} in {{ $labels.source_cluster }}.
         description: OADP experienced increase in partial failures for schedule backup over the last hour for schedule {{ $labels.schedule }} in cluster {{ $labels.source_cluster }}.
         alert_routing_key: spreandinfra
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/backup/backup-failed.md
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/disaster-recovery/cluster/oadp-alerts.md
       expr: increase(velero_backup_partial_failure_total[1h]) > 0
       for: 5m
       labels:
@@ -47,7 +47,7 @@ spec:
         summary: OADP experienced long running backups for schedule {{ $labels.schedule }} in {{ $labels.source_cluster }}.
         description: OADP experienced long running backups over the last 12 hours for schedule {{ $labels.schedule }} in cluster {{ $labels.source_cluster }}.
         alert_routing_key: spreandinfra
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/backup/backup-failed.md
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/disaster-recovery/cluster/oadp-alerts.md
       expr: histogram_quantile(1.0, sum(increase(velero_backup_duration_seconds_bucket[12h])) by (le, schedule,source_cluster)) > 7200
       for: 5m
       labels:

--- a/test/promql/tests/data_plane/backup_failed_test.yaml
+++ b/test/promql/tests/data_plane/backup_failed_test.yaml
@@ -26,7 +26,7 @@ tests:
               summary: OADP experienced backup failures for schedule backup-tenants
               description: OADP had 60 backup failure(s) over the last hour for schedule backup-tenants.
               alert_routing_key: spreandinfra
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/backup/backup-failed.md
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/disaster-recovery/cluster/oadp-alerts.md
 
   - interval: 1m
     input_series:
@@ -47,7 +47,7 @@ tests:
               summary: OADP experienced issues with schedule backup not running backup-tenants in cluster01.
               description: OADP schedule backups not running over the last 25 hours for schedule backup-tenants in cluster cluster01.
               alert_routing_key: spreandinfra
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/backup/backup-failed.md
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/disaster-recovery/cluster/oadp-alerts.md
 
   - interval: 1m
     input_series:
@@ -71,7 +71,7 @@ tests:
               summary: OADP experienced increase in partial failures for schedule backup backup-tenants in cluster01.
               description: OADP experienced increase in partial failures for schedule backup over the last hour for schedule backup-tenants in cluster cluster01.
               alert_routing_key: spreandinfra
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/backup/backup-failed.md
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/disaster-recovery/cluster/oadp-alerts.md
 
   - interval: 1m
     input_series:
@@ -97,4 +97,4 @@ tests:
               summary: OADP experienced long running backups for schedule backup-tenants in cluster01.
               description: OADP experienced long running backups over the last 12 hours for schedule backup-tenants in cluster cluster01.
               alert_routing_key: spreandinfra
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/backup/backup-failed.md
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/disaster-recovery/cluster/oadp-alerts.md


### PR DESCRIPTION
SOP for failed backups were changed in KFLUXINFRA-2356. This MR fixes the runbook link accordingly

