### PR TITLE
fix(STONEINTG-1635): change SLO from critical to high

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.integration_service_build_pipeline_to_snapshot_in_progress_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.integration_service_build_pipeline_to_snapshot_in_progress_alerts.yaml
@@ -21,14 +21,15 @@ spec:
         ) > 0.25
       for: 30m
       labels:
-        severity: critical
-        slo: "true"
+        severity: high
+        slo: "false"
         component: integration-service
       annotations:
         summary: >-
           PipelineRunFinish to SnapshotInProgress time exceeded
         description: >
           Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 25% of requests during the last 30 minutes on cluster {{ $labels.source_cluster }}
-        alert_team_handle: <!subteam^S05M4AG8CJH>
+        # alert_team_handle: <!subteam^S05M4AG8CJH>
+        alert_routing_key: <!subteam^S05M4AG8CJH>
         team: integration
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md

--- a/test/promql/tests/data_plane/integration_service_build_pipeline_to_snapshot_in_progress_test.yaml
+++ b/test/promql/tests/data_plane/integration_service_build_pipeline_to_snapshot_in_progress_test.yaml
@@ -23,8 +23,8 @@ tests:
       alertname: PipelineRunToSnapshotExceeded
       exp_alerts:
         - exp_labels:
-            severity: critical
-            slo: "true"
+            severity: high
+            slo: "false"
             component: integration-service
             namespace: integration-service
             source_cluster: cluster01
@@ -32,7 +32,8 @@ tests:
             summary: PipelineRunFinish to SnapshotInProgress time exceeded
             description: >
               Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 25% of requests during the last 30 minutes on cluster cluster01
-            alert_team_handle: <!subteam^S05M4AG8CJH>
+            # alert_team_handle: <!subteam^S05M4AG8CJH>
+            alert_routing_key: <!subteam^S05M4AG8CJH>
             team: integration
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
 
@@ -54,8 +55,8 @@ tests:
       alertname: PipelineRunToSnapshotExceeded
       exp_alerts:
         - exp_labels:
-            severity: critical
-            slo: "true"
+            severity: high
+            slo: "false"
             component: integration-service
             namespace: integration-service
             source_cluster: cluster01
@@ -63,12 +64,13 @@ tests:
             summary: PipelineRunFinish to SnapshotInProgress time exceeded
             description: >
               Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 25% of requests during the last 30 minutes on cluster cluster01
-            alert_team_handle: <!subteam^S05M4AG8CJH>
+            # alert_team_handle: <!subteam^S05M4AG8CJH>
+            alert_routing_key: <!subteam^S05M4AG8CJH>
             team: integration
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
         - exp_labels:
-            severity: critical
-            slo: "true"
+            severity: high
+            slo: "false"
             component: integration-service
             namespace: integration-service
             source_cluster: cluster02
@@ -76,7 +78,8 @@ tests:
             summary: PipelineRunFinish to SnapshotInProgress time exceeded
             description: >
               Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 25% of requests during the last 30 minutes on cluster cluster02
-            alert_team_handle: <!subteam^S05M4AG8CJH>
+            # alert_team_handle: <!subteam^S05M4AG8CJH>
+            alert_routing_key: <!subteam^S05M4AG8CJH>
             team: integration
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
 


### PR DESCRIPTION
Request from SRE in slack discussion
https://redhat-internal.slack.com/archives/C030SGP2VB9/p1777462522444589 Temp change to address possible gc connection
https://redhat.atlassian.net/browse/STONEINTG-1635

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ y] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ y] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ n/a] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ n/a] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ y] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [x] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
