### PR TITLE
fix(KFLUXVNGD-901): Exclude clusters namespace from PodNotReady alert

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
@@ -36,7 +36,7 @@ spec:
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-crashLoopBackOff.md
     - alert: PodNotReady
       expr: |
-            kube_pod_status_phase{phase=~"Pending|Unknown|Failed", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci|mintmaker|multi-platform-.*|clusters-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"} == 1
+            kube_pod_status_phase{phase=~"Pending|Unknown|Failed", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci|mintmaker|multi-platform-.*|clusters|clusters-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"} == 1
             unless ignoring (phase) (kube_pod_status_unschedulable == 1)
       for: 30m
       labels:

--- a/test/promql/tests/data_plane/notready_pods_test.yaml
+++ b/test/promql/tests/data_plane/notready_pods_test.yaml
@@ -217,6 +217,12 @@ tests:
       - series: 'kube_pod_status_unschedulable{namespace="clusters-37fcee5b-cbe0-4732-9b0b-b6c12054510f", pod="olm-collect-profiles-29554010-p4g26", source_cluster="cluster01"}'
         values: '0x29'
 
+      # Pod is in the Failed state and scheduled, but it's in the 'clusters' namespace so it's ignored.
+      - series: 'kube_pod_status_phase{pod="create-cluster-21d2ff92-52d1-426d-8aaa-77b40aa1616d-fxb8f", namespace="clusters", phase="Failed"}'
+        values: '1x29'
+      - series: 'kube_pod_status_unschedulable{namespace="clusters", pod="create-cluster-21d2ff92-52d1-426d-8aaa-77b40aa1616d-fxb8f", source_cluster="cluster01"}'
+        values: '0x29'
+
     alert_rule_test:
       - eval_time: 30m
         alertname: PodNotReady


### PR DESCRIPTION
### Description

HyperShift cluster provisioning jobs (create-cluster-{uuid}) run in the clusters namespace. These jobs have no retry on failure (backoffLimit: 0) and no TTL, so failed pods persist indefinitely — well beyond the 30-minute PodNotReady alert threshold. Exclude the clusters namespace from the alerting rule to prevent these false alerts.

Assisted-by: Claude Opus 4.6
---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [x] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [x] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
