### PR TITLE
feat(KFLUXVNGD-752): Artifact registry proxy alerting rules

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.artifact_registry_proxy_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.artifact_registry_proxy_alerts.yaml
@@ -1,0 +1,142 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-artifact-registry-proxy-alerting-rules
+  labels:
+    tenant: rhtap
+
+spec:
+  groups:
+  - name: artifact_registry_proxy_availability
+    interval: 1m
+    rules:
+    - alert: NginxProxyDown
+      expr: |
+        konflux_up{namespace="caching", service="artifact-registry-proxy"} == 0
+      for: 5m
+      labels:
+        severity: critical
+        slo: "true"
+        component: artifact-registry-proxy
+      annotations:
+        summary: >-
+          Artifact Registry Nginx proxy is down
+        description: >-
+          Nginx exporter cannot scrape the artifact registry proxy successfully in namespace caching.
+          The proxy has been down for 5 minutes in cluster {{ $labels.source_cluster }}.
+        alert_team_handle: <!subteam^S07NDQV6A4D>
+        team: vanguard
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-down.md
+
+  - name: artifact_registry_proxy_performance
+    interval: 1m
+    rules:
+    # Record rule: calculate total request rate
+    - record: artifact_registry_proxy:http_requests:rate5m
+      expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="caching", service="artifact-registry-proxy"}[5m]))
+
+    # Record rule: calculate error rate (5xx responses)
+    - record: artifact_registry_proxy:http_errors:rate5m
+      expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="caching", service="artifact-registry-proxy", status=~"5.."}[5m]))
+
+    # Record rule: calculate cache HIT rate
+    - record: artifact_registry_proxy:cache_hit:rate5m
+      expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="HIT"}[5m]))
+
+    # Record rule: calculate cache MISS rate
+    - record: artifact_registry_proxy:cache_miss:rate5m
+      expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="MISS"}[5m]))
+
+    # Alert: High error rate (>5% of requests are 5xx errors)
+    - alert: NginxHighErrorRate
+      expr: |
+        (
+          artifact_registry_proxy:http_errors:rate5m
+          /
+          artifact_registry_proxy:http_requests:rate5m
+        ) > 0.05
+      for: 10m
+      labels:
+        severity: high
+        slo: "true"
+        component: artifact-registry-proxy
+      annotations:
+        summary: >-
+          Artifact Registry Nginx proxy has high error rate
+        description: >-
+          More than 5% of requests to the artifact registry proxy are returning 5xx errors
+          in cluster {{ $labels.source_cluster }}. Current error rate: {{ $value | humanizePercentage }}.
+        alert_team_handle: <!subteam^S07NDQV6A4D>
+        team: vanguard
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-high-error-rate.md
+
+    # Alert: Low cache hit ratio (<50% cache hits)
+    - alert: NginxLowCacheHitRatio
+      expr: |
+        (
+          artifact_registry_proxy:cache_hit:rate5m
+          /
+          (artifact_registry_proxy:cache_hit:rate5m + artifact_registry_proxy:cache_miss:rate5m)
+        ) < 0.50
+        and
+        (artifact_registry_proxy:cache_hit:rate5m + artifact_registry_proxy:cache_miss:rate5m) > 0.1
+      for: 30m
+      labels:
+        severity: warning
+        slo: "false"
+        component: artifact-registry-proxy
+      annotations:
+        summary: >-
+          Artifact Registry Nginx proxy has low cache hit ratio
+        description: >-
+          Cache hit ratio for artifact registry proxy is below 50% in cluster {{ $labels.source_cluster }}.
+          This may indicate cache configuration issues or unusual traffic patterns.
+          Current hit ratio: {{ $value | humanizePercentage }}.
+        alert_team_handle: <!subteam^S07NDQV6A4D>
+        team: vanguard
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-low-cache-hit-ratio.md
+
+    # Alert: Nginx exporter is down
+    - alert: NginxExporterDown
+      expr: |
+        up{namespace="caching", job=~".*artifact-registry-proxy.*"} == 0
+      for: 5m
+      labels:
+        severity: warning
+        slo: "false"
+        component: artifact-registry-proxy
+      annotations:
+        summary: >-
+          Nginx Prometheus exporter is down
+        description: >-
+          The nginx-prometheus-exporter for artifact registry proxy is down in cluster {{ $labels.source_cluster }}.
+          Metrics collection is not working.
+        alert_team_handle: <!subteam^S07NDQV6A4D>
+        team: vanguard
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-exporter-down.md
+
+  - name: artifact_registry_proxy_latency
+    interval: 1m
+    rules:
+    # Alert: High response time (p95 > 5 seconds)
+    - alert: NginxHighResponseTime
+      expr: |
+        histogram_quantile(0.95,
+          sum by (source_cluster, namespace, service, le) (
+            rate(http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy"}[5m])
+          )
+        ) > 5
+      for: 15m
+      labels:
+        severity: warning
+        slo: "false"
+        component: artifact-registry-proxy
+      annotations:
+        summary: >-
+          Artifact Registry Nginx proxy has high response time
+        description: >-
+          95th percentile response time for artifact registry proxy exceeds 5 seconds
+          in cluster {{ $labels.source_cluster }}. Current p95: {{ $value | humanizeDuration }}.
+        alert_team_handle: <!subteam^S07NDQV6A4D>
+        team: vanguard
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-high-latency.md

--- a/rhobs/alerting/data_plane/prometheus.artifact_registry_proxy_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.artifact_registry_proxy_alerts.yaml
@@ -22,31 +22,15 @@ spec:
         summary: >-
           Artifact Registry Nginx proxy is down
         description: >-
-          Nginx exporter cannot scrape the artifact registry proxy successfully in namespace caching.
+          Access log exporter cannot scrape the artifact registry proxy successfully in namespace caching.
           The proxy has been down for 5 minutes in cluster {{ $labels.source_cluster }}.
         alert_team_handle: <!subteam^S07NDQV6A4D>
         team: vanguard
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-down.md
 
-  - name: artifact_registry_proxy_performance
+  - name: artifact_registry_proxy_alerts
     interval: 1m
     rules:
-    # Record rule: calculate total request rate
-    - record: artifact_registry_proxy:http_requests:rate5m
-      expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="caching", service="artifact-registry-proxy"}[5m]))
-
-    # Record rule: calculate error rate (5xx responses)
-    - record: artifact_registry_proxy:http_errors:rate5m
-      expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="caching", service="artifact-registry-proxy", status=~"5.."}[5m]))
-
-    # Record rule: calculate cache HIT rate
-    - record: artifact_registry_proxy:cache_hit:rate5m
-      expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="HIT"}[5m]))
-
-    # Record rule: calculate cache MISS rate
-    - record: artifact_registry_proxy:cache_miss:rate5m
-      expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="MISS"}[5m]))
-
     # Alert: High error rate (>5% of requests are 5xx errors)
     - alert: NginxHighErrorRate
       expr: |
@@ -58,7 +42,7 @@ spec:
       for: 10m
       labels:
         severity: high
-        slo: "true"
+        slo: "false"
         component: artifact-registry-proxy
       annotations:
         summary: >-
@@ -69,74 +53,3 @@ spec:
         alert_team_handle: <!subteam^S07NDQV6A4D>
         team: vanguard
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-high-error-rate.md
-
-    # Alert: Low cache hit ratio (<50% cache hits)
-    - alert: NginxLowCacheHitRatio
-      expr: |
-        (
-          artifact_registry_proxy:cache_hit:rate5m
-          /
-          (artifact_registry_proxy:cache_hit:rate5m + artifact_registry_proxy:cache_miss:rate5m)
-        ) < 0.50
-        and
-        (artifact_registry_proxy:cache_hit:rate5m + artifact_registry_proxy:cache_miss:rate5m) > 0.1
-      for: 30m
-      labels:
-        severity: warning
-        slo: "false"
-        component: artifact-registry-proxy
-      annotations:
-        summary: >-
-          Artifact Registry Nginx proxy has low cache hit ratio
-        description: >-
-          Cache hit ratio for artifact registry proxy is below 50% in cluster {{ $labels.source_cluster }}.
-          This may indicate cache configuration issues or unusual traffic patterns.
-          Current hit ratio: {{ $value | humanizePercentage }}.
-        alert_team_handle: <!subteam^S07NDQV6A4D>
-        team: vanguard
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-low-cache-hit-ratio.md
-
-    # Alert: Nginx exporter is down
-    - alert: NginxExporterDown
-      expr: |
-        up{namespace="caching", job=~".*artifact-registry-proxy.*"} == 0
-      for: 5m
-      labels:
-        severity: warning
-        slo: "false"
-        component: artifact-registry-proxy
-      annotations:
-        summary: >-
-          Nginx Prometheus exporter is down
-        description: >-
-          The nginx-prometheus-exporter for artifact registry proxy is down in cluster {{ $labels.source_cluster }}.
-          Metrics collection is not working.
-        alert_team_handle: <!subteam^S07NDQV6A4D>
-        team: vanguard
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-exporter-down.md
-
-  - name: artifact_registry_proxy_latency
-    interval: 1m
-    rules:
-    # Alert: High response time (p95 > 5 seconds)
-    - alert: NginxHighResponseTime
-      expr: |
-        histogram_quantile(0.95,
-          sum by (source_cluster, namespace, service, le) (
-            rate(http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy"}[5m])
-          )
-        ) > 5
-      for: 15m
-      labels:
-        severity: warning
-        slo: "false"
-        component: artifact-registry-proxy
-      annotations:
-        summary: >-
-          Artifact Registry Nginx proxy has high response time
-        description: >-
-          95th percentile response time for artifact registry proxy exceeds 5 seconds
-          in cluster {{ $labels.source_cluster }}. Current p95: {{ $value | humanizeDuration }}.
-        alert_team_handle: <!subteam^S07NDQV6A4D>
-        team: vanguard
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-high-latency.md

--- a/rhobs/recording/caching_availability_recording_rules.yaml
+++ b/rhobs/recording/caching_availability_recording_rules.yaml
@@ -19,3 +19,13 @@ spec:
             min by (namespace, service) (
               nginx_up{namespace="caching", service="artifact-registry-proxy"}
             )
+    - name: artifact_registry_proxy_performance
+      interval: 1m
+      rules:
+        # Record rule: calculate total request rate
+        - record: artifact_registry_proxy:http_requests:rate5m
+          expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="caching", service="artifact-registry-proxy"}[5m]))
+
+        # Record rule: calculate error rate (5xx responses)
+        - record: artifact_registry_proxy:http_errors:rate5m
+          expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="caching", service="artifact-registry-proxy", status=~"5.."}[5m]))

--- a/test/promql/tests/data_plane/artifact_registry_proxy_alerts_test.yaml
+++ b/test/promql/tests/data_plane/artifact_registry_proxy_alerts_test.yaml
@@ -1,0 +1,274 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.artifact_registry_proxy_alerts.yaml
+
+tests:
+  # ========================================
+  # NginxProxyDown Alert Tests
+  # ========================================
+  - name: NginxProxyDown_Firing
+    interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01"}'
+        values: '0x10'
+
+    alert_rule_test:
+      - eval_time: 7m
+        alertname: NginxProxyDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo: "true"
+              component: artifact-registry-proxy
+              namespace: caching
+              service: artifact-registry-proxy
+              source_cluster: cluster01
+            exp_annotations:
+              summary: "Artifact Registry Nginx proxy is down"
+              description: "Nginx exporter cannot scrape the artifact registry proxy successfully in namespace caching. The proxy has been down for 5 minutes in cluster cluster01."
+              alert_team_handle: "<!subteam^S07NDQV6A4D>"
+              team: vanguard
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-down.md
+
+  - name: NginxProxyDown_NotFiring
+    interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01"}'
+        values: '1x10'
+
+    alert_rule_test:
+      - eval_time: 7m
+        alertname: NginxProxyDown
+        exp_alerts: []
+
+  - name: NginxProxyDown_RecoveredBeforeThreshold
+    interval: 1m
+    input_series:
+      # Down for 4 minutes, then recovers - should not fire (needs 5m)
+      - series: 'konflux_up{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01"}'
+        values: '0x4 1x6'
+
+    alert_rule_test:
+      - eval_time: 7m
+        alertname: NginxProxyDown
+        exp_alerts: []
+
+  # ========================================
+  # NginxHighErrorRate Alert Tests
+  # ========================================
+  - name: NginxHighErrorRate_Firing
+    interval: 1m
+    input_series:
+      # 10 errors out of 100 requests = 10% error rate (> 5% threshold)
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", status="500", source_cluster="cluster01"}'
+        values: '0+10x20'
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", status="200", source_cluster="cluster01"}'
+        values: '0+90x20'
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: NginxHighErrorRate
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              slo: "true"
+              component: artifact-registry-proxy
+              source_cluster: cluster01
+              namespace: caching
+              service: artifact-registry-proxy
+            exp_annotations:
+              summary: "Artifact Registry Nginx proxy has high error rate"
+              description: "More than 5% of requests to the artifact registry proxy are returning 5xx errors in cluster cluster01. Current error rate: 10%."
+              alert_team_handle: "<!subteam^S07NDQV6A4D>"
+              team: vanguard
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-high-error-rate.md
+
+  - name: NginxHighErrorRate_NotFiring_BelowThreshold
+    interval: 1m
+    input_series:
+      # 3 errors out of 100 requests = 3% error rate (< 5% threshold)
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", status="500", source_cluster="cluster01"}'
+        values: '0+3x20'
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", status="200", source_cluster="cluster01"}'
+        values: '0+97x20'
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: NginxHighErrorRate
+        exp_alerts: []
+
+  - name: NginxHighErrorRate_NotFiring_NoErrors
+    interval: 1m
+    input_series:
+      # No errors at all
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", status="200", source_cluster="cluster01"}'
+        values: '0+100x20'
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: NginxHighErrorRate
+        exp_alerts: []
+
+  # ========================================
+  # NginxLowCacheHitRatio Alert Tests
+  # ========================================
+  - name: NginxLowCacheHitRatio_Firing
+    interval: 1m
+    input_series:
+      # 30 HITs out of 100 total (30 HIT + 70 MISS) = 30% hit ratio (< 50% threshold)
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="HIT", source_cluster="cluster01"}'
+        values: '0+30x40'
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="MISS", source_cluster="cluster01"}'
+        values: '0+70x40'
+
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: NginxLowCacheHitRatio
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: artifact-registry-proxy
+              source_cluster: cluster01
+              namespace: caching
+              service: artifact-registry-proxy
+            exp_annotations:
+              summary: "Artifact Registry Nginx proxy has low cache hit ratio"
+              description: "Cache hit ratio for artifact registry proxy is below 50% in cluster cluster01. This may indicate cache configuration issues or unusual traffic patterns. Current hit ratio: 30%."
+              alert_team_handle: "<!subteam^S07NDQV6A4D>"
+              team: vanguard
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-low-cache-hit-ratio.md
+
+  - name: NginxLowCacheHitRatio_NotFiring_HealthyRatio
+    interval: 1m
+    input_series:
+      # 70 HITs out of 100 total = 70% hit ratio (> 50% threshold)
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="HIT", source_cluster="cluster01"}'
+        values: '0+70x40'
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="MISS", source_cluster="cluster01"}'
+        values: '0+30x40'
+
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: NginxLowCacheHitRatio
+        exp_alerts: []
+
+  - name: NginxLowCacheHitRatio_NotFiring_LowTraffic
+    interval: 1m
+    input_series:
+      # Very low traffic (below 0.1 req/s threshold) - should not fire even with 0% hit rate
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="HIT", source_cluster="cluster01"}'
+        values: '0+0x40'
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="MISS", source_cluster="cluster01"}'
+        values: '0+1x40'
+
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: NginxLowCacheHitRatio
+        exp_alerts: []
+
+  - name: NginxLowCacheHitRatio_NotFiring_RecoveredBeforeThreshold
+    interval: 1m
+    input_series:
+      # Low hit ratio for 25 minutes (< 30m threshold), then improves
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="HIT", source_cluster="cluster01"}'
+        values: '0+30x25 0+70x15'
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="MISS", source_cluster="cluster01"}'
+        values: '0+70x25 0+30x15'
+
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: NginxLowCacheHitRatio
+        exp_alerts: []
+
+  # ========================================
+  # NginxExporterDown Alert Tests
+  # ========================================
+  - name: NginxExporterDown_Firing
+    interval: 1m
+    input_series:
+      - series: 'up{namespace="caching", job="artifact-registry-proxy-exporter", source_cluster="cluster01"}'
+        values: '0x10'
+
+    alert_rule_test:
+      - eval_time: 7m
+        alertname: NginxExporterDown
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: artifact-registry-proxy
+              namespace: caching
+              job: artifact-registry-proxy-exporter
+              source_cluster: cluster01
+            exp_annotations:
+              summary: "Nginx Prometheus exporter is down"
+              description: "The nginx-prometheus-exporter for artifact registry proxy is down in cluster cluster01. Metrics collection is not working."
+              alert_team_handle: "<!subteam^S07NDQV6A4D>"
+              team: vanguard
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-exporter-down.md
+
+  - name: NginxExporterDown_NotFiring
+    interval: 1m
+    input_series:
+      - series: 'up{namespace="caching", job="artifact-registry-proxy-exporter", source_cluster="cluster01"}'
+        values: '1x10'
+
+    alert_rule_test:
+      - eval_time: 7m
+        alertname: NginxExporterDown
+        exp_alerts: []
+
+  # ========================================
+  # NginxHighResponseTime Alert Tests
+  # ========================================
+  - name: NginxHighResponseTime_Firing
+    interval: 1m
+    input_series:
+      # p95 = 6 seconds (> 5s threshold)
+      # Simulating histogram buckets where most requests are > 5s
+      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="1", source_cluster="cluster01"}'
+        values: '0+5x20'
+      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="5", source_cluster="cluster01"}'
+        values: '0+90x20'
+      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="10", source_cluster="cluster01"}'
+        values: '0+100x20'
+      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="+Inf", source_cluster="cluster01"}'
+        values: '0+100x20'
+
+    alert_rule_test:
+      - eval_time: 18m
+        alertname: NginxHighResponseTime
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: artifact-registry-proxy
+              source_cluster: cluster01
+              namespace: caching
+              service: artifact-registry-proxy
+            exp_annotations:
+              summary: "Artifact Registry Nginx proxy has high response time"
+              description: "95th percentile response time for artifact registry proxy exceeds 5 seconds in cluster cluster01. Current p95: 6s."
+              alert_team_handle: "<!subteam^S07NDQV6A4D>"
+              team: vanguard
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-high-latency.md
+
+  - name: NginxHighResponseTime_NotFiring
+    interval: 1m
+    input_series:
+      # p95 < 5s - most requests complete quickly
+      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="1", source_cluster="cluster01"}'
+        values: '0+90x20'
+      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="5", source_cluster="cluster01"}'
+        values: '0+98x20'
+      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="10", source_cluster="cluster01"}'
+        values: '0+100x20'
+      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="+Inf", source_cluster="cluster01"}'
+        values: '0+100x20'
+
+    alert_rule_test:
+      - eval_time: 18m
+        alertname: NginxHighResponseTime
+        exp_alerts: []

--- a/test/promql/tests/data_plane/artifact_registry_proxy_alerts_test.yaml
+++ b/test/promql/tests/data_plane/artifact_registry_proxy_alerts_test.yaml
@@ -26,7 +26,7 @@ tests:
               source_cluster: cluster01
             exp_annotations:
               summary: "Artifact Registry Nginx proxy is down"
-              description: "Nginx exporter cannot scrape the artifact registry proxy successfully in namespace caching. The proxy has been down for 5 minutes in cluster cluster01."
+              description: "Access log exporter cannot scrape the artifact registry proxy successfully in namespace caching. The proxy has been down for 5 minutes in cluster cluster01."
               alert_team_handle: "<!subteam^S07NDQV6A4D>"
               team: vanguard
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-down.md
@@ -65,6 +65,11 @@ tests:
         values: '0+10x20'
       - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", status="200", source_cluster="cluster01"}'
         values: '0+90x20'
+      # Simulated recording rule outputs (normally created by caching_availability_recording_rules.yaml)
+      - series: 'artifact_registry_proxy:http_requests:rate5m{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01"}'
+        values: '0 0.25 0.25 0.25 0.25 0.25 0.25+0x20'
+      - series: 'artifact_registry_proxy:http_errors:rate5m{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01"}'
+        values: '0 0.025 0.025 0.025 0.025 0.025 0.025+0x20'
 
     alert_rule_test:
       - eval_time: 15m
@@ -72,7 +77,7 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: high
-              slo: "true"
+              slo: "false"
               component: artifact-registry-proxy
               source_cluster: cluster01
               namespace: caching
@@ -92,6 +97,11 @@ tests:
         values: '0+3x20'
       - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", status="200", source_cluster="cluster01"}'
         values: '0+97x20'
+      # Simulated recording rule outputs
+      - series: 'artifact_registry_proxy:http_requests:rate5m{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01"}'
+        values: '0 0.25 0.25 0.25 0.25 0.25 0.25+0x20'
+      - series: 'artifact_registry_proxy:http_errors:rate5m{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01"}'
+        values: '0 0.0075 0.0075 0.0075 0.0075 0.0075 0.0075+0x20'
 
     alert_rule_test:
       - eval_time: 15m
@@ -104,171 +114,13 @@ tests:
       # No errors at all
       - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", status="200", source_cluster="cluster01"}'
         values: '0+100x20'
+      # Simulated recording rule outputs
+      - series: 'artifact_registry_proxy:http_requests:rate5m{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01"}'
+        values: '0 0.25 0.25 0.25 0.25 0.25 0.25+0x20'
+      - series: 'artifact_registry_proxy:http_errors:rate5m{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01"}'
+        values: '0+0x20'
 
     alert_rule_test:
       - eval_time: 15m
         alertname: NginxHighErrorRate
-        exp_alerts: []
-
-  # ========================================
-  # NginxLowCacheHitRatio Alert Tests
-  # ========================================
-  - name: NginxLowCacheHitRatio_Firing
-    interval: 1m
-    input_series:
-      # 30 HITs out of 100 total (30 HIT + 70 MISS) = 30% hit ratio (< 50% threshold)
-      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="HIT", source_cluster="cluster01"}'
-        values: '0+30x40'
-      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="MISS", source_cluster="cluster01"}'
-        values: '0+70x40'
-
-    alert_rule_test:
-      - eval_time: 35m
-        alertname: NginxLowCacheHitRatio
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              slo: "false"
-              component: artifact-registry-proxy
-              source_cluster: cluster01
-              namespace: caching
-              service: artifact-registry-proxy
-            exp_annotations:
-              summary: "Artifact Registry Nginx proxy has low cache hit ratio"
-              description: "Cache hit ratio for artifact registry proxy is below 50% in cluster cluster01. This may indicate cache configuration issues or unusual traffic patterns. Current hit ratio: 30%."
-              alert_team_handle: "<!subteam^S07NDQV6A4D>"
-              team: vanguard
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-low-cache-hit-ratio.md
-
-  - name: NginxLowCacheHitRatio_NotFiring_HealthyRatio
-    interval: 1m
-    input_series:
-      # 70 HITs out of 100 total = 70% hit ratio (> 50% threshold)
-      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="HIT", source_cluster="cluster01"}'
-        values: '0+70x40'
-      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="MISS", source_cluster="cluster01"}'
-        values: '0+30x40'
-
-    alert_rule_test:
-      - eval_time: 35m
-        alertname: NginxLowCacheHitRatio
-        exp_alerts: []
-
-  - name: NginxLowCacheHitRatio_NotFiring_LowTraffic
-    interval: 1m
-    input_series:
-      # Very low traffic (below 0.1 req/s threshold) - should not fire even with 0% hit rate
-      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="HIT", source_cluster="cluster01"}'
-        values: '0+0x40'
-      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="MISS", source_cluster="cluster01"}'
-        values: '0+1x40'
-
-    alert_rule_test:
-      - eval_time: 35m
-        alertname: NginxLowCacheHitRatio
-        exp_alerts: []
-
-  - name: NginxLowCacheHitRatio_NotFiring_RecoveredBeforeThreshold
-    interval: 1m
-    input_series:
-      # Low hit ratio for 25 minutes (< 30m threshold), then improves
-      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="HIT", source_cluster="cluster01"}'
-        values: '0+30x25 0+70x15'
-      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", cache_status="MISS", source_cluster="cluster01"}'
-        values: '0+70x25 0+30x15'
-
-    alert_rule_test:
-      - eval_time: 35m
-        alertname: NginxLowCacheHitRatio
-        exp_alerts: []
-
-  # ========================================
-  # NginxExporterDown Alert Tests
-  # ========================================
-  - name: NginxExporterDown_Firing
-    interval: 1m
-    input_series:
-      - series: 'up{namespace="caching", job="artifact-registry-proxy-exporter", source_cluster="cluster01"}'
-        values: '0x10'
-
-    alert_rule_test:
-      - eval_time: 7m
-        alertname: NginxExporterDown
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              slo: "false"
-              component: artifact-registry-proxy
-              namespace: caching
-              job: artifact-registry-proxy-exporter
-              source_cluster: cluster01
-            exp_annotations:
-              summary: "Nginx Prometheus exporter is down"
-              description: "The nginx-prometheus-exporter for artifact registry proxy is down in cluster cluster01. Metrics collection is not working."
-              alert_team_handle: "<!subteam^S07NDQV6A4D>"
-              team: vanguard
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-exporter-down.md
-
-  - name: NginxExporterDown_NotFiring
-    interval: 1m
-    input_series:
-      - series: 'up{namespace="caching", job="artifact-registry-proxy-exporter", source_cluster="cluster01"}'
-        values: '1x10'
-
-    alert_rule_test:
-      - eval_time: 7m
-        alertname: NginxExporterDown
-        exp_alerts: []
-
-  # ========================================
-  # NginxHighResponseTime Alert Tests
-  # ========================================
-  - name: NginxHighResponseTime_Firing
-    interval: 1m
-    input_series:
-      # p95 = 6 seconds (> 5s threshold)
-      # Simulating histogram buckets where most requests are > 5s
-      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="1", source_cluster="cluster01"}'
-        values: '0+5x20'
-      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="5", source_cluster="cluster01"}'
-        values: '0+90x20'
-      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="10", source_cluster="cluster01"}'
-        values: '0+100x20'
-      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="+Inf", source_cluster="cluster01"}'
-        values: '0+100x20'
-
-    alert_rule_test:
-      - eval_time: 18m
-        alertname: NginxHighResponseTime
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              slo: "false"
-              component: artifact-registry-proxy
-              source_cluster: cluster01
-              namespace: caching
-              service: artifact-registry-proxy
-            exp_annotations:
-              summary: "Artifact Registry Nginx proxy has high response time"
-              description: "95th percentile response time for artifact registry proxy exceeds 5 seconds in cluster cluster01. Current p95: 6s."
-              alert_team_handle: "<!subteam^S07NDQV6A4D>"
-              team: vanguard
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-high-latency.md
-
-  - name: NginxHighResponseTime_NotFiring
-    interval: 1m
-    input_series:
-      # p95 < 5s - most requests complete quickly
-      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="1", source_cluster="cluster01"}'
-        values: '0+90x20'
-      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="5", source_cluster="cluster01"}'
-        values: '0+98x20'
-      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="10", source_cluster="cluster01"}'
-        values: '0+100x20'
-      - series: 'http_request_duration_seconds_bucket{namespace="caching", service="artifact-registry-proxy", le="+Inf", source_cluster="cluster01"}'
-        values: '0+100x20'
-
-    alert_rule_test:
-      - eval_time: 18m
-        alertname: NginxHighResponseTime
         exp_alerts: []

--- a/test/promql/tests/recording/caching_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/caching_availability_recording_rules_test.yaml
@@ -59,3 +59,31 @@ tests:
         exp_samples:
           - labels: 'konflux_up{namespace="caching", service="artifact-registry-proxy"}'
             value: 0
+
+  - interval: 1m
+    # Test artifact_registry_proxy:http_requests:rate5m recording rule
+    input_series:
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01", status="200"}'
+        values: '0+10x10'
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01", status="500"}'
+        values: '0+5x10'
+    promql_expr_test:
+      - expr: artifact_registry_proxy:http_requests:rate5m
+        eval_time: 6m
+        exp_samples:
+          - labels: 'artifact_registry_proxy:http_requests:rate5m{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01"}'
+            value: 0.25
+
+  - interval: 1m
+    # Test artifact_registry_proxy:http_errors:rate5m recording rule
+    input_series:
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01", status="200"}'
+        values: '0+10x10'
+      - series: 'http_requests_total{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01", status="500"}'
+        values: '0+5x10'
+    promql_expr_test:
+      - expr: artifact_registry_proxy:http_errors:rate5m
+        eval_time: 6m
+        exp_samples:
+          - labels: 'artifact_registry_proxy:http_errors:rate5m{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01"}'
+            value: 0.08333333333333334


### PR DESCRIPTION
### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

Add essential SLO monitoring for artifact-registry-proxy service:
- NginxProxyDown: critical availability monitoring
- NginxHighErrorRate: high error rate detection (>5% threshold)

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-752
Co-Authored-By: Claude Sonnet 4.5

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [x] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [x] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
