### PR TITLE
feat(dashboards): add full Kueue dashboard configuration for SPRE-5357

### DIFF
--- a/dashboards/grafana-dashboard-konflux-kueue.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-kueue.configmap.yaml
@@ -965,6 +965,164 @@ data:
               "type": "stat"
             },
             {
+              "id": 102,
+              "type": "stat",
+              "title": "Admission Wait Time 99th Percentile By Priority Class",
+              "description": "99% of the workloads waited in the queue less time from the shown value. Broke into Priority Classes.",
+              "gridPos": {
+                "x": 12,
+                "y": 26,
+                "h": 6,
+                "w": 12
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 300
+                      },
+                      {
+                        "color": "orange",
+                        "value": 600
+                      },
+                      {
+                        "color": "red",
+                        "value": 900
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "transparent": true,
+              "pluginVersion": "11.6.3",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "histogram_quantile(0.99, sum(increase(kueue_admission_wait_time_seconds_bucket{source_cluster=~\"$cluster\", cluster_queue=\"cluster-pipeline-queue\"}[$__range])) by (le, priority_class))",
+                  "legendFormat": "__auto",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "options": {
+                "reduceOptions": {
+                  "values": false,
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": ""
+                },
+                "orientation": "auto",
+                "textMode": "auto",
+                "wideLayout": true,
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "showPercentChange": false,
+                "percentChangeColorMode": "standard"
+              }
+            },
+            {
+              "id": 103,
+              "type": "stat",
+              "title": "Admitted Workloads Increase By Priority Class",
+              "description": "The total number of admitted workloads,  by priority class , in the selected range",
+              "gridPos": {
+                "x": 12,
+                "y": 32,
+                "h": 6,
+                "w": 12
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 300
+                      },
+                      {
+                        "color": "orange",
+                        "value": 600
+                      },
+                      {
+                        "color": "red",
+                        "value": 900
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "transparent": true,
+              "pluginVersion": "11.6.3",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "round(sum by (priority_class) (increase(kueue_admitted_workloads_total{source_cluster=~\"$cluster\"}[$__range])))",
+                  "legendFormat": "__auto",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "options": {
+                "reduceOptions": {
+                  "values": false,
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": ""
+                },
+                "orientation": "auto",
+                "textMode": "auto",
+                "wideLayout": true,
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "showPercentChange": false,
+                "percentChangeColorMode": "standard"
+              }
+            },
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${datasource}"
@@ -2376,5 +2534,5 @@ data:
       "timezone": "UTC",
       "title": "Konflux Kueue-sre",
       "uid": "ef0bjmoh7cbggc--",
-      "version": 29
+      "version": 30
     }


### PR DESCRIPTION
Description

https://redhat-internal.slack.com/archives/C04F4NE15U1/p1779168995291749

Test on stage 
https://grafana.stage.devshift.net/d/ef0bjmoh7cbggc--1/konflux-kueue-sre?orgId=1&from=now-6h&to=now&timezone=UTC&var-datasource=P22466E8E7855F1E0&var-cluster=stone-prd-rh01&refresh=1m


Update the Kueue dashboard in app-sre grafana to breakdown the data by priority_class (like we do in the in-cluster grafana instances) - https://grafana-access-appstudio-grafana.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/d/ceq3r2cpy01z4a/kueue?from=now-15m&to=now&refresh=auto

-Admitted Workloads Increase By Priority Class
- dmission Wait Time 99th Percentile By Priority Class

SPRE-5357
https://redhat.atlassian.net/browse/SPRE-5357

### Deployment Notice
Test: get json grafana from configmap after change and loud to stage

https://grafana.stage.devshift.net/d/ef0bjmoh7cbggc--555/konflux-kueue-sre-5555555?orgId=1&from=now-12h&to=now&timezone=UTC&var-datasource=P22466E8E7855F1E0&var-cluster=stone-prd-rh01&refresh=5m
