### PR TITLE
SPRE-5195 Fix probe alert descriptions accuracy

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
@@ -41,7 +41,7 @@ spec:
           summary: >-
              Probe alert {{ $labels.instance }} in multiple clusters.
           description: >-
-             Probes are down on instance {{ $labels.instance }} for more than 80% of all clusters over the last 15 minutes.
+             Probes from more than 20% of Konflux clusters are unable to connect to {{ $labels.instance }} for the last 25 minutes.
           alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
           runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md
 

--- a/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
@@ -59,7 +59,7 @@ spec:
           summary: >-
              Quay Probe alert {{ $labels.instance }} in multiple clusters.
           description: >-
-             Quay Probes are down on instance {{ $labels.instance }} for more than 80% of all clusters over the last 15 minutes.
+             Quay probes from more than 20% of Konflux clusters are unable to connect to {{ $labels.instance }} for the last 20 minutes.
           alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG> <!subteam^S01B3J0AEEL>'
           runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md
 

--- a/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
@@ -41,7 +41,7 @@ spec:
           summary: >-
              Probe alert {{ $labels.instance }} in multiple clusters.
           description: >-
-             Probes from more than 20% of Konflux clusters are unable to connect to {{ $labels.instance }} for the last 25 minutes.
+             More than 20% of Konflux cluster probes are failing to connect to {{ $labels.instance }} for the last 25 minutes.
           alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
           runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md
 

--- a/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
@@ -23,7 +23,7 @@ spec:
           summary: >-
              Probe alert {{ $labels.job }}.
           description: >-
-             Probe is down on instance {{ $labels.instance }} for job {{ $labels.job }} and target {{ $labels.target }} on cluster {{ $labels.source_cluster }}. Probe failures represent less than 80% of total {{ $labels.instance }} probes across all monitored clusters over the last 15 minutes.
+             Probe on {{ $labels.source_cluster }} is unable to connect to {{ $labels.instance }} ({{ $labels.job }}) for the last 25 minutes. At least 80% of Konflux clusters successfully connect to {{ $labels.instance }}.
           alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
           runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md
 

--- a/test/promql/tests/data_plane/probe_test.yaml
+++ b/test/promql/tests/data_plane/probe_test.yaml
@@ -51,7 +51,7 @@ tests:
               check: probe-multicluster
               service: web-server
             exp_annotations:
-              description: 'Probes from more than 20% of Konflux clusters are unable to connect to instance01 for the last 25 minutes.'
+              description: 'More than 20% of Konflux cluster probes are failing to connect to instance01 for the last 25 minutes.'
               summary: Probe alert instance01 in multiple clusters.
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md

--- a/test/promql/tests/data_plane/probe_test.yaml
+++ b/test/promql/tests/data_plane/probe_test.yaml
@@ -31,7 +31,7 @@ tests:
               service: web-server
               slo: "true"
             exp_annotations:
-              description: 'Probe is down on instance instance01 for job web-server and target target01 on cluster cluster01. Probe failures represent less than 80% of total instance01 probes across all monitored clusters over the last 15 minutes.'
+              description: 'Probe on cluster01 is unable to connect to instance01 (web-server) for the last 25 minutes. At least 80% of Konflux clusters successfully connect to instance01.'
               summary: Probe alert web-server.
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md

--- a/test/promql/tests/data_plane/probe_test.yaml
+++ b/test/promql/tests/data_plane/probe_test.yaml
@@ -51,7 +51,7 @@ tests:
               check: probe-multicluster
               service: web-server
             exp_annotations:
-              description: 'Probes are down on instance instance01 for more than 80% of all clusters over the last 15 minutes.'
+              description: 'Probes from more than 20% of Konflux clusters are unable to connect to instance01 for the last 25 minutes.'
               summary: Probe alert instance01 in multiple clusters.
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md

--- a/test/promql/tests/data_plane/probe_test.yaml
+++ b/test/promql/tests/data_plane/probe_test.yaml
@@ -71,7 +71,7 @@ tests:
               check: probe-multicluster
               service: quay
             exp_annotations:
-              description: 'Quay Probes are down on instance instance01 for more than 80% of all clusters over the last 15 minutes.'
+              description: 'Quay probes from more than 20% of Konflux clusters are unable to connect to instance01 for the last 20 minutes.'
               summary: Quay Probe alert instance01 in multiple clusters.
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG> <!subteam^S01B3J0AEEL>'
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md


### PR DESCRIPTION
Corrected the alert description to accurately reflect the recording rule logic:
- Changed from "more than 80% of clusters" to "more than 20% of Konflux clusters" (the alert fires when less than 80% succeed, meaning more than 20% fail)
- Updated time from "15 minutes" to "25 minutes" to match the 'for: 25m' setting
- Improved clarity: "Probes from X clusters are unable to connect to instance"
- Updated test expectations to match the corrected description

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
