### PR TITLE
fix(PVO11Y-5178): Set imagePullPolicy to Always for kanary exporter container

### DIFF
--- a/config/exporters/monitoring/kanary/base/kanary-exporter-service.yaml
+++ b/config/exporters/monitoring/kanary/base/kanary-exporter-service.yaml
@@ -94,6 +94,7 @@ spec:
           runAsNonRoot: true
       - name: exporters
         image: exporter:latest
+        imagePullPolicy: Always
         args: ["kanaryexporter"]
         env:
           - name: CONNECTION_STRING


### PR DESCRIPTION
The default IfNotPresent policy was preventing updated images from being pulled, causing stale versions to run.

Issue: PVO11Y-5178