### PR TITLE
feat(SPRE-5245)-Tune EtcdSlowNetworkRTT alert logic

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.performance_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.performance_alerts.yaml
@@ -54,7 +54,18 @@ spec:
 
         - alert: EtcdSlowNetworkRTT
           expr: |
-            max by (source_cluster, pod) (histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))) > 0.1
+            (
+              count by (source_cluster) (
+                histogram_quantile(
+                  0.99,
+                  rate(etcd_network_peer_round_trip_time_seconds_bucket[5m])
+                ) > 0.15
+              ) >= 2
+            )
+            and on(source_cluster)
+            (
+              increase(etcd_server_proposals_failed_total[5m]) > 0
+            )
           for: 15m
           labels:
             severity: warning
@@ -63,5 +74,5 @@ spec:
             summary: >-
               High RTT latency on ETCD cluster member requests.
             description: >-
-              99th etcd RTT latency rate on {{$labels.pod}} higher than 0.1 in cluster {{ $labels.source_cluster }}.
+              99th etcd RTT latency is higher than 0.15 on at least 2 members, with proposal failures increasing in cluster {{ $labels.source_cluster }}.
             alert_routing_key: perfandscale

--- a/test/promql/tests/data_plane/performance_test.yaml
+++ b/test/promql/tests/data_plane/performance_test.yaml
@@ -93,7 +93,8 @@ tests:
 
   - interval: 1m
     input_series:
-      # Etcd cluster member RTT delay is over 0.1, so it will be alerted.
+      # Two etcd members have RTT > 0.15 and proposal failures increase,
+      # so it will be alerted.
       - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="0.01", pod="etcd-pod-1", source_cluster="cluster01"}'
         values: '0.1+0.3x16'
 
@@ -103,40 +104,17 @@ tests:
       - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="+Inf", pod="etcd-pod-1", source_cluster="cluster01"}'
         values: '0.1+0.2x16'
 
-    alert_rule_test:
-      - eval_time: 16m
-        alertname: EtcdSlowNetworkRTT
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              component: etcd
-              pod: etcd-pod-1
-              source_cluster: cluster01
-            exp_annotations:
-              summary: "High RTT latency on ETCD cluster member requests."
-              description: "99th etcd RTT latency rate on etcd-pod-1 higher than 0.1 in cluster cluster01."
-              alert_routing_key: perfandscale
-
-  - interval: 1m
-    input_series:
-      # Etcd cluster member RTT delay is over 0.1 on second pod, so it will be alerted.
-      - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="0.01", pod="etcd-pod-1", source_cluster="cluster01"}'
-        values: '0.01+0x15'
-
-      - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="0.2", pod="etcd-pod-1", source_cluster="cluster01"}'
-        values: '0.01+0x15'
-
-      - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="+Inf", pod="etcd-pod-1", source_cluster="cluster01"}'
-        values: '0.01+0x15'
-
       - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="0.01", pod="etcd-pod-2", source_cluster="cluster01"}'
-        values: '0.1+0.3x15'
+        values: '0.1+0.3x16'
 
       - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="0.2", pod="etcd-pod-2", source_cluster="cluster01"}'
-        values: '0.1+0.5x15'
+        values: '0.1+0.5x16'
 
       - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="+Inf", pod="etcd-pod-2", source_cluster="cluster01"}'
-        values: '0.1+0.2x15'
+        values: '0.1+0.2x16'
+
+      - series: 'etcd_server_proposals_failed_total{source_cluster="cluster01"}'
+        values: '0+1x16'
 
     alert_rule_test:
       - eval_time: 16m
@@ -145,18 +123,55 @@ tests:
           - exp_labels:
               severity: warning
               component: etcd
-              pod: etcd-pod-2
               source_cluster: cluster01
             exp_annotations:
               summary: "High RTT latency on ETCD cluster member requests."
-              description: "99th etcd RTT latency rate on etcd-pod-2 higher than 0.1 in cluster cluster01."
+              description: "99th etcd RTT latency is higher than 0.15 on at least 2 members, with proposal failures increasing in cluster cluster01."
               alert_routing_key: perfandscale
 
   - interval: 1m
     input_series:
-      # Etcd cluster member RTT delay is below alert threshold rate, so it will not be alerted.
-      - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="0.1", pod="etcd-pod-2", source_cluster="cluster01"}'
-        values: '0.1+0.01x16'
+      # Only one etcd member has RTT > 0.15, so it will not be alerted.
+      - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="0.01", pod="etcd-pod-1", source_cluster="cluster01"}'
+        values: '0.1+0.3x16'
+
+      - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="0.2", pod="etcd-pod-1", source_cluster="cluster01"}'
+        values: '0.1+0.5x16'
+
+      - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="+Inf", pod="etcd-pod-1", source_cluster="cluster01"}'
+        values: '0.1+0.2x16'
+
+      - series: 'etcd_server_proposals_failed_total{source_cluster="cluster01"}'
+        values: '0+1x16'
+
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: EtcdSlowNetworkRTT
+
+  - interval: 1m
+    input_series:
+      # Two etcd members have RTT, but proposal failures are not increasing,
+      # so it will not be alerted.
+      - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="0.01", pod="etcd-pod-1", source_cluster="cluster01"}'
+        values: '0.1+0.3x16'
+
+      - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="0.2", pod="etcd-pod-1", source_cluster="cluster01"}'
+        values: '0.1+0.5x16'
+
+      - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="+Inf", pod="etcd-pod-1", source_cluster="cluster01"}'
+        values: '0.1+0.2x16'
+
+      - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="0.01", pod="etcd-pod-2", source_cluster="cluster01"}'
+        values: '0.1+0.3x16'
+
+      - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="0.2", pod="etcd-pod-2", source_cluster="cluster01"}'
+        values: '0.1+0.5x16'
+
+      - series: 'etcd_network_peer_round_trip_time_seconds_bucket{le="+Inf", pod="etcd-pod-2", source_cluster="cluster01"}'
+        values: '0.1+0.2x16'
+
+      - series: 'etcd_server_proposals_failed_total{source_cluster="cluster01"}'
+        values: '0+0x16'
 
     alert_rule_test:
       - eval_time: 16m


### PR DESCRIPTION
### Description

Updated the EtcdSlowNetworkRTT alert logic to reduce low-value RTT-only alert noise and improve actionability.

Changes made:

Updated alert from single-pod detection to cluster-level multi-member detection
Alert now requires at least 2 etcd members in the same cluster to exceed RTT threshold
Increased RTT threshold from 0.1 to 0.15
Added correlation with etcd_server_proposals_failed_total to ensure alert fires only when proposal failures are increasing
Updated unit tests to validate the new cluster-level alert behavior

Impact observed during testing:

Original alert count: 270
Multi-node only logic: 168
Multi-node + proposal failures logic: 114

This significantly reduces low-value RTT-only noise while keeping alerts focused on actionable etcd cluster issues.

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
