### PR TITLE
SPRE-5347: simplify TektonKueueRolloutStuck alert expr and extend for…

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -112,9 +112,8 @@ spec:
         summary: "Tekton Kueue rollout stuck: {{ $labels.deployment }}"
         description: >-
           Deployment {{ $labels.deployment }} in namespace {{ $labels.namespace }} on cluster
-          {{ $labels.source_cluster }} has not completed its rollout for over 20 minutes.
-          New pods are failing to start while old pods continue serving traffic.
-          Check pod events and logs for the failing ReplicaSet.
+          {{ $labels.source_cluster }} update is delayed or stuck (no full health for 20m).
+          Check pod events and logs for the deployment and its ReplicaSets.
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueRolloutStuck.md
         alert_routing_key: infra
         team: konflux-infra

--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -101,20 +101,10 @@ spec:
 
     - alert: TektonKueueRolloutStuck
       expr: |
-        (
-          kube_deployment_status_replicas_updated{namespace="tekton-kueue"}
-            <
-          kube_deployment_spec_replicas{namespace="tekton-kueue"}
-        )
-        and
-        (
-          changes(kube_deployment_status_replicas_updated{namespace="tekton-kueue"}[15m]) == 0
-        )
-        and
-        (
-          kube_deployment_status_replicas_updated{namespace="tekton-kueue"} offset 15m
-        )
-      for: 5m
+        kube_deployment_status_replicas_updated{namespace="tekton-kueue"}
+          <
+        kube_deployment_spec_replicas{namespace="tekton-kueue"}
+      for: 20m
       labels:
         severity: warning
         component: tekton-kueue

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -72,7 +72,7 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # TektonKueueRolloutStuck - should fire: updated < desired, no progress, metric exists 15m+
+  # TektonKueueRolloutStuck - should fire: updated < desired for 20m
   - interval: 1m
     input_series:
       - series: 'kube_deployment_spec_replicas{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
@@ -108,7 +108,7 @@ tests:
         alertname: TektonKueueRolloutStuck
         exp_alerts: []
 
-  # TektonKueueRolloutStuck - should NOT fire at 10m: young series, offset 15m returns nothing
+  # TektonKueueRolloutStuck - should NOT fire at 10m: condition true but for: 20m not yet satisfied
   - interval: 1m
     input_series:
       - series: 'kube_deployment_spec_replicas{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -91,7 +91,7 @@ tests:
               source_cluster: c1
             exp_annotations:
               summary: "Tekton Kueue rollout stuck: tekton-kueue-controller-manager"
-              description: "Deployment tekton-kueue-controller-manager in namespace tekton-kueue on cluster c1 has not completed its rollout for over 20 minutes. New pods are failing to start while old pods continue serving traffic. Check pod events and logs for the failing ReplicaSet."
+              description: "Deployment tekton-kueue-controller-manager in namespace tekton-kueue on cluster c1 update is delayed or stuck (no full health for 20m). Check pod events and logs for the deployment and its ReplicaSets."
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueRolloutStuck.md
               alert_routing_key: infra
               team: konflux-infra


### PR DESCRIPTION
… duration to 20m

Replace complex three-part expression with a direct replica comparison and extend the for duration from 5m to 20m to reduce noise from transient rollout states.

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
