### PR TITLE
fix(PVO11Y-5049): Fix recording of the time elapsed for accurate test duration

### DIFF
--- a/exporters/registryexporter/registryexporter.go
+++ b/exporters/registryexporter/registryexporter.go
@@ -162,8 +162,7 @@ func setImageSize(metrics *Metrics, registryType string, testType string, sizeMB
 }
 
 // recordDuration records the duration of a test operation in seconds.
-func recordDuration(metrics *Metrics, registryType string, testType string, duration time.Duration) {
-	durationSeconds := duration.Seconds()
+func recordDuration(metrics *Metrics, registryType string, testType string, durationSeconds float64) {
 	metrics.RegistryDuration.WithLabelValues(registryType, k8sNodeName, testType).Observe(durationSeconds)
 }
 
@@ -202,29 +201,34 @@ func createFileOfSize(filePath string, artifactType string) error {
 	return nil
 }
 
-func executeCmdWithRetry(args []string) (output []byte, err error) {
+func executeCmdWithRetry(args []string) (output []byte, timeElapsed float64, err error) {
 	for attempt := range maxRetries {
 		ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+		startTime := time.Now()
 
 		cmd := exec.CommandContext(ctx, "oras", args...)
 		output, err = cmd.CombinedOutput()
 		cancel()
 
 		if err == nil {
-			return output, nil
+			// Success, measure the time elapsed
+			timeElapsed = time.Since(startTime).Seconds()
+			return nil, timeElapsed, nil
 		}
 
 		if attempt+1 < maxRetries {
-			backoff_duration := time.Duration(math.Pow(2, float64(attempt))) * time.Second
+			// Failed attempt, sleep and retry
+			backoffDuration := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 
 			log.Printf("Command %s attempt %d failed: %v, output: %s", args[0], attempt+1, err, string(output))
-			log.Printf("Retrying in %v...", backoff_duration)
-			time.Sleep(backoff_duration)
+			log.Printf("Retrying in %v...", backoffDuration)
+			time.Sleep(backoffDuration)
 		} else {
-			return output, err
+			// All attempts failed, time elapsed doesn't matter as we measure only successful attempts
+			return output, 0.0, err
 		}
 	}
-	return output, err
+	return output, 0.0, err
 }
 
 func loadDockerConfig() (DockerConfig, error) {
@@ -309,7 +313,7 @@ func CreatePullTag(registryMap map[string]RegistryConfig, registryType string, s
 	if !skipCheckExisting {
 		// Check if the tag already exists in the registry
 		args = []string{"pull", registryName, "--output", pullArtifactPath}
-		if _, err := executeCmdWithRetry(args); err == nil {
+		if _, _, err := executeCmdWithRetry(args); err == nil {
 			// Check the size of the existing artifact
 			existingSizeMB, err := getFileSizeMB(pullArtifactPath)
 			if err == nil {
@@ -329,7 +333,7 @@ func CreatePullTag(registryMap map[string]RegistryConfig, registryType string, s
 	}
 
 	args = []string{"push", registryName, "--disable-path-validation", pullArtifactPath}
-	if output, err := executeCmdWithRetry(args); err != nil {
+	if output, _, err := executeCmdWithRetry(args); err != nil {
 		log.Printf("Pull tag creation failed: %v, output: %s", err, string(output))
 		return
 	}
@@ -342,8 +346,12 @@ func PullTest(metrics *Metrics, registryMap map[string]RegistryConfig, registryT
 	registryName += pullTag
 
 	args := []string{"pull", registryName, "--output", pullArtifactPath}
-	startTime := time.Now()
-	if output, err := executeCmdWithRetry(args); err != nil {
+
+	var output []byte
+	var timeElapsed float64
+	var err error
+
+	if output, timeElapsed, err = executeCmdWithRetry(args); err != nil {
 		log.Printf("Pull test failed: %v, output: %s", err, string(output))
 		// Edge case that the pullTag does not exist anymore, registry error otherwise
 		if !strings.Contains(string(output), "not found") {
@@ -353,15 +361,15 @@ func PullTest(metrics *Metrics, registryMap map[string]RegistryConfig, registryT
 		log.Printf("Pull tag %s for %s not found, creating it.", pullTag, registryType)
 		CreatePullTag(registryMap, registryType, true)
 		// Retry the pull operation after re-creating the tag
-		if output, err = executeCmdWithRetry(args); err != nil {
+		if output, timeElapsed, err = executeCmdWithRetry(args); err != nil {
 			log.Printf("Pull test failed after re-creating tag: %v, output: %s", err, string(output))
 			setErrorState(metrics, registryType, "pull", output, err.Error())
 			return
 		}
 	}
-	log.Printf("Pull test for registry type %s successful.", registryType)
+	log.Printf("Pull test for registry type %s successful. Time elapsed: %.2f seconds", registryType, timeElapsed)
 
-	recordDuration(metrics, registryType, "pull", time.Since(startTime))
+	recordDuration(metrics, registryType, "pull", timeElapsed)
 
 	if sizeMB, err := getFileSizeMB(pullArtifactPath); err == nil {
 		setImageSize(metrics, registryType, "pull", sizeMB)
@@ -389,13 +397,16 @@ func PushTest(metrics *Metrics, registryMap map[string]RegistryConfig, registryT
 	args := []string{"push", registryName, "--annotation", "quay.expires-after=30s", "--disable-path-validation"}
 	args = append(args, artifactPaths...)
 
-	startTime := time.Now()
-	if output, err := executeCmdWithRetry(args); err != nil {
+	var output []byte
+	var timeElapsed float64
+	var err error
+
+	if output, timeElapsed, err = executeCmdWithRetry(args); err != nil {
 		log.Printf("Push test failed: %v, output: %s", err, string(output))
 		setErrorState(metrics, registryType, "push", output, err.Error())
 		return
 	}
-	log.Printf("Push test for registry type %s successful.", registryType)
+	log.Printf("Push test for registry type %s successful. Time elapsed: %.2f seconds", registryType, timeElapsed)
 
 	sizeMB := 0.0
 	for _, file := range artifactPaths {
@@ -403,7 +414,7 @@ func PushTest(metrics *Metrics, registryMap map[string]RegistryConfig, registryT
 			sizeMB += fileSizeMB
 		}
 	}
-	recordDuration(metrics, registryType, "push", time.Since(startTime))
+	recordDuration(metrics, registryType, "push", timeElapsed)
 
 	setImageSize(metrics, registryType, "push", sizeMB)
 
@@ -416,7 +427,7 @@ func deleteArtifact(registryMap map[string]RegistryConfig, registryType string, 
 	registryName += tag
 
 	args := []string{"push", registryName, "--annotation", "quay.expires-after=10s", "--disable-path-validation", "/mnt/storage/pull-artifact.txt"}
-	if output, err := executeCmdWithRetry(args); err != nil {
+	if output, _, err := executeCmdWithRetry(args); err != nil {
 		log.Printf("Artifact deletion failed: %v, output: %s", err, string(output))
 		return
 	}
@@ -431,15 +442,18 @@ func MetadataTest(metrics *Metrics, registryMap map[string]RegistryConfig, regis
 
 	args := []string{"tag", sourceArtifact, strings.TrimPrefix(newTag, ":")}
 
-	startTime := time.Now()
-	if output, err := executeCmdWithRetry(args); err != nil {
+	var output []byte
+	var timeElapsed float64
+	var err error
+
+	if output, timeElapsed, err = executeCmdWithRetry(args); err != nil {
 		log.Printf("Tag creation test failed: %v, output: %s", err, string(output))
 		setErrorState(metrics, registryType, "metadata", output, err.Error())
 		return
 	}
-	log.Printf("Metadata test for registry type %s successful.", registryType)
+	log.Printf("Metadata test for registry type %s successful. Time elapsed: %.2f seconds", registryType, timeElapsed)
 
-	recordDuration(metrics, registryType, "metadata", time.Since(startTime))
+	recordDuration(metrics, registryType, "metadata", timeElapsed)
 
 	setSuccessState(metrics, registryType, "metadata")
 }
@@ -447,16 +461,20 @@ func MetadataTest(metrics *Metrics, registryMap map[string]RegistryConfig, regis
 func AuthenticationTest(metrics *Metrics, registryMap map[string]RegistryConfig, registryType string) {
 	credentials := registryMap[registryType].Credentials
 
-	startTime := time.Now()
 	args := []string{"login", registryType, "--username", credentials.Username, "--password", credentials.Password, "--registry-config", "/mnt/storage/authtest-config.json"} // new path needed not to overwrite the original config.json
-	if output, err := executeCmdWithRetry(args); err != nil {
+
+	var output []byte
+	var timeElapsed float64
+	var err error
+
+	if output, timeElapsed, err = executeCmdWithRetry(args); err != nil {
 		log.Printf("Authentication test failed: %v, output: %s", err, string(output))
 		setErrorState(metrics, registryType, "authentication", output, err.Error())
 		return
 	}
-	log.Printf("Authentication test for registry type %s successful.", registryType)
+	log.Printf("Authentication test for registry type %s successful. Time elapsed: %.2f seconds", registryType, timeElapsed)
 
-	recordDuration(metrics, registryType, "authentication", time.Since(startTime))
+	recordDuration(metrics, registryType, "authentication", timeElapsed)
 
 	setSuccessState(metrics, registryType, "authentication")
 }


### PR DESCRIPTION
### Description

There was a lot of spikes in the duration metrics that were probably caused by recording the total time spent on tests, starting from *scrape time* till success.

With this change the logic is moved to the executeCmdWithRetry function, that starts to record the time every try - recording only the _last_ successful attempt.

<!-- Please provide a description of the changes. What is being changed (and why)? -->

[PVO11Y-5049](https://issues.redhat.com/browse/PVO11Y-5049)

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [X] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [X] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [X] **Pipeline Finished Successfully**

---

### Deployment Notice

- [X] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.


[PVO11Y-5049]: https://redhat.atlassian.net/browse/PVO11Y-5049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ