### PR TITLE
feat(KFLUXVNGD-747): add nginx access-log-exporter availability recording rule

### DIFF
--- a/rhobs/recording/caching_availability_recording_rules.yaml
+++ b/rhobs/recording/caching_availability_recording_rules.yaml
@@ -14,3 +14,8 @@ spec:
             min by (namespace, service) (
               squid_up{namespace="caching", service="squid"}
             )
+        - record: konflux_up
+          expr: |
+            min by (namespace, service) (
+              nginx_up{namespace="caching", service="artifact-registry-proxy"}
+            )

--- a/test/promql/tests/recording/caching_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/caching_availability_recording_rules_test.yaml
@@ -31,3 +31,31 @@ tests:
         exp_samples:
           - labels: 'konflux_up{namespace="caching", service="squid"}'
             value: 0
+
+  - interval: 1m
+    # All replicas up → konflux_up = 1
+    input_series:
+      - series: 'nginx_up{namespace="caching", service="artifact-registry-proxy", job="uwm/scrape", instance="10.0.0.1:9113", pod="nginx-0"}'
+        values: '1 1 1'
+      - series: 'nginx_up{namespace="caching", service="artifact-registry-proxy", job="uwm/scrape", instance="10.0.0.2:9113", pod="nginx-1"}'
+        values: '1 1 1'
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 2m
+        exp_samples:
+          - labels: 'konflux_up{namespace="caching", service="artifact-registry-proxy"}'
+            value: 1
+
+  - interval: 1m
+    # One replica down → konflux_up = 0 (min across targets)
+    input_series:
+      - series: 'nginx_up{namespace="caching", service="artifact-registry-proxy", job="uwm/scrape", instance="10.0.0.1:9113", pod="nginx-0"}'
+        values: '1 1 1'
+      - series: 'nginx_up{namespace="caching", service="artifact-registry-proxy", job="uwm/scrape", instance="10.0.0.2:9113", pod="nginx-1"}'
+        values: '1 0 0'
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 2m
+        exp_samples:
+          - labels: 'konflux_up{namespace="caching", service="artifact-registry-proxy"}'
+            value: 0


### PR DESCRIPTION
### Description

Add Prometheus recording rule to transform nginx_up metric from access-log-exporter to konflux_up format for SLO tracking.

The rule follows the existing caching pattern:
- Aggregates nginx_up metric by namespace and service
- Targets caching namespace with nginx service
- Uses min aggregation to report DOWN if any replica fails

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-747

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [x] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [x] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [x] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
