### PR TITLE
SPRE-5254 Add P99 latency SLO alerts for API server with warning  and critical thresholds

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml
@@ -52,6 +52,54 @@ spec:
 #          team: konflux-infra
 #          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/apiserver_HighCPUUsage.md
 
+  - name: api_server_latency
+    interval: 1m
+    rules:
+    - alert: KonfluxAPIServerLatencyWarning
+      expr: |
+        (
+          sum by (source_cluster) (rate(apiserver_request_duration_seconds_bucket{le="1", verb!~"WATCH|LIST"}[5m]))
+          /
+          sum by (source_cluster) (rate(apiserver_request_duration_seconds_count{verb!~"WATCH|LIST"}[5m]))
+        ) < 0.99
+      for: 15m
+      labels:
+        severity: warning
+        component: api-server
+        team: konflux-infra
+      annotations:
+        summary: "API Server high latency detected in cluster {{ $labels.source_cluster }}"
+        description: "More than 1% of requests exceeded 1s for 15m. Impact: Slow CLI/UI response. Action: Check for Control Plane load or resource pressure."
+        alert_routing_key: infra
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/apiserver_HighP99Latency.md
+
+    - alert: KonfluxAPIServerLatencySLOCritical
+      expr: |
+        (
+          sum by (source_cluster) (rate(apiserver_request_duration_seconds_bucket{le="1", verb!~"WATCH|LIST"}[1h]))
+          /
+          sum by (source_cluster) (rate(apiserver_request_duration_seconds_count{verb!~"WATCH|LIST"}[1h]))
+          < 0.95
+        )
+        and
+        (
+          sum by (source_cluster) (rate(apiserver_request_duration_seconds_bucket{le="1", verb!~"WATCH|LIST"}[5m]))
+          /
+          sum by (source_cluster) (rate(apiserver_request_duration_seconds_count{verb!~"WATCH|LIST"}[5m]))
+          < 0.95
+        )
+      for: 5m
+      labels:
+        severity: critical
+        slo: "true"
+        component: api-server
+        team: konflux-infra
+      annotations:
+        summary: "API Server Latency: Critical SLO Breach ({{ $labels.source_cluster }})"
+        description: "More than 5% of requests exceeded 1s. Impact: High risk of system-wide timeouts. Action: Immediate check of Etcd health and admission webhooks."
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/apiserver_HighP99Latency.md
+
   - name: api_memory_usage
     interval: 1m
     rules:

--- a/test/promql/tests/data_plane/api_server_availability_test.yaml
+++ b/test/promql/tests/data_plane/api_server_availability_test.yaml
@@ -112,3 +112,76 @@ tests:
       - alertname: KonfluxAPIServerHighMemoryUsage
         eval_time: 10m
         exp_alerts: []
+
+  # Latency SLO Warning - 98% of requests complete within 1s, below 99% SLO
+  - name: KonfluxAPIServerLatencyWarning
+    interval: 1m
+    input_series:
+      - series: 'apiserver_request_duration_seconds_bucket{le="1", verb="GET", source_cluster="cluster01"}'
+        values: '0+98x20'
+      - series: 'apiserver_request_duration_seconds_count{verb="GET", source_cluster="cluster01"}'
+        values: '0+100x20'
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: KonfluxAPIServerLatencyWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: api-server
+              team: konflux-infra
+              source_cluster: "cluster01"
+            exp_annotations:
+              summary: "API Server high latency detected in cluster cluster01"
+              description: "More than 1% of requests exceeded 1s for 15m. Impact: Slow CLI/UI response. Action: Check for Control Plane load or resource pressure."
+              alert_routing_key: "infra"
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/apiserver_HighP99Latency.md
+
+  # Latency SLO Warning - 100% of requests complete within 1s, alert should not fire
+  - name: KonfluxAPIServerLatencyWarning not firing
+    interval: 1m
+    input_series:
+      - series: 'apiserver_request_duration_seconds_bucket{le="1", verb="GET", source_cluster="cluster01"}'
+        values: '0+100x20'
+      - series: 'apiserver_request_duration_seconds_count{verb="GET", source_cluster="cluster01"}'
+        values: '0+100x20'
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: KonfluxAPIServerLatencyWarning
+        exp_alerts: []
+
+  # Latency SLO Critical - 90% of requests complete within 1s, below 95% in both 5m and 1h windows
+  - name: KonfluxAPIServerLatencySLOCritical
+    interval: 1m
+    input_series:
+      - series: 'apiserver_request_duration_seconds_bucket{le="1", verb="GET", source_cluster="cluster01"}'
+        values: '0+90x70'
+      - series: 'apiserver_request_duration_seconds_count{verb="GET", source_cluster="cluster01"}'
+        values: '0+100x70'
+    alert_rule_test:
+      - eval_time: 66m
+        alertname: KonfluxAPIServerLatencySLOCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo: "true"
+              component: api-server
+              team: konflux-infra
+              source_cluster: "cluster01"
+            exp_annotations:
+              summary: "API Server Latency: Critical SLO Breach (cluster01)"
+              description: "More than 5% of requests exceeded 1s. Impact: High risk of system-wide timeouts. Action: Immediate check of Etcd health and admission webhooks."
+              alert_team_handle: "<!subteam^S05Q1P4Q2TG>"
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/apiserver_HighP99Latency.md
+
+  # Latency SLO Critical - 100% of requests complete within 1s, alert should not fire
+  - name: KonfluxAPIServerLatencySLOCritical not firing
+    interval: 1m
+    input_series:
+      - series: 'apiserver_request_duration_seconds_bucket{le="1", verb="GET", source_cluster="cluster01"}'
+        values: '0+100x70'
+      - series: 'apiserver_request_duration_seconds_count{verb="GET", source_cluster="cluster01"}'
+        values: '0+100x70'
+    alert_rule_test:
+      - eval_time: 66m
+        alertname: KonfluxAPIServerLatencySLOCritical
+        exp_alerts: []


### PR DESCRIPTION
…critical thresholds

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
