### PR TITLE
chore(STONEINTG-1566): add right hand y axis to latency

### DIFF
--- a/dashboards/grafana-dashboard-konflux-integration-service-slo.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-integration-service-slo.configmap.yaml
@@ -29,7 +29,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 1140623,
+      "id": 1267772,
       "links": [
         {
           "asDropdown": false,
@@ -327,7 +327,7 @@ data:
             "type": "prometheus",
             "uid": "${Datasource}"
           },
-          "description": "Measures the duration from when a build PipelineRun completes. until the corresponding Snapshot CR is marked as 'in progress'. Spikes in the red zone are > 30 sec",
+          "description": "Latency (Left Axis): P90 response time. Spikes in the red zone are > 30 sec, indicating a violation of the target service level.\n\nSaturation (Right Axis): The white dashed line indicates 80% saturation. This represents the percentage of requests hitting the maximum measurable delay (20m).\n\nNote: Use the saturation line to identify if a spike is caused by total cluster exhaustion rather than isolated service slowness.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -384,7 +384,57 @@ data:
               },
               "unit": "short"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/Saturation/"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 100
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "saturation"
+                  },
+                  {
+                    "id": "custom.thresholdsStyle",
+                    "value": {
+                      "mode": "dashed"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "transparent"
+                        },
+                        {
+                          "color": "#ffffff",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 9,
@@ -426,6 +476,21 @@ data:
               "legendFormat": "{{source_cluster}}",
               "range": true,
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "(sum by (source_cluster) (rate(integration_svc_response_seconds_bucket{le=\"+Inf\", source_cluster=~\"$cluster\"}[$__rate_interval])) - sum by (source_cluster) (rate(integration_svc_response_seconds_bucket{le=\"1200\", source_cluster=~\"$cluster\"}[$__rate_interval]))) / sum by (source_cluster) (rate(integration_svc_response_seconds_count{source_cluster=~\"$cluster\"}[$__rate_interval])) * 100",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "Saturation {{source_cluster}}",
+              "range": true,
+              "refId": "B"
             }
           ],
           "title": "#1 Latency - Percentile Service Response (in-progress change)",
@@ -1104,5 +1169,5 @@ data:
       "timezone": "browser",
       "title": "Konflux - Integration Service SLO",
       "uid": "cerzhj80cyvi8c",
-      "version": 51
+      "version": 1
     }


### PR DESCRIPTION
in service response to monitor saturation

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

Monitor flapping alerts to assist SRE with troubleshooting by highlighting saturation metrics. 

https://redhat.atlassian.net/browse/STONEINTG-1566

The new axis will not be visible until such time as the additional measurement buckets are merged in integration service repo. Screenshot of panel added below as example of intended output but only on existing buckets (~240s)



---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [x] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [x] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
