### PR TITLE
fix(SPRE-4674): Downgrade SLO for ReleaseServiceValidationDurationSeconds alert

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
@@ -35,15 +35,15 @@ spec:
         ) < 0.90
       for: 15m
       labels:
-        severity: critical
-        slo: "true"
+        severity: high
+        slo: "false"
         component: release-service
       annotations:
         summary: >-
           90% of Releases must be validated under 5 seconds
         description: >-
           Release service is failing to run the validations under 5 seconds for 90% of releases
-        alert_team_handle: <!subteam^S03SVBS426R>
+        alert_routing_key: release-service
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-validation-latency.md?ref_type=heads
         team: release
 

--- a/test/promql/tests/data_plane/release_service_test.yaml
+++ b/test/promql/tests/data_plane/release_service_test.yaml
@@ -50,8 +50,8 @@ tests:
         alertname: ReleaseServiceValidationDurationSeconds
         exp_alerts:
           - exp_labels:
-              severity: critical
-              slo: "true"
+              severity: high
+              slo: "false"
               job: "release"
               source_cluster: "cluster01"
               component: release-service
@@ -60,7 +60,7 @@ tests:
                 90% of Releases must be validated under 5 seconds
               description: >-
                 Release service is failing to run the validations under 5 seconds for 90% of releases
-              alert_team_handle: <!subteam^S03SVBS426R>
+              alert_routing_key: release-service
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/release-validation-latency.md?ref_type=heads
               team: release
 


### PR DESCRIPTION
### Description

Original ticket: https://redhat.atlassian.net/browse/SPRE-4674  
Downgrade `ReleaseServiceValidationDurationSeconds` alert from SLO to non-SLO (high severity), since this alert has been flapping for some time.  
This is part of a larger process (re ticket) to tweak the existing alert - since it is currently flapping - and eventually promote it to SLO again.  

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [x] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [x] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.