### PR TITLE
Prometheus.pod alerts spre 4453 excluded appstudio-probe-monitoring-grafana-fix

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
@@ -22,7 +22,7 @@ spec:
         alert_routing_key: '{{ $labels.namespace }}'
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-unschedualablePods.md
     - alert: CrashLoopBackOff
-      expr: max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|multi-platform-.*|clusters-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"}[5m]) >= 1
+      expr: max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|multi-platform-.*|appstudio-probe-monitoring-grafana|clusters-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"}[5m]) >= 1
       for: 15m
       labels:
         severity: warning
@@ -36,7 +36,7 @@ spec:
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-crashLoopBackOff.md
     - alert: PodNotReady
       expr: |
-            kube_pod_status_phase{phase=~"Pending|Unknown|Failed", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci|mintmaker|multi-platform-.*|clusters|clusters-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"} == 1
+            kube_pod_status_phase{phase=~"Pending|Unknown|Failed", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci|mintmaker|multi-platform-.*|appstudio-probe-monitoring-grafana|clusters|clusters-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"} == 1
             unless ignoring (phase) (kube_pod_status_unschedulable == 1)
       for: 30m
       labels:


### PR DESCRIPTION
Description
Prometheus.pod alerts spre 4453 excluded appstudio-probe-monitoring-grafana
This PR addresses SPRE-4453 by introducing a targeted exclusion for the appstudio-probe-monitoring-grafana namespace within the PodNotReady alert.

https://redhat-internal.slack.com/archives/C04FDFTF8EB/p1778078672412279

As discussed with the o11y team and following the recent noise observed in the logs, the infrastructure probes running in this specific namespace were triggering unnecessary "Pod Not Ready" alerts. To maintain high-quality alerting, we've decided to silence this namespace while keeping the monitoring active for all other core appstudio- namespaces (e.g., appstudio-monitoring, appstudio-grafana) as requested by the team.

Changes:

Updated the regex in rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
to
exclude appstudio-probe-monitoring-grafana.
Pre-Submission Checklist
[x] Jira Ticket: SPRE-4453

[x] Alert Tests: Verified using make check-and-test. All tests passed.

[ X] SOP / Runbook: No changes required for existing runbooks.

[ ] Dashboards Addition: N/A

[x] Contribution Guides: Follows commit conventions.

[x] Pipeline Finished Successfully (Local check passed).