### PR TITLE
fix(PVO11Y-5129): Review registry exporter alerts based on previous incidents

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
@@ -27,7 +27,27 @@ spec:
         team: o11y
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
-# Notify o11y team when there are issues with individual nodes, but cluster-level check is still passing.
+  # Alert when a specific test type (pull, push, metadata, authentication) fails across all nodes.
+  - name: registry-exporter-test-type-availability
+    interval: 1m
+    rules:
+    - alert: RegistryExporterTestTypeFailure
+      expr: |
+        max by(source_cluster, tested_registry, type) (registry_exporter_success) == 0
+      for: 15m
+      labels:
+        severity: high
+        slo: "false"
+        component: registry-exporter
+      annotations:
+        summary: >-
+          Test for {{ $labels.type }} failing across all nodes for {{ $labels.tested_registry }} in {{ $labels.source_cluster }}
+        description: >-
+          Tests for {{ $labels.type }} for {{ $labels.tested_registry }} in {{ $labels.source_cluster }} is failing for 15 minutes.
+        alert_routing_key: o11y
+        team: o11y
+
+  # Notify o11y team when there are issues with individual nodes, but cluster-level check is still passing.
   - name: registry-exporter-node-availability
     interval: 1m
     rules:
@@ -39,7 +59,9 @@ spec:
             konflux_up{service="registry-exporter"} == 1,
             "tested_registry", "$1", "check", "(.*)"
           )
-      for: 20m
+        unless on(source_cluster, tested_registry)
+          (max by(source_cluster, tested_registry, type) (registry_exporter_success) == 0)
+      for: 15m
       labels:
         severity: warning
         slo: "false"
@@ -49,7 +71,7 @@ spec:
           Registry exporter running tests on node {{ $labels.node }} for registry {{ $labels.tested_registry }} in cluster {{ $labels.source_cluster }} is failing.
         description: >-
           Registry exporter running tests on node {{ $labels.node }} for registry {{ $labels.tested_registry }} in cluster {{ $labels.source_cluster }} is failing.
-          At least one test type (pull, push, metadata, or authentication) has been failing for 20 minutes.
+          At least one test type (pull, push, metadata, or authentication) has been failing for 15 minutes.
           The cluster-level check for this registry is still passing, indicating this is a node-specific issue.
         alert_routing_key: o11y
         team: o11y

--- a/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
@@ -34,6 +34,11 @@ spec:
     - alert: RegistryExporterTestTypeFailure
       expr: |
         max by(source_cluster, tested_registry, type) (registry_exporter_success) == 0
+        and on(source_cluster, tested_registry)
+          label_replace(
+            konflux_up{service="registry-exporter"} == 1,
+            "tested_registry", "$1", "check", "(.*)"
+          )
       for: 15m
       labels:
         severity: high
@@ -53,14 +58,16 @@ spec:
     rules:
     - alert: RegistryExporterNodeFailure
       expr: |
-        min by(source_cluster, tested_registry, node) (registry_exporter_success) == 0
+        min by(source_cluster, tested_registry, node) (
+          registry_exporter_success
+          unless on(source_cluster, tested_registry, type)
+            (max by(source_cluster, tested_registry, type) (registry_exporter_success) == 0)
+        ) == 0
         and on(source_cluster, tested_registry)
           label_replace(
             konflux_up{service="registry-exporter"} == 1,
             "tested_registry", "$1", "check", "(.*)"
           )
-        unless on(source_cluster, tested_registry)
-          (max by(source_cluster, tested_registry, type) (registry_exporter_success) == 0)
       for: 15m
       labels:
         severity: warning

--- a/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
+++ b/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
@@ -140,25 +140,211 @@ tests:
               team: o11y
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
+  # Registry exporter test-type failure tests
+  # Single test type failing on all nodes (should alert for that type)
+  - interval: 1m
+    input_series:
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
+        values: "1x16"
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RegistryExporterTestTypeFailure
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              tested_registry: quay.io
+              type: push
+              source_cluster: c1
+              slo: "false"
+              component: registry-exporter
+            exp_annotations:
+              summary: >-
+                Test for push failing across all nodes for quay.io in c1
+              description: >-
+                Tests for push for quay.io in c1 is failing for 15 minutes.
+              alert_routing_key: o11y
+              team: o11y
+
+  # Test type failing on some nodes but passing on others (should NOT alert)
+  - interval: 1m
+    input_series:
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
+        values: "1x16"
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RegistryExporterTestTypeFailure
+        exp_alerts: []
+
+  # Test type recovers before 15 minutes (should NOT alert)
+  - interval: 1m
+    input_series:
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="metadata", source_cluster="c1"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="metadata", source_cluster="c1"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1"
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RegistryExporterTestTypeFailure
+        exp_alerts: []
+
+  # Multiple test types failing across all nodes (should alert for each type)
+  - interval: 1m
+    input_series:
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="authentication", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="authentication", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
+        values: "1x16"
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RegistryExporterTestTypeFailure
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              tested_registry: quay.io
+              type: authentication
+              source_cluster: c1
+              slo: "false"
+              component: registry-exporter
+            exp_annotations:
+              summary: >-
+                Test for authentication failing across all nodes for quay.io in c1
+              description: >-
+                Tests for authentication for quay.io in c1 is failing for 15 minutes.
+              alert_routing_key: o11y
+              team: o11y
+          - exp_labels:
+              severity: high
+              tested_registry: quay.io
+              type: push
+              source_cluster: c1
+              slo: "false"
+              component: registry-exporter
+            exp_annotations:
+              summary: >-
+                Test for push failing across all nodes for quay.io in c1
+              description: >-
+                Tests for push for quay.io in c1 is failing for 15 minutes.
+              alert_routing_key: o11y
+              team: o11y
+
+  # Test type failure isolated to one registry (should only alert for that registry)
+  - interval: 1m
+    input_series:
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="registry.example.com", node="node1", type="pull", source_cluster="c1"}'
+        values: "1x16"
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RegistryExporterTestTypeFailure
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              tested_registry: quay.io
+              type: pull
+              source_cluster: c1
+              slo: "false"
+              component: registry-exporter
+            exp_annotations:
+              summary: >-
+                Test for pull failing across all nodes for quay.io in c1
+              description: >-
+                Tests for pull for quay.io in c1 is failing for 15 minutes.
+              alert_routing_key: o11y
+              team: o11y
+
+  # Combined test: push fails cluster-wide — TestTypeFailure fires at 15m, NodeFailure suppressed at 15m
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="metadata", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="metadata", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="authentication", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="authentication", source_cluster="c1"}'
+        values: "1x16"
+
+    alert_rule_test:
+      # TestTypeFailure fires at 15m for push
+      - eval_time: 15m
+        alertname: RegistryExporterTestTypeFailure
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              tested_registry: quay.io
+              type: push
+              source_cluster: c1
+              slo: "false"
+              component: registry-exporter
+            exp_annotations:
+              summary: >-
+                Test for push failing across all nodes for quay.io in c1
+              description: >-
+                Tests for push for quay.io in c1 is failing for 15 minutes.
+              alert_routing_key: o11y
+              team: o11y
+      # NodeFailure does NOT fire at 15m — suppressed by the unless clause
+      - eval_time: 15m
+        alertname: RegistryExporterNodeFailure
+        exp_alerts: []
+
   # Registry exporter node-level alert tests
   # Node failure when cluster is up (should alert)
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "1x21"
+        values: "1x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "0x21"
+        values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
-        values: "0x21"
+        values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="metadata", source_cluster="c1"}'
-        values: "0x21"
+        values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="authentication", source_cluster="c1"}'
-        values: "0x21"
+        values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
-        values: "1x21"
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="metadata", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="authentication", source_cluster="c1"}'
+        values: "1x16"
 
     alert_rule_test:
-      - eval_time: 20m
+      - eval_time: 15m
         alertname: RegistryExporterNodeFailure
         exp_alerts:
           - exp_labels:
@@ -173,7 +359,7 @@ tests:
                 Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
               description: >-
                 Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
-                At least one test type (pull, push, metadata, or authentication) has been failing for 20 minutes.
+                At least one test type (pull, push, metadata, or authentication) has been failing for 15 minutes.
                 The cluster-level check for this registry is still passing, indicating this is a node-specific issue.
               alert_routing_key: o11y
               team: o11y
@@ -182,14 +368,14 @@ tests:
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "0x21"
+        values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "0x21"
+        values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
-        values: "0x21"
+        values: "0x16"
 
     alert_rule_test:
-      - eval_time: 20m
+      - eval_time: 15m
         alertname: RegistryExporterNodeFailure
         exp_alerts: []
 
@@ -197,16 +383,22 @@ tests:
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "1x21"
+        values: "1x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "0x21"
+        values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
-        values: "0x21"
+        values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node3", type="pull", source_cluster="c1"}'
-        values: "1x21"
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node3", type="push", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node3", type="metadata", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node3", type="authentication", source_cluster="c1"}'
+        values: "1x16"
 
     alert_rule_test:
-      - eval_time: 20m
+      - eval_time: 15m
         alertname: RegistryExporterNodeFailure
         exp_alerts:
           - exp_labels:
@@ -221,7 +413,7 @@ tests:
                 Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
               description: >-
                 Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
-                At least one test type (pull, push, metadata, or authentication) has been failing for 20 minutes.
+                At least one test type (pull, push, metadata, or authentication) has been failing for 15 minutes.
                 The cluster-level check for this registry is still passing, indicating this is a node-specific issue.
               alert_routing_key: o11y
               team: o11y
@@ -237,23 +429,46 @@ tests:
                 Registry exporter running tests on node node2 for registry quay.io in cluster c1 is failing.
               description: >-
                 Registry exporter running tests on node node2 for registry quay.io in cluster c1 is failing.
-                At least one test type (pull, push, metadata, or authentication) has been failing for 20 minutes.
+                At least one test type (pull, push, metadata, or authentication) has been failing for 15 minutes.
                 The cluster-level check for this registry is still passing, indicating this is a node-specific issue.
               alert_routing_key: o11y
               team: o11y
 
-  # Node recovers before 20 minutes (should NOT alert)
+  # Node failure suppressed when a test type fails cluster-wide (should NOT alert - covered by TestTypeFailure)
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "1x21"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1"
+        values: "1x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
-        values: "1x21"
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
+        values: "1x16"
 
     alert_rule_test:
-      - eval_time: 20m
+      - eval_time: 15m
+        alertname: RegistryExporterNodeFailure
+        exp_alerts: []
+
+  # Node recovers before 15 minutes (should NOT alert)
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
+        values: "1x16"
+
+    alert_rule_test:
+      - eval_time: 15m
         alertname: RegistryExporterNodeFailure
         exp_alerts: []
 
@@ -261,18 +476,26 @@ tests:
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "1x21"
+        values: "1x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "0x21"
+        values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
-        values: "1x21"
+        values: "1x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="metadata", source_cluster="c1"}'
-        values: "1x21"
+        values: "1x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="authentication", source_cluster="c1"}'
-        values: "1x21"
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="metadata", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="authentication", source_cluster="c1"}'
+        values: "1x16"
 
     alert_rule_test:
-      - eval_time: 20m
+      - eval_time: 15m
         alertname: RegistryExporterNodeFailure
         exp_alerts:
           - exp_labels:
@@ -287,7 +510,7 @@ tests:
                 Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
               description: >-
                 Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
-                At least one test type (pull, push, metadata, or authentication) has been failing for 20 minutes.
+                At least one test type (pull, push, metadata, or authentication) has been failing for 15 minutes.
                 The cluster-level check for this registry is still passing, indicating this is a node-specific issue.
               alert_routing_key: o11y
               team: o11y

--- a/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
+++ b/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
@@ -144,6 +144,8 @@ tests:
   # Single test type failing on all nodes (should alert for that type)
   - interval: 1m
     input_series:
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "1x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
         values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
@@ -201,6 +203,8 @@ tests:
   # Multiple test types failing across all nodes (should alert for each type)
   - interval: 1m
     input_series:
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "1x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
         values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
@@ -250,6 +254,10 @@ tests:
   # Test type failure isolated to one registry (should only alert for that registry)
   - interval: 1m
     input_series:
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'konflux_up{service="registry-exporter", check="registry.example.com", source_cluster="c1"}'
+        values: "1x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
         values: "0x16"
       - series: 'registry_exporter_success{tested_registry="registry.example.com", node="node1", type="pull", source_cluster="c1"}'
@@ -273,6 +281,25 @@ tests:
                 Tests for pull for quay.io in c1 is failing for 15 minutes.
               alert_routing_key: o11y
               team: o11y
+
+  # Test type failure suppressed when cluster check is down (should NOT alert - covered by RegistryExporterDown)
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
+        values: "0x16"
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RegistryExporterTestTypeFailure
+        exp_alerts: []
 
   # Combined test: push fails cluster-wide — TestTypeFailure fires at 15m, NodeFailure suppressed at 15m
   - interval: 1m
@@ -339,6 +366,50 @@ tests:
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
         values: "1x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="metadata", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="authentication", source_cluster="c1"}'
+        values: "1x16"
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RegistryExporterNodeFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              tested_registry: quay.io
+              node: node1
+              source_cluster: c1
+              slo: "false"
+              component: registry-exporter
+            exp_annotations:
+              summary: >-
+                Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
+              description: >-
+                Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
+                At least one test type (pull, push, metadata, or authentication) has been failing for 15 minutes.
+                The cluster-level check for this registry is still passing, indicating this is a node-specific issue.
+              alert_routing_key: o11y
+              team: o11y
+
+  # Node-specific failure alongside cluster-wide type failure (should alert for node-specific issue only)
+  # Push fails cluster-wide (covered by TestTypeFailure), pull fails only on node1 (node-specific)
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="metadata", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="metadata", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="authentication", source_cluster="c1"}'
         values: "1x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="authentication", source_cluster="c1"}'
         values: "1x16"


### PR DESCRIPTION
### Description

Based on previous incidents it was identified that per-node alerts are not enough and we need less granular one for per-test cluster wide alerts. Also the pending duration was identified to be too long and is shorten to 15 minutes only.

Jira: https://redhat.atlassian.net/browse/PVO11Y-5129


<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [X] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [X] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [X] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [X] **Pipeline Finished Successfully**

---

### Deployment Notice

- [X] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
