### PR TITLE
SPRE-5309: convert PipelineRunStuckWithPACFinalizer to count-based ag…

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pipelinerun_stuck_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipelinerun_stuck_alerts.yaml
@@ -52,21 +52,25 @@ spec:
 
     - alert: PipelineRunStuckWithPACFinalizer
       expr: |
-        kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
-          finalizers=~".*pipelinesascode.tekton.dev/finalizer.*",
-        } > 0
-        and
-        (time() - kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
-          finalizers=~".*pipelinesascode.tekton.dev/finalizer.*",
-        }) > 1800
-      for: 10m
+        count by (source_cluster) (
+          kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
+            finalizers=~".*pipelinesascode.tekton.dev/finalizer.*",
+          } > 0
+          and
+          (
+            time() - kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
+              finalizers=~".*pipelinesascode.tekton.dev/finalizer.*",
+            }
+          ) > 2400
+        ) > 0
+      for: 0m
       labels:
         severity: warning
         component: pipelines-as-code
         slo: "false"
       annotations:
-        summary: "PipelineRun {{ $labels.pipelinerun }} stuck with Pipelines-as-Code finalizer in namespace {{ $labels.namespace }}"
-        description: "PipelineRun {{ $labels.pipelinerun }} (pipeline: {{ $labels.pipeline }}) in namespace {{ $labels.namespace }} has had deletionTimestamp set for more than 30 minutes and still has finalizers: {{ $labels.finalizers }}."
+        summary: "{{ $value }} PipelineRun(s) on {{ $labels.source_cluster }} stuck with Pipelines-as-Code finalizer"
+        description: "{{ $value }} PipelineRun(s) on {{ $labels.source_cluster }} have had deletionTimestamp set for more than 40 minutes and still have the PAC finalizer."
         alert_routing_key: pipelines
         team: pipelines
 

--- a/test/promql/tests/data_plane/pipelinerun_stuck_test.yaml
+++ b/test/promql/tests/data_plane/pipelinerun_stuck_test.yaml
@@ -63,10 +63,10 @@ tests:
               alert_routing_key: pipelines
               team: pipelines
 
-  # Test 4: PAC finalizer — stuck PipelineRun fires alert
+  # Test 4: PAC finalizer — 1 stuck PipelineRun for >40m fires alert with count=1
   - interval: 1m
     input_series:
-      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-pac-stuck", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[pipelinesascode.tekton.dev/finalizer]"}
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-pac-stuck", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[pipelinesascode.tekton.dev/finalizer]", source_cluster="stone-prod-p02"}
         values: '1+0x50'
 
     alert_rule_test:
@@ -77,15 +77,62 @@ tests:
               severity: warning
               component: pipelines-as-code
               slo: "false"
-              pipelinerun: pr-pac-stuck
-              namespace: tenant-ns
-              pipeline: build-pipeline
-              finalizers: "[pipelinesascode.tekton.dev/finalizer]"
+              source_cluster: stone-prod-p02
             exp_annotations:
-              summary: "PipelineRun pr-pac-stuck stuck with Pipelines-as-Code finalizer in namespace tenant-ns"
-              description: "PipelineRun pr-pac-stuck (pipeline: build-pipeline) in namespace tenant-ns has had deletionTimestamp set for more than 30 minutes and still has finalizers: [pipelinesascode.tekton.dev/finalizer]."
+              summary: "1 PipelineRun(s) on stone-prod-p02 stuck with Pipelines-as-Code finalizer"
+              description: "1 PipelineRun(s) on stone-prod-p02 have had deletionTimestamp set for more than 40 minutes and still have the PAC finalizer."
               alert_routing_key: pipelines
               team: pipelines
+
+  # Test 4b: PAC finalizer — 3 stuck PipelineRuns for >40m, alert fires with count=3
+  - interval: 1m
+    input_series:
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-pac-stuck-1", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[pipelinesascode.tekton.dev/finalizer]", source_cluster="stone-prod-p02"}
+        values: '1+0x50'
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-pac-stuck-2", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[pipelinesascode.tekton.dev/finalizer]", source_cluster="stone-prod-p02"}
+        values: '1+0x50'
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-pac-stuck-3", namespace="other-ns", pipeline="build-pipeline", finalizers="[pipelinesascode.tekton.dev/finalizer]", source_cluster="stone-prod-p02"}
+        values: '1+0x50'
+
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: PipelineRunStuckWithPACFinalizer
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: pipelines-as-code
+              slo: "false"
+              source_cluster: stone-prod-p02
+            exp_annotations:
+              summary: "3 PipelineRun(s) on stone-prod-p02 stuck with Pipelines-as-Code finalizer"
+              description: "3 PipelineRun(s) on stone-prod-p02 have had deletionTimestamp set for more than 40 minutes and still have the PAC finalizer."
+              alert_routing_key: pipelines
+              team: pipelines
+
+  # Test 4c: PAC finalizer — stuck less than 40 minutes ago, no alert
+  - interval: 1m
+    input_series:
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-pac-recent", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[pipelinesascode.tekton.dev/finalizer]"}
+        values: '600+0x20'
+
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: PipelineRunStuckWithPACFinalizer
+        exp_alerts: []
+
+  # Test 4d: PAC finalizer — rotation scenario: PipelineRuns rotate under 40m threshold, no alert
+  # pr-pac-rotate-1 disappears at 30m, pr-pac-rotate-2 appears at 25m — neither was stuck >40m
+  - interval: 1m
+    input_series:
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-pac-rotate-1", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[pipelinesascode.tekton.dev/finalizer]"}
+        values: '1+0x30 stale'
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-pac-rotate-2", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[pipelinesascode.tekton.dev/finalizer]"}
+        values: '1500+0x20'
+
+    alert_rule_test:
+      - eval_time: 38m
+        alertname: PipelineRunStuckWithPACFinalizer
+        exp_alerts: []
 
   # Test 5: Integration finalizer — stuck PipelineRun fires alert
   - interval: 1m


### PR DESCRIPTION
…gregation

Replace the per-PipelineRun expression with a count() aggregation so that N stuck PipelineRuns produce a single alert with $value=N instead of N separate alerts. Update the summary and description annotations accordingly.

Add tests for single stuck run (count=1), multiple stuck runs (count=3), and a run deleted less than 30 minutes ago (no alert expected).

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
