### PR TITLE
fix: reenable cluster p02 alerts in MintMaker

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
@@ -16,7 +16,6 @@ spec:
           namespace="mintmaker",
           check="replicas-available",
           service="mintmaker-controller-manager",
-          source_cluster!="stone-prod-p02"
         } != 1
       for: 15m
       labels:
@@ -41,7 +40,6 @@ spec:
           namespace="mintmaker",
           check="replicas-available",
           service="redis",
-          source_cluster!="stone-prod-p02"
         } != 1
       for: 15m
       labels:

--- a/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
+++ b/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
@@ -60,30 +60,6 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="mintmaker-controller-manager", source_cluster="stone-prod-p02"}'
-        values: '0 0 0 0 0'
-      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="mintmaker-controller-manager", source_cluster="c7"}'
-        values: '1 1 1 1 1'
-
-    alert_rule_test:
-      - eval_time: 5m
-        alertname: MintMakerControllerDown
-        exp_alerts: null
-
-  - interval: 1m
-    input_series:
-      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="redis", source_cluster="stone-prod-p02"}'
-        values: '0 0 0 0 0'
-      - series: 'konflux_up{namespace="mintmaker", check="replicas-available", service="redis", source_cluster="c8"}'
-        values: '1 1 1 1 1'
-
-    alert_rule_test:
-      - eval_time: 5m
-        alertname: MintMakerControllerDown
-        exp_alerts: null
-
-  - interval: 1m
-    input_series:
       # DUC created at test start time (timestamp 0), value stays constant
       - series: 'mintmaker_dependency_update_check_creation_time{name="dependencyupdatecheck-old",namespace="mintmaker", source_cluster="c7"}'
         values: '0+0x300'


### PR DESCRIPTION


### Description

There was an exclusion rule for cluster p02 in MintMaker because it was firing very frequently when it was being set up.

However, the cluster is functional for a while, and we forgot to remove that exclusion.

This commit reenables it.

---

### Pre-Submission Checklist

- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [x] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [x] **Pipeline Finished Successfully**

Other items in the list (Jira ticket, SOP/Runbook) don't apply.

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
