### PR TITLE
chore(STONEINTG-1566): amend alert times to reduce flapping SLO

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.integration_service_build_pipeline_to_snapshot_in_progress_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.integration_service_build_pipeline_to_snapshot_in_progress_alerts.yaml
@@ -18,8 +18,8 @@ spec:
           increase(integration_svc_response_seconds_bucket{le="30"}[5m])
          ) / ignoring(le)
          increase(integration_svc_response_seconds_bucket{le="+Inf"}[5m])
-        ) > 0.10
-      for: 20m
+        ) > 0.25
+      for: 30m
       labels:
         severity: critical
         slo: "true"
@@ -28,7 +28,7 @@ spec:
         summary: >-
           PipelineRunFinish to SnapshotInProgress time exceeded
         description: >
-          Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 20 minutes on cluster {{ $labels.source_cluster }}
+          Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 25% of requests during the last 30 minutes on cluster {{ $labels.source_cluster }}
         alert_team_handle: <!subteam^S05M4AG8CJH>
         team: integration
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md

--- a/test/promql/tests/data_plane/integration_service_build_pipeline_to_snapshot_in_progress_test.yaml
+++ b/test/promql/tests/data_plane/integration_service_build_pipeline_to_snapshot_in_progress_test.yaml
@@ -5,21 +5,21 @@ rule_files:
 
 tests:
 
-# Scenario where one cluster crosses the 10% threshold and another does not
+# Scenario where one cluster crosses the 25% threshold and another does not
 - interval: 1m
   input_series:
     # Simulating data from Cluster 1
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service",  source_cluster="cluster01"}'
-      values: '0+10x25'  # 10 requests took less than 30s
+      values: '0+70x40'
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster01"}'
-      values: '0+100x25'  # 100 total occurrences in cluster1
+      values: '0+100x40'
     # Simulating data from Cluster 2
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+95x25'  # 95 requests took less than 30s
+      values: '0+95x40'
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+100x25'  # 100 total occurrences in cluster2
+      values: '0+100x40'
   alert_rule_test:
-    - eval_time: 25m
+    - eval_time: 35m
       alertname: PipelineRunToSnapshotExceeded
       exp_alerts:
         - exp_labels:
@@ -31,26 +31,26 @@ tests:
           exp_annotations:
             summary: PipelineRunFinish to SnapshotInProgress time exceeded
             description: >
-              Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 20 minutes on cluster cluster01
+              Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 25% of requests during the last 30 minutes on cluster cluster01
             alert_team_handle: <!subteam^S05M4AG8CJH>
             team: integration
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
 
-# Scenario where both clusters cross the 10% threshold, alert should trigger for both
+# Scenario where both clusters cross the 25% threshold
 - interval: 1m
   input_series:
-    # Simulating data from Cluster 01
+    # Cluster 01: 70 fast, 100 total = 30% failure (Alerts!)
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster01"}'
-      values: '0+10x25'  # 10 requests took less than 30s
+      values: '0+70x40'
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster01"}'
-      values: '0+100x25'  # 100 total occurrences in cluster1
-    # Simulating data from Cluster 2
+      values: '0+100x40'
+    # Cluster 02: 10 fast, 100 total = 90% failure (Alerts!)
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+10x25'  # 10 requests took less than 30s
+      values: '0+10x40'
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+100x25'  # 100 total occurrences in cluster2
+      values: '0+100x40'
   alert_rule_test:
-    - eval_time: 25m
+    - eval_time: 35m
       alertname: PipelineRunToSnapshotExceeded
       exp_alerts:
         - exp_labels:
@@ -62,7 +62,7 @@ tests:
           exp_annotations:
             summary: PipelineRunFinish to SnapshotInProgress time exceeded
             description: >
-              Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 20 minutes on cluster cluster01
+              Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 25% of requests during the last 30 minutes on cluster cluster01
             alert_team_handle: <!subteam^S05M4AG8CJH>
             team: integration
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
@@ -75,26 +75,26 @@ tests:
           exp_annotations:
             summary: PipelineRunFinish to SnapshotInProgress time exceeded
             description: >
-              Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 10% of requests during the last 20 minutes on cluster cluster02
+              Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 25% of requests during the last 30 minutes on cluster cluster02
             alert_team_handle: <!subteam^S05M4AG8CJH>
             team: integration
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
 
-# Scenario where no alert is triggered as both clusters stay below the 10% threshold
+# Scenario where no alert is triggered as both clusters stay below the 25% threshold
 - interval: 1m
   input_series:
-    # Simulating data from Cluster 1 for 9% above 30s
+    # Cluster 01: 91 fast, 100 total = 9% failure (Below 25%)
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster01"}'
-      values: '0+91x25'  # 91 requests took less than 30s
+      values: '0+91x40'
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster01"}'
-      values: '0+100x25'  # 100 total occurrences in cluster1
+      values: '0+100x40'
 
     # Simulating data from Cluster 2 for 4% above 30s, alert should not trigger
     - series: 'integration_svc_response_seconds_bucket{le="30", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+96x25'  # 96 requests took less than 30s
+      values: '0+96x40'  # 96 requests took less than 30s
     - series: 'integration_svc_response_seconds_bucket{le="+Inf", namespace="integration-service", source_cluster="cluster02"}'
-      values: '0+100x25'  # 100 total occurrences in cluster2
+      values: '0+100x40'  # 100 total occurrences in cluster2
   alert_rule_test:
-    - eval_time: 25m
+    - eval_time: 35m
       alertname: PipelineRunToSnapshotExceeded
       exp_alerts: []  # No alerts are expected in this scenario


### PR DESCRIPTION
### Description

Extending the alert and alert test times for flapping SLO
Percentile service response (in progress change) measures
the duration from when a build PipelineRun completes until the corresponding 
Snapshot CR is marked as 'in progress'.
Additional info will gathered to try address the reason for
flapping as flapping is mostly limited to 3 specific clusters.
Steps approved by SRE. 

https://redhat.atlassian.net/browse/STONEINTG-1566

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
