### PR TITLE
SPRE-5346: downgrade TektonKueuePodsCrashLoopBackOff from critical to high

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -67,22 +67,20 @@ spec:
 
     - alert: TektonKueuePodsCrashLoopBackOff
       expr: |
-        sum by (source_cluster) (
-          max_over_time(kube_pod_container_status_waiting_reason{
-            namespace="tekton-kueue",
-            reason="CrashLoopBackOff"
-          }[3m]) or vector(0)
-        ) > 0
+        max_over_time(kube_pod_container_status_waiting_reason{
+          namespace="tekton-kueue",
+          reason="CrashLoopBackOff"
+        }[3m]) > 0
       for: 3m
       labels:
-        severity: critical
+        severity: high
         component: tekton-kueue
-        slo: "true"
+        slo: "false"
       annotations:
-        summary: "Tekton Kueue pod is in a crash loop"
-        description: "Tekton Kueue pod has degraded into CrashLoopBackOff status in cluster {{ $labels.source_cluster }} and is not starting up."
+        summary: "Tekton Kueue pod is in a crash loop: {{ $labels.pod }}"
+        description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is in CrashLoopBackOff and is not starting up."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsCrashLoopBackOff.md
-        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        alert_routing_key: infra
         team: konflux-infra
 
     - alert: KueueCELEvaluationFailures

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -72,6 +72,40 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
+  # TektonKueuePodsCrashLoopBackOff - should fire: pod in CrashLoopBackOff for 3m
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="CrashLoopBackOff", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: TektonKueuePodsCrashLoopBackOff
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              component: tekton-kueue
+              slo: "false"
+              namespace: tekton-kueue
+              reason: CrashLoopBackOff
+              pod: tekton-kueue-controller-manager-abc123
+              source_cluster: c1
+            exp_annotations:
+              summary: "Tekton Kueue pod is in a crash loop: tekton-kueue-controller-manager-abc123"
+              description: "Pod tekton-kueue-controller-manager-abc123 in namespace tekton-kueue on cluster c1 is in CrashLoopBackOff and is not starting up."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsCrashLoopBackOff.md
+              alert_routing_key: infra
+              team: konflux-infra
+
+  # TektonKueuePodsCrashLoopBackOff - should NOT fire: no CrashLoopBackOff pods
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="CrashLoopBackOff", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: TektonKueuePodsCrashLoopBackOff
+        exp_alerts: []
+
   # TektonKueueRolloutStuck - should fire: updated < desired for 20m
   - interval: 1m
     input_series:


### PR DESCRIPTION
… high

CrashLoopBackOff is an early warning signal, not an outage. TektonKueueControllerDown (critical/SLO) already covers the case where available replicas drop. Downgrading to high/slo:false prevents burning error budget on situations with no user impact, such as stuck rollouts where old pods continue serving.

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
