### PR TITLE
Prefix SPRE-5273: update PipelineRunStuckWithIntegrationFinalizer to 60 min

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pipelinerun_stuck_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipelinerun_stuck_alerts.yaml
@@ -78,7 +78,7 @@ spec:
         and
         (time() - kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
           finalizers=~".*test.appstudio.openshift.io/pipelinerun.*",
-        }) > 1800
+        }) > 3600
       for: 10m
       labels:
         severity: warning
@@ -86,7 +86,7 @@ spec:
         slo: "false"
       annotations:
         summary: "PipelineRun {{ $labels.pipelinerun }} stuck with Integration Service finalizer in namespace {{ $labels.namespace }}"
-        description: "PipelineRun {{ $labels.pipelinerun }} (pipeline: {{ $labels.pipeline }}) in namespace {{ $labels.namespace }} has had deletionTimestamp set for more than 30 minutes and still has finalizers: {{ $labels.finalizers }}."
+        description: "PipelineRun {{ $labels.pipelinerun }} (pipeline: {{ $labels.pipeline }}) in namespace {{ $labels.namespace }} has had deletionTimestamp set for more than 60 minutes and still has finalizers: {{ $labels.finalizers }}."
         alert_routing_key: integration
         team: integration
 

--- a/test/promql/tests/data_plane/pipelinerun_stuck_test.yaml
+++ b/test/promql/tests/data_plane/pipelinerun_stuck_test.yaml
@@ -91,10 +91,10 @@ tests:
   - interval: 1m
     input_series:
       - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-integration-stuck", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[test.appstudio.openshift.io/pipelinerun]"}
-        values: '1+0x50'
+        values: '1+0x90'
 
     alert_rule_test:
-      - eval_time: 45m
+      - eval_time: 80m
         alertname: PipelineRunStuckWithIntegrationFinalizer
         exp_alerts:
           - exp_labels:
@@ -107,7 +107,7 @@ tests:
               finalizers: "[test.appstudio.openshift.io/pipelinerun]"
             exp_annotations:
               summary: "PipelineRun pr-integration-stuck stuck with Integration Service finalizer in namespace tenant-ns"
-              description: "PipelineRun pr-integration-stuck (pipeline: build-pipeline) in namespace tenant-ns has had deletionTimestamp set for more than 30 minutes and still has finalizers: [test.appstudio.openshift.io/pipelinerun]."
+              description: "PipelineRun pr-integration-stuck (pipeline: build-pipeline) in namespace tenant-ns has had deletionTimestamp set for more than 60 minutes and still has finalizers: [test.appstudio.openshift.io/pipelinerun]."
               alert_routing_key: integration
               team: integration
 


### PR DESCRIPTION
### Description
This PR tunes the `PipelineRunStuckWithIntegrationFinalizer` alert by increasing its stuck duration threshold from 30 minutes (1800s) to 60 minutes (3600s), and updates the alert description accordingly.

infra team approve:
https://redhat-internal.slack.com/archives/C030SGP2VB9/p1778710306008199


**Why:**
The SRE team has been experiencing heavy alert fatigue due to transient issues where PipelineRuns get temporarily delayed with the integration finalizer but clear out before reaching an hour. Based on recent production data and an Alert Review session, moving the threshold to 60 minutes drastically reduces noise while still catching genuinely stuck pipelines that require manual engineering intervention.

* **Jira Ticket:** SPRE-5273
* **Impact:** Reduces low-signal firing alerts in `#konflux-misc-alerts` and prevents false alarms for the integration service.



### Pre-Submission Checklist

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly. *(Note: If your repo requires updating promql tests under test/promql/tests/, remember to run them or update them if needed)*
- [x] **SOP / Runbook:** Any required SOP has been created or updated as needed. 
- [x] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the staging instance for validation purposes.
- [x] **Contribution Guides:** This submission follows the guidelines in our `CONTRIBUTING.md` and `README.md`.
- [x] **Pipeline Finished Successfully**

