### PR TITLE
 SPRE-2041   Tenant Pod Dashboard

### DIFF
--- a/rhobs/recording/tenant_pod_oom_leading_indicators_recording_rules.yaml
+++ b/rhobs/recording/tenant_pod_oom_leading_indicators_recording_rules.yaml
@@ -1,0 +1,53 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-tenant-pod-oom-leading-indicators
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    # OOM leading indicators for Konflux user tenant namespaces (namespace =~ ".*-tenant").
+    # Uses federated kube-state-metrics series already in the OBO endpoints-params allowlist.
+    # Review cardinality before widening namespace regex.
+    - name: tenant_pod_memory_headroom
+      interval: 1m
+      rules:
+        - record: tenant:namespace:containers:memory_request_to_limit_ratio:avg
+          expr: |
+            avg by (source_cluster, namespace) (
+              kube_pod_container_resource_requests{
+                namespace=~".*-tenant",
+                resource="memory"
+              }
+              / on (namespace, pod, container, source_cluster)
+              kube_pod_container_resource_limits{
+                namespace=~".*-tenant",
+                resource="memory"
+              }
+            )
+    - name: tenant_pod_oom_risk
+      interval: 1m
+      rules:
+        - record: tenant:namespace:containers:memory_oom_risk:count
+          expr: |
+            count by (source_cluster, namespace) (
+              (
+                kube_pod_container_resource_requests{
+                  namespace=~".*-tenant",
+                  resource="memory"
+                }
+                / on (namespace, pod, container, source_cluster)
+                kube_pod_container_resource_limits{
+                  namespace=~".*-tenant",
+                  resource="memory"
+                }
+              ) > 0.8
+            )
+    - name: tenant_pod_restart_total
+      interval: 1m
+      rules:
+        - record: tenant:namespace:pod_container:restarts:sum
+          expr: |
+            sum by (source_cluster, namespace) (
+              kube_pod_container_status_restarts_total{namespace=~".*-tenant"}
+            )


### PR DESCRIPTION
### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->
Based on previous issues with pods being OMMKilled [1] it would be useful to create a dashboard (or improve existing dashboards) to assess the amount of pods with potential issues on user tenants based on CPU/Memory consumption and request/limits.

https://redhat.atlassian.net/issues?filter=-9&jql=statusCategory%20%3D%20Done%20AND%20assignee%20%3D%20currentUser()%20ORDER%20BY%20updated%20DESC&selectedIssue=SPRE-2041
---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
