### PR TITLE
chore: update grafana uid for cache performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ data:
   <your-dashboard-name>.json: |-
 ```
 
-Note: The dashboard UID must always be unique in each Grafana instance. Make sure to modify it by changing a few characters or deleting the test dashboard in staging instance. If the test dashboard is kept and the uid is not updated, glitches will occur insta grafana as it will juggle between the two dashboards with identical UIDs.
+Note: The dashboard `uid` must always be unique in each Grafana instance and must be a maximum of 40 characters. Make sure to modify it by changing a few characters or deleting the test dashboard in staging instance. If the test dashboard is kept and the uid is not updated, glitches will occur in Grafana as it will juggle between the two dashboards with identical UIDs.
 
 ## Adding Metrics and Labels
 

--- a/dashboards/grafana-dashboard-artifact-registry-proxy-cache-performance.configmap.yaml
+++ b/dashboards/grafana-dashboard-artifact-registry-proxy-cache-performance.configmap.yaml
@@ -1415,6 +1415,6 @@ data:
       },
       "timezone": "",
       "title": "Artifact Registry Proxy Cache Performance",
-      "uid": "artifact-registry-proxy-cache-performance",
+      "uid": "artifact-registry-proxy-cache-perf",
       "version": 3
     }


### PR DESCRIPTION
### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

Update README and artifact regitry proxy cache performance uid since the max length should be 40 chars


### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [x] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
