### PR TITLE
chore(STONEINTG-1594): image_rbac_proxy alerts & recording

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.image_rbac_proxy_availability_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.image_rbac_proxy_availability_alerts.yaml
@@ -1,0 +1,52 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-image-rbac-proxy-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: image-rbac-proxy-availability
+    interval: 1m
+    rules:
+    - alert: ImageRbacProxyDown
+      expr: |
+        konflux_up{
+          namespace="image-rbac-proxy",
+          check="replicas-available",
+          service="image-rbac-proxy"
+        } != 1
+      for: 5m
+      labels:
+        severity: high
+        slo: "false"
+        component: image-rbac-proxy
+      annotations:
+        summary: >-
+          image-rbac-proxy is down in cluster {{ $labels.source_cluster }}
+        description: >
+          The image-rbac-proxy pod has been down for 5min in cluster {{ $labels.source_cluster }}
+        team: integration
+        alert_routing_key: <!subteam^S05M4AG8CJH>
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/image_rbac_proxy_availability.md
+
+    - alert: ImageRbacProxyDexDown
+      expr: |
+        konflux_up{
+          namespace="image-rbac-proxy",
+          check="replicas-available",
+          service="dex"
+        } != 1
+      for: 5m
+      labels:
+        severity: high
+        slo: "false"
+        component: image-rbac-proxy
+      annotations:
+        summary: >-
+          image-rbac-proxy dex is down in cluster {{ $labels.source_cluster }}
+        description: >
+          The image-rbac-proxy dex pod has been down for 5min in cluster {{ $labels.source_cluster }}
+        team: integration
+        alert_routing_key: <!subteam^S05M4AG8CJH>
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/image_rbac_proxy_availability.md

--- a/rhobs/recording/image_rbac_proxy_availability_recording_rules.yaml
+++ b/rhobs/recording/image_rbac_proxy_availability_recording_rules.yaml
@@ -1,0 +1,37 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-image-rbac-proxy-availability
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: image_rbac_proxy_availability
+      interval: 1m
+      rules:
+        - record: konflux_up
+          expr: |
+            clamp_max(
+              label_replace(
+                label_replace(
+                  floor(
+                    kube_deployment_status_replicas_available{
+                      namespace="image-rbac-proxy", deployment="image-rbac-proxy"
+                    } / kube_deployment_spec_replicas
+                  ), "check", "replicas-available", "",""
+                ), "service", "$1", "deployment","(.*)"
+              ), 1
+            )
+        - record: konflux_up
+          expr: |
+            clamp_max(
+              label_replace(
+                label_replace(
+                  floor(
+                    kube_deployment_status_replicas_available{
+                      namespace="image-rbac-proxy", deployment="dex"
+                    } / kube_deployment_spec_replicas
+                  ), "check", "replicas-available", "",""
+                ), "service", "$1", "deployment","(.*)"
+              ), 1
+            )

--- a/test/promql/tests/data_plane/image_rbac_proxy_alerts_test.yaml
+++ b/test/promql/tests/data_plane/image_rbac_proxy_alerts_test.yaml
@@ -1,0 +1,64 @@
+---
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.image_rbac_proxy_availability_alerts.yaml
+
+tests:
+# ImageRbacProxyDown - replica count = 0
+- interval: 1m
+  input_series:
+    - series: 'konflux_up{namespace="image-rbac-proxy", check="replicas-available", service="image-rbac-proxy", source_cluster="c1"}'
+      values: '0 0 0 0 0'
+    - series: 'konflux_up{namespace="image-rbac-proxy", check="replicas-available", service="image-rbac-proxy", source_cluster="c2"}'
+      values: '1 1 1 1 1'
+
+  alert_rule_test:
+    - eval_time: 5m
+      alertname: ImageRbacProxyDown
+      exp_alerts:
+        - exp_labels:
+            severity: high
+            component: image-rbac-proxy
+            check: replicas-available
+            namespace: image-rbac-proxy
+            service: image-rbac-proxy
+            slo: "false"
+            source_cluster: c1
+          exp_annotations:
+            summary: >-
+              image-rbac-proxy is down in cluster c1
+            description: >
+              The image-rbac-proxy pod has been down for 5min in cluster c1
+            team: integration
+            alert_routing_key: <!subteam^S05M4AG8CJH>
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/image_rbac_proxy_availability.md
+
+# ImageRbacProxyDexDown - replica count = 0
+- interval: 1m
+  input_series:
+    - series: 'konflux_up{namespace="image-rbac-proxy", check="replicas-available", service="dex", source_cluster="c1"}'
+      values: '0 0 0 0 0'
+    - series: 'konflux_up{namespace="image-rbac-proxy", check="replicas-available", service="dex", source_cluster="c2"}'
+      values: '1 1 1 1 1'
+
+  alert_rule_test:
+    - eval_time: 5m
+      alertname: ImageRbacProxyDexDown
+      exp_alerts:
+        - exp_labels:
+            severity: high
+            component: image-rbac-proxy
+            check: replicas-available
+            namespace: image-rbac-proxy
+            service: dex
+            slo: "false"
+            source_cluster: c1
+          exp_annotations:
+            summary: >-
+              image-rbac-proxy dex is down in cluster c1
+            description: >
+              The image-rbac-proxy dex pod has been down for 5min in cluster c1
+            team: integration
+            alert_routing_key: <!subteam^S05M4AG8CJH>
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/image_rbac_proxy_availability.md

--- a/test/promql/tests/recording/image_rbac_proxy_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/image_rbac_proxy_availability_recording_rules_test.yaml
@@ -1,0 +1,91 @@
+evaluation_interval: 1m
+
+rule_files:
+  - image_rbac_proxy_availability_recording_rules.yaml
+
+tests:
+  - name: ImageRbacProxyAvailabilityAllUpTest
+    interval: 1m
+    input_series:
+      - series: "kube_deployment_status_replicas_available{namespace='image-rbac-proxy', deployment='image-rbac-proxy'}"
+        values: "3 3 3 3 3"
+      - series: "kube_deployment_spec_replicas{namespace='image-rbac-proxy', deployment='image-rbac-proxy'}"
+        values: "3 3 3 3 3"
+      - series: "kube_deployment_status_replicas_available{namespace='image-rbac-proxy', deployment='dex'}"
+        values: "3 3 3 3 3"
+      - series: "kube_deployment_spec_replicas{namespace='image-rbac-proxy', deployment='dex'}"
+        values: "3 3 3 3 3"
+
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{service='image-rbac-proxy', check='replicas-available', namespace='image-rbac-proxy', deployment='image-rbac-proxy'}
+            value: 1
+          - labels: konflux_up{service='dex', check='replicas-available', namespace='image-rbac-proxy', deployment='dex'}
+            value: 1
+
+  - name: ImageRbacProxyAvailabilitySomeUpTest
+    interval: 1m
+    input_series:
+      - series: "kube_deployment_status_replicas_available{namespace='image-rbac-proxy', deployment='image-rbac-proxy'}"
+        values: "2 2 2 2 2"
+      - series: "kube_deployment_spec_replicas{namespace='image-rbac-proxy', deployment='image-rbac-proxy'}"
+        values: "4 4 4 4 4"
+      - series: "kube_deployment_status_replicas_available{namespace='image-rbac-proxy', deployment='dex'}"
+        values: "2 2 2 2 2"
+      - series: "kube_deployment_spec_replicas{namespace='image-rbac-proxy', deployment='dex'}"
+        values: "4 4 4 4 4"
+
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{service='image-rbac-proxy', check='replicas-available', namespace='image-rbac-proxy', deployment='image-rbac-proxy'}
+            value: 0
+          - labels: konflux_up{service='dex', check='replicas-available', namespace='image-rbac-proxy', deployment='dex'}
+            value: 0
+
+  - name: ImageRbacProxyAvailabilityMultipleDeploymentsTest
+    interval: 1m
+    input_series:
+      # should be up (c1)
+      - series: "kube_deployment_status_replicas_available{namespace='image-rbac-proxy', deployment='image-rbac-proxy', source_cluster='c1'}"
+        values: "1 1 1 1 1"
+      - series: "kube_deployment_spec_replicas{namespace='image-rbac-proxy', deployment='image-rbac-proxy', source_cluster='c1'}"
+        values: "1 1 1 1 1"
+
+      # should be down (c2)
+      - series: "kube_deployment_status_replicas_available{namespace='image-rbac-proxy', deployment='image-rbac-proxy', source_cluster='c2'}"
+        values: "0 0 0 0 0"
+      - series: "kube_deployment_spec_replicas{namespace='image-rbac-proxy', deployment='image-rbac-proxy', source_cluster='c2'}"
+        values: "1 1 1 1 1"
+
+      # should be up (dex from c1)
+      - series: "kube_deployment_status_replicas_available{namespace='image-rbac-proxy', deployment='dex', source_cluster='c1'}"
+        values: "2 2 2 2 2"
+      - series: "kube_deployment_spec_replicas{namespace='image-rbac-proxy', deployment='dex', source_cluster='c1'}"
+        values: "1 1 1 1 1"
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples:
+          - labels: konflux_up{service='image-rbac-proxy', check='replicas-available', namespace='image-rbac-proxy', deployment='image-rbac-proxy', source_cluster='c1'}
+            value: 1
+          - labels: konflux_up{service='image-rbac-proxy', check='replicas-available', namespace='image-rbac-proxy', deployment='image-rbac-proxy', source_cluster='c2'}
+            value: 0
+          - labels: konflux_up{service='dex', check='replicas-available', namespace='image-rbac-proxy', deployment='dex', source_cluster='c1'}
+            value: 1
+
+  - name: ImageRbacProxyAbsent
+    interval: 1m
+    input_series:
+      - series: "kube_deployment_status_replicas_available{namespace='another-controller', deployment='image-rbac-proxy'}"
+        values: "1 1 1 1 1"
+      - series: "kube_deployment_spec_replicas{namespace='another-controller', deployment='image-rbac-proxy'}"
+        values: "1 1 1 1 1"
+
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 5m
+        exp_samples: []


### PR DESCRIPTION
### Description

Alert & alert tests, recording rules & recording rules tests
added for image_rback_proxy_availability. 
Not an SLO but needs alerting if/when services goes down
Assigned to integration team. 
Previous PR https://github.com/redhat-appstudio/o11y/pull/1053
can now be closed. 
SOP awaiting final approval https://gitlab.cee.redhat.com/konflux/docs/sop/-/merge_requests/701
Dashboard is next step. 

https://redhat.atlassian.net/browse/STONEINTG-1594

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [x] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [x] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
