### PR TITLE
fix(PVO11Y-5178): use ComponentRepoUrl for filtering kanary test data

### DIFF
--- a/exporters/kanaryexporter/kanaryexporter.go
+++ b/exporters/kanaryexporter/kanaryexporter.go
@@ -26,14 +26,11 @@ const (
 	// The interval at which metrics will be collected and exported
 	scrapeInterval = 1 * time.Minute
 	// Label filters for different test types
-	containerLabelFilter = "'nodejs-devfile-sample%%'"
-	rpmLabelFilter       = "'libecpg%%'"
+	containerLabelFilter = "'%%nodejs-devfile-sample%%'"
+	rpmLabelFilter       = "'%%libecpg%%'"
 	// Additional WHERE conditions for container test types
 	containerSingleArchAdditionalConditions = `
-			AND (label_values->>'__parameters_options_PipelineRepoTemplatingSourceDir' IS NULL 
-				OR label_values->>'__parameters_options_PipelineRepoTemplatingSourceDir' = '' 
-				OR label_values->>'__parameters_options_PipelineRepoTemplatingSourceDir' = 'nodejs-devfile-sample-test/' 
-				OR label_values->>'__parameters_options_PipelineRepoTemplatingSourceDir' = 'nodejs-devfile-sample-SingleArch/')`
+			AND label_values->>'__parameters_options_PipelineRepoTemplatingSourceDir' = 'nodejs-devfile-sample-SingleArch/'`
 	containerMultiArchAdditionalConditions = `
 			AND label_values->>'__parameters_options_PipelineRepoTemplatingSourceDir' = 'nodejs-devfile-sample-MultiArch/'`
 	// Query templates
@@ -44,7 +41,7 @@ const (
 			label_values->>'.metadata.env.MEMBER_CLUSTER' LIKE $1
 			AND horreum_testid = 372
 			-- This limits the results to e2e test results
-			AND label_values->>'.repo_type' LIKE %s
+			AND label_values->>'.parameters.options.ComponentRepoUrl' LIKE %s
 			%s;
 	`
 	delayCheckQueryTemplate = `
@@ -57,7 +54,7 @@ const (
 			label_values->>'.metadata.env.MEMBER_CLUSTER' LIKE $1
 			AND horreum_testid = 372
 			-- This limits the results to e2e test results
-			AND label_values->>'.repo_type' LIKE %s
+			AND label_values->>'.parameters.options.ComponentRepoUrl' LIKE %s
 			%s
 		ORDER BY
 			EXTRACT(epoch FROM start) DESC
@@ -72,7 +69,7 @@ const (
 			label_values->>'.metadata.env.MEMBER_CLUSTER' LIKE $1
 			AND horreum_testid = 372
 			-- This limits the results to e2e test results
-			AND label_values->>'.repo_type' LIKE %s
+			AND label_values->>'.parameters.options.ComponentRepoUrl' LIKE %s
 			%s
 		ORDER BY
 			EXTRACT(epoch FROM start) DESC


### PR DESCRIPTION
The .repo_type label in Horreum returns incorrect values (full URLs instead of repo names). Switch all SQL query templates to filter on .parameters.options.ComponentRepoUrl instead, and adjust label filter patterns to match within full URLs.

Issue: [PVO11Y-5178](https://redhat.atlassian.net/browse/PVO11Y-5178)


[PVO11Y-5178]: https://redhat.atlassian.net/browse/PVO11Y-5178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ