### PR TITLE
SPRE-4459 Update Tekton Alerts Severity (Critical+SLO)

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -62,7 +62,7 @@ spec:
         summary: "Tekton Kueue pods are repeatedly restarting"
         description: "Tekton Kueue pods have restarted {{ $value }} times in the last 5 minutes in cluster {{ $labels.source_cluster }}. This may indicate resource pressure or application issues."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsRepeatedRestarts.md
-        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        alert_routing_key: infra
         team: konflux-infra
 
     - alert: TektonKueuePodsCrashLoopBackOff

--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -25,7 +25,7 @@ spec:
         summary: "Tekton Kueue controller is down"
         description: "The Tekton Kueue controller has no available replicas in cluster {{ $labels.source_cluster }}. PipelineRuns will be created in Pending state but cannot be processed, resulting in stuck builds."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueControllerDown.md
-        alert_routing_key: infra
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
         team: konflux-infra
 
     - alert: TektonKueueWebhookDown
@@ -44,7 +44,7 @@ spec:
         summary: "Tekton Kueue webhook is down"
         description: "The Tekton Kueue webhook has no available replicas in cluster {{ $labels.source_cluster }}. PipelineRuns may not be created with Pending state and Workload resources, bypassing Kueue admission control."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueWebhookDown.md
-        alert_routing_key: infra
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
         team: konflux-infra
 
     - alert: TektonKueuePodsRepeatedRestarts
@@ -62,7 +62,7 @@ spec:
         summary: "Tekton Kueue pods are repeatedly restarting"
         description: "Tekton Kueue pods have restarted {{ $value }} times in the last 5 minutes in cluster {{ $labels.source_cluster }}. This may indicate resource pressure or application issues."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsRepeatedRestarts.md
-        alert_routing_key: infra
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
         team: konflux-infra
 
     - alert: TektonKueuePodsCrashLoopBackOff
@@ -82,7 +82,7 @@ spec:
         summary: "Tekton Kueue pod is in a crash loop"
         description: "Tekton Kueue pod has degraded into CrashLoopBackOff status in cluster {{ $labels.source_cluster }} and is not starting up."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsCrashLoopBackOff.md
-        alert_routing_key: infra
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
         team: konflux-infra
 
     - alert: KueueCELEvaluationFailures

--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -18,9 +18,9 @@ spec:
         } != 1
       for: 5m
       labels:
-        severity: high
+        severity: critical
         component: tekton-kueue
-        slo: "false"
+        slo: "true"
       annotations:
         summary: "Tekton Kueue controller is down"
         description: "The Tekton Kueue controller has no available replicas in cluster {{ $labels.source_cluster }}. PipelineRuns will be created in Pending state but cannot be processed, resulting in stuck builds."
@@ -37,9 +37,9 @@ spec:
         } != 1
       for: 5m
       labels:
-        severity: high
+        severity: critical
         component: tekton-kueue
-        slo: "false"
+        slo: "true"
       annotations:
         summary: "Tekton Kueue webhook is down"
         description: "The Tekton Kueue webhook has no available replicas in cluster {{ $labels.source_cluster }}. PipelineRuns may not be created with Pending state and Workload resources, bypassing Kueue admission control."
@@ -75,9 +75,9 @@ spec:
         ) > 0
       for: 3m
       labels:
-        severity: high
+        severity: critical
         component: tekton-kueue
-        slo: "false"
+        slo: "true"
       annotations:
         summary: "Tekton Kueue pod is in a crash loop"
         description: "Tekton Kueue pod has degraded into CrashLoopBackOff status in cluster {{ $labels.source_cluster }} and is not starting up."

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -128,9 +128,9 @@ tests:
         alertname: TektonKueueControllerDown
         exp_alerts:
           - exp_labels:
-              severity: high
+              severity: critical
               component: tekton-kueue
-              slo: "false"
+              slo: "true"
               namespace: tekton-kueue
               service: tekton-kueue-controller-manager
               check: replicas-available
@@ -154,9 +154,9 @@ tests:
         alertname: TektonKueueWebhookDown
         exp_alerts:
           - exp_labels:
-              severity: high
+              severity: critical
               component: tekton-kueue
-              slo: "false"
+              slo: "true"
               namespace: tekton-kueue
               service: tekton-kueue-webhook
               check: replicas-available
@@ -202,9 +202,9 @@ tests:
         alertname: TektonKueuePodsCrashLoopBackOff
         exp_alerts:
           - exp_labels:
-              severity: high
+              severity: critical
               component: tekton-kueue
-              slo: "false"
+              slo: "true"
               source_cluster: c1
             exp_annotations:
               summary: "Tekton Kueue pod is in a crash loop"

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -139,7 +139,7 @@ tests:
               summary: "Tekton Kueue controller is down"
               description: "The Tekton Kueue controller has no available replicas in cluster c1. PipelineRuns will be created in Pending state but cannot be processed, resulting in stuck builds."
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueControllerDown.md
-              alert_routing_key: infra
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
               team: konflux-infra
 
   # Test TektonKueueWebhookDown alert
@@ -165,7 +165,7 @@ tests:
               summary: "Tekton Kueue webhook is down"
               description: "The Tekton Kueue webhook has no available replicas in cluster c1. PipelineRuns may not be created with Pending state and Workload resources, bypassing Kueue admission control."
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueWebhookDown.md
-              alert_routing_key: infra
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
               team: konflux-infra
 
   # Test TektonKueuePodsRepeatedRestarts alert
@@ -187,7 +187,7 @@ tests:
               summary: "Tekton Kueue pods are repeatedly restarting"
               description: "Tekton Kueue pods have restarted 5 times in the last 5 minutes in cluster c1. This may indicate resource pressure or application issues."
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsRepeatedRestarts.md
-              alert_routing_key: infra
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
               team: konflux-infra
 
   # Test TektonKueuePodsCrashLoopBackOff alert
@@ -210,7 +210,7 @@ tests:
               summary: "Tekton Kueue pod is in a crash loop"
               description: "Tekton Kueue pod has degraded into CrashLoopBackOff status in cluster c1 and is not starting up."
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsCrashLoopBackOff.md
-              alert_routing_key: infra
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
               team: konflux-infra
 
   # Test positive case - no alerts should fire when everything is healthy

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -187,7 +187,7 @@ tests:
               summary: "Tekton Kueue pods are repeatedly restarting"
               description: "Tekton Kueue pods have restarted 5 times in the last 5 minutes in cluster c1. This may indicate resource pressure or application issues."
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsRepeatedRestarts.md
-              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              alert_routing_key: infra
               team: konflux-infra
 
   # Test TektonKueuePodsCrashLoopBackOff alert


### PR DESCRIPTION
### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [x] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
