### PR TITLE
update KonfluxAlert threshold to 15m and adjust test…

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml
@@ -11,7 +11,7 @@ spec:
     rules:
     - alert: KonfluxAlert
       expr: (konflux_up offset 1h) unless on(service, check, source_cluster) konflux_up
-      for: 5m
+      for: 15m
       labels:
         severity: warning
       annotations:

--- a/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
+++ b/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
@@ -12,7 +12,10 @@ tests:
         values: '1x120'
 
     alert_rule_test:
-      - eval_time: 120m
+      - eval_time: 70m
+        alertname: KonfluxAlert
+
+      - eval_time: 90m
         alertname: KonfluxAlert
         exp_alerts:
           - exp_labels:


### PR DESCRIPTION
### Description
After a conversation and agreement to change the time to 15 minutes
https://redhat-internal.slack.com/archives/C04FDFTF8EB/p1779283222869229

This PR updates the `for` duration threshold of the `KonfluxAlert` from 5 minutes to 15 minutes. 

The current 5-minute window causes frequent false positives due to transient monitoring flaps and temporary signal missing blips. Following sync and approval from the o11y team, we are increasing the duration to 15 minutes to reduce alert noise while still ensuring reliable alerting for prolonged availability issues.

The corresponding PromQL unit tests have been updated and validated to ensure the 15-minute threshold is strictly enforced and verified.

Jira Ticket: SPRE-5244
https://redhat.atlassian.net/issues?filter=-1&selectedIssue=SPRE-5244
### Pre-Submission Checklist

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [x] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [x] **Pipeline Finished Successfully**
