### PR TITLE
KFLUXINFRA-3503 Add staging alerts for stuck PipelineRuns with finalizers

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pipelinerun_stuck_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipelinerun_stuck_alerts.yaml
@@ -1,0 +1,111 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-pipelinerun-stuck-alerts
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: pipelinerun.stuck
+    interval: 1m
+    rules:
+
+    - alert: PipelineRunStuckWithChainsFinalizer
+      expr: |
+        kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
+          finalizers=~".*chains.tekton.dev/pipelinerun.*",
+        } > 0
+        and
+        (time() - kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
+          finalizers=~".*chains.tekton.dev/pipelinerun.*",
+        }) > 1800
+      for: 10m
+      labels:
+        severity: warning
+        component: tekton-chains
+        slo: "false"
+      annotations:
+        summary: "PipelineRun {{ $labels.pipelinerun }} stuck with Tekton Chains finalizer in namespace {{ $labels.namespace }}"
+        description: "PipelineRun {{ $labels.pipelinerun }} (pipeline: {{ $labels.pipeline }}) in namespace {{ $labels.namespace }} has had deletionTimestamp set for more than 30 minutes and still has finalizers: {{ $labels.finalizers }}."
+        alert_routing_key: pipelines
+        team: pipelines
+
+    - alert: PipelineRunStuckWithResultsFinalizer
+      expr: |
+        kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
+          finalizers=~".*results.tekton.dev/pipelinerun.*",
+        } > 0
+        and
+        (time() - kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
+          finalizers=~".*results.tekton.dev/pipelinerun.*",
+        }) > 1800
+      for: 10m
+      labels:
+        severity: warning
+        component: tekton-results
+        slo: "false"
+      annotations:
+        summary: "PipelineRun {{ $labels.pipelinerun }} stuck with Tekton Results finalizer in namespace {{ $labels.namespace }}"
+        description: "PipelineRun {{ $labels.pipelinerun }} (pipeline: {{ $labels.pipeline }}) in namespace {{ $labels.namespace }} has had deletionTimestamp set for more than 30 minutes and still has finalizers: {{ $labels.finalizers }}."
+        alert_routing_key: pipelines
+        team: pipelines
+
+    - alert: PipelineRunStuckWithPACFinalizer
+      expr: |
+        kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
+          finalizers=~".*pipelinesascode.tekton.dev/finalizer.*",
+        } > 0
+        and
+        (time() - kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
+          finalizers=~".*pipelinesascode.tekton.dev/finalizer.*",
+        }) > 1800
+      for: 10m
+      labels:
+        severity: warning
+        component: pipelines-as-code
+        slo: "false"
+      annotations:
+        summary: "PipelineRun {{ $labels.pipelinerun }} stuck with Pipelines-as-Code finalizer in namespace {{ $labels.namespace }}"
+        description: "PipelineRun {{ $labels.pipelinerun }} (pipeline: {{ $labels.pipeline }}) in namespace {{ $labels.namespace }} has had deletionTimestamp set for more than 30 minutes and still has finalizers: {{ $labels.finalizers }}."
+        alert_routing_key: pipelines
+        team: pipelines
+
+    - alert: PipelineRunStuckWithIntegrationFinalizer
+      expr: |
+        kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
+          finalizers=~".*test.appstudio.openshift.io/pipelinerun.*",
+        } > 0
+        and
+        (time() - kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
+          finalizers=~".*test.appstudio.openshift.io/pipelinerun.*",
+        }) > 1800
+      for: 10m
+      labels:
+        severity: warning
+        component: integration-service
+        slo: "false"
+      annotations:
+        summary: "PipelineRun {{ $labels.pipelinerun }} stuck with Integration Service finalizer in namespace {{ $labels.namespace }}"
+        description: "PipelineRun {{ $labels.pipelinerun }} (pipeline: {{ $labels.pipeline }}) in namespace {{ $labels.namespace }} has had deletionTimestamp set for more than 30 minutes and still has finalizers: {{ $labels.finalizers }}."
+        alert_routing_key: integration
+        team: integration
+
+    - alert: PipelineRunStuckWithReleaseFinalizer
+      expr: |
+        kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
+          finalizers=~".*appstudio.redhat.com/release-finalizer.*",
+        } > 0
+        and
+        (time() - kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
+          finalizers=~".*appstudio.redhat.com/release-finalizer.*",
+        }) > 1800
+      for: 10m
+      labels:
+        severity: warning
+        component: release-service
+        slo: "false"
+      annotations:
+        summary: "PipelineRun {{ $labels.pipelinerun }} stuck with Release Service finalizer in namespace {{ $labels.namespace }}"
+        description: "PipelineRun {{ $labels.pipelinerun }} (pipeline: {{ $labels.pipeline }}) in namespace {{ $labels.namespace }} has had deletionTimestamp set for more than 30 minutes and still has finalizers: {{ $labels.finalizers }}."
+        alert_routing_key: release
+        team: release

--- a/test/promql/tests/data_plane/pipelinerun_stuck_test.yaml
+++ b/test/promql/tests/data_plane/pipelinerun_stuck_test.yaml
@@ -1,0 +1,203 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.pipelinerun_stuck_alerts.yaml
+
+tests:
+  # Test 1: Chains finalizer — stuck PipelineRun fires alert
+  - interval: 1m
+    input_series:
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-chains-stuck", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[chains.tekton.dev/pipelinerun]"}
+        values: '1+0x50'
+
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: PipelineRunStuckWithChainsFinalizer
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: tekton-chains
+              slo: "false"
+              pipelinerun: pr-chains-stuck
+              namespace: tenant-ns
+              pipeline: build-pipeline
+              finalizers: "[chains.tekton.dev/pipelinerun]"
+            exp_annotations:
+              summary: "PipelineRun pr-chains-stuck stuck with Tekton Chains finalizer in namespace tenant-ns"
+              description: "PipelineRun pr-chains-stuck (pipeline: build-pipeline) in namespace tenant-ns has had deletionTimestamp set for more than 30 minutes and still has finalizers: [chains.tekton.dev/pipelinerun]."
+              alert_routing_key: pipelines
+              team: pipelines
+
+  # Test 2: Chains finalizer — deleted 10 minutes ago (age positive but under 30 min), no alert
+  - interval: 1m
+    input_series:
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-chains-recent", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[chains.tekton.dev/pipelinerun]"}
+        values: '600+0x20'
+
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: PipelineRunStuckWithChainsFinalizer
+        exp_alerts: []
+
+  # Test 3: Results finalizer — stuck PipelineRun fires alert
+  - interval: 1m
+    input_series:
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-results-stuck", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[results.tekton.dev/pipelinerun]"}
+        values: '1+0x50'
+
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: PipelineRunStuckWithResultsFinalizer
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: tekton-results
+              slo: "false"
+              pipelinerun: pr-results-stuck
+              namespace: tenant-ns
+              pipeline: build-pipeline
+              finalizers: "[results.tekton.dev/pipelinerun]"
+            exp_annotations:
+              summary: "PipelineRun pr-results-stuck stuck with Tekton Results finalizer in namespace tenant-ns"
+              description: "PipelineRun pr-results-stuck (pipeline: build-pipeline) in namespace tenant-ns has had deletionTimestamp set for more than 30 minutes and still has finalizers: [results.tekton.dev/pipelinerun]."
+              alert_routing_key: pipelines
+              team: pipelines
+
+  # Test 4: PAC finalizer — stuck PipelineRun fires alert
+  - interval: 1m
+    input_series:
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-pac-stuck", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[pipelinesascode.tekton.dev/finalizer]"}
+        values: '1+0x50'
+
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: PipelineRunStuckWithPACFinalizer
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: pipelines-as-code
+              slo: "false"
+              pipelinerun: pr-pac-stuck
+              namespace: tenant-ns
+              pipeline: build-pipeline
+              finalizers: "[pipelinesascode.tekton.dev/finalizer]"
+            exp_annotations:
+              summary: "PipelineRun pr-pac-stuck stuck with Pipelines-as-Code finalizer in namespace tenant-ns"
+              description: "PipelineRun pr-pac-stuck (pipeline: build-pipeline) in namespace tenant-ns has had deletionTimestamp set for more than 30 minutes and still has finalizers: [pipelinesascode.tekton.dev/finalizer]."
+              alert_routing_key: pipelines
+              team: pipelines
+
+  # Test 5: Integration finalizer — stuck PipelineRun fires alert
+  - interval: 1m
+    input_series:
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-integration-stuck", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[test.appstudio.openshift.io/pipelinerun]"}
+        values: '1+0x50'
+
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: PipelineRunStuckWithIntegrationFinalizer
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: integration-service
+              slo: "false"
+              pipelinerun: pr-integration-stuck
+              namespace: tenant-ns
+              pipeline: build-pipeline
+              finalizers: "[test.appstudio.openshift.io/pipelinerun]"
+            exp_annotations:
+              summary: "PipelineRun pr-integration-stuck stuck with Integration Service finalizer in namespace tenant-ns"
+              description: "PipelineRun pr-integration-stuck (pipeline: build-pipeline) in namespace tenant-ns has had deletionTimestamp set for more than 30 minutes and still has finalizers: [test.appstudio.openshift.io/pipelinerun]."
+              alert_routing_key: integration
+              team: integration
+
+  # Test 6: Release finalizer — stuck PipelineRun fires alert
+  - interval: 1m
+    input_series:
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-release-stuck", namespace="tenant-ns", pipeline="fbc-release", finalizers="[appstudio.redhat.com/release-finalizer]"}
+        values: '1+0x50'
+
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: PipelineRunStuckWithReleaseFinalizer
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: release-service
+              slo: "false"
+              pipelinerun: pr-release-stuck
+              namespace: tenant-ns
+              pipeline: fbc-release
+              finalizers: "[appstudio.redhat.com/release-finalizer]"
+            exp_annotations:
+              summary: "PipelineRun pr-release-stuck stuck with Release Service finalizer in namespace tenant-ns"
+              description: "PipelineRun pr-release-stuck (pipeline: fbc-release) in namespace tenant-ns has had deletionTimestamp set for more than 30 minutes and still has finalizers: [appstudio.redhat.com/release-finalizer]."
+              alert_routing_key: release
+              team: release
+
+  # Test 7: Multiple finalizers — fires alerts for each matching finalizer
+  - interval: 1m
+    input_series:
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-multi-stuck", namespace="tenant-ns", pipeline="rh-advisories", finalizers="[appstudio.redhat.com/release-finalizer results.tekton.dev/pipelinerun chains.tekton.dev/pipelinerun]"}
+        values: '1+0x50'
+
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: PipelineRunStuckWithChainsFinalizer
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: tekton-chains
+              slo: "false"
+              pipelinerun: pr-multi-stuck
+              namespace: tenant-ns
+              pipeline: rh-advisories
+              finalizers: "[appstudio.redhat.com/release-finalizer results.tekton.dev/pipelinerun chains.tekton.dev/pipelinerun]"
+            exp_annotations:
+              summary: "PipelineRun pr-multi-stuck stuck with Tekton Chains finalizer in namespace tenant-ns"
+              description: "PipelineRun pr-multi-stuck (pipeline: rh-advisories) in namespace tenant-ns has had deletionTimestamp set for more than 30 minutes and still has finalizers: [appstudio.redhat.com/release-finalizer results.tekton.dev/pipelinerun chains.tekton.dev/pipelinerun]."
+              alert_routing_key: pipelines
+              team: pipelines
+      - eval_time: 45m
+        alertname: PipelineRunStuckWithResultsFinalizer
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: tekton-results
+              slo: "false"
+              pipelinerun: pr-multi-stuck
+              namespace: tenant-ns
+              pipeline: rh-advisories
+              finalizers: "[appstudio.redhat.com/release-finalizer results.tekton.dev/pipelinerun chains.tekton.dev/pipelinerun]"
+            exp_annotations:
+              summary: "PipelineRun pr-multi-stuck stuck with Tekton Results finalizer in namespace tenant-ns"
+              description: "PipelineRun pr-multi-stuck (pipeline: rh-advisories) in namespace tenant-ns has had deletionTimestamp set for more than 30 minutes and still has finalizers: [appstudio.redhat.com/release-finalizer results.tekton.dev/pipelinerun chains.tekton.dev/pipelinerun]."
+              alert_routing_key: pipelines
+              team: pipelines
+      - eval_time: 45m
+        alertname: PipelineRunStuckWithReleaseFinalizer
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: release-service
+              slo: "false"
+              pipelinerun: pr-multi-stuck
+              namespace: tenant-ns
+              pipeline: rh-advisories
+              finalizers: "[appstudio.redhat.com/release-finalizer results.tekton.dev/pipelinerun chains.tekton.dev/pipelinerun]"
+            exp_annotations:
+              summary: "PipelineRun pr-multi-stuck stuck with Release Service finalizer in namespace tenant-ns"
+              description: "PipelineRun pr-multi-stuck (pipeline: rh-advisories) in namespace tenant-ns has had deletionTimestamp set for more than 30 minutes and still has finalizers: [appstudio.redhat.com/release-finalizer results.tekton.dev/pipelinerun chains.tekton.dev/pipelinerun]."
+              alert_routing_key: release
+              team: release
+
+  # Test 8: deletionTimestamp is 0 (not deleted) — no alert
+  - interval: 1m
+    input_series:
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-not-deleted", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[chains.tekton.dev/pipelinerun]"}
+        values: '0+0x50'
+
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: PipelineRunStuckWithChainsFinalizer
+        exp_alerts: []


### PR DESCRIPTION
## What
KFLUXINFRA-3503 — Add 5 Prometheus alerts to detect PipelineRuns stuck with unremoved finalizers after deletion, one per finalizer type:
- `PipelineRunStuckWithChainsFinalizer` (chains.tekton.dev/pipelinerun) → pipelines team
- `PipelineRunStuckWithResultsFinalizer` (results.tekton.dev/pipelinerun) → pipelines team
- `PipelineRunStuckWithPACFinalizer` (pipelinesascode.tekton.dev/finalizer) → pipelines team
- `PipelineRunStuckWithIntegrationFinalizer` (test.appstudio.openshift.io/pipelinerun) → integration team
- `PipelineRunStuckWithReleaseFinalizer` (appstudio.redhat.com/release-finalizer) → release team

## Why
PipelineRuns get stuck when a controller fails to remove its finalizer after `deletionTimestamp` is set. Kubernetes waits forever — no timeout, no retry. We've observed 19 stuck on staging and 48 on production (as of late April 2026). Once stuck, they never recover on their own and require manual intervention.

Each alert filters by finalizer regex and routes to the owning team via `alert_routing_key`, so the right team gets notified directly.

## Validation
- All alerts pass `make selective-check-and-test` (rules check, YAML lint, pint lint, unit tests)
- Tests cover: each finalizer firing individually, multi-finalizer scenario (3 alerts fire for one PipelineRun), not-yet-stuck case (under 30min), and deletionTimestamp=0 case
- Metric validated in Grafana staging (`rhtap-observatorium-stage` datasource)
- Related infra-deployments PRs for the metric:
  - https://github.com/redhat-appstudio/infra-deployments/pull/11354
  - https://github.com/redhat-appstudio/infra-deployments/pull/11440
  - https://github.com/redhat-appstudio/infra-deployments/pull/11447
  - https://github.com/redhat-appstudio/infra-deployments/pull/11466

Query in Grafana:
<img width="1466" height="742" alt="image" src="https://github.com/user-attachments/assets/dacb7b5a-4239-4f00-8890-aaa93b3c3636" />



## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert the commit or remove the PrometheusRule file
These are new warning-severity alerts with no impact on existing rules. Staging deploys automatically from main. Production requires a manual commit hash update in app-interface.