### PR TITLE
Add tekton kueue pod health alerts

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -119,10 +119,15 @@ spec:
 
     - alert: TektonKueuePodOOMKilled
       expr: |
-        kube_pod_container_status_last_terminated_reason{
-          namespace="tekton-kueue",
-          reason="OOMKilled"
-        } == 1
+        (
+          increase(kube_pod_container_status_restarts_total{namespace="tekton-kueue"}[15m]) > 0
+        ) * on (pod, container, namespace, source_cluster) group_left(reason)
+        (
+          kube_pod_container_status_last_terminated_reason{
+            namespace="tekton-kueue",
+            reason="OOMKilled"
+          } == 1
+        )
       for: 1m
       labels:
         severity: high

--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -83,7 +83,7 @@ spec:
         alert_routing_key: infra
         team: konflux-infra
 
-    - alert: TektonKueuePodsStuckInPending
+    - alert: TektonKueuePodStuckInPending
       expr: |
         kube_pod_status_phase{
           namespace="tekton-kueue",
@@ -96,7 +96,7 @@ spec:
       annotations:
         summary: "Tekton Kueue pod is stuck in Pending: {{ $labels.pod }}"
         description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} has been in Pending state for more than 5 minutes. This may indicate a scheduling issue, resource constraint, or unresolvable volume."
-        # runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsStuckInPending.md
+        # runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodStuckInPending.md
         alert_routing_key: infra
         team: konflux-infra
 

--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -83,6 +83,23 @@ spec:
         alert_routing_key: infra
         team: konflux-infra
 
+    - alert: TektonKueuePodsStuckInPending
+      expr: |
+        kube_pod_status_phase{
+          namespace="tekton-kueue",
+          phase="Pending"
+        } == 1
+      for: 5m
+      labels:
+        severity: warning
+        component: tekton-kueue
+      annotations:
+        summary: "Tekton Kueue pod is stuck in Pending: {{ $labels.pod }}"
+        description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} has been in Pending state for more than 5 minutes. This may indicate a scheduling issue, resource constraint, or unresolvable volume."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsStuckInPending.md
+        alert_routing_key: infra
+        team: konflux-infra
+
     - alert: KueueCELEvaluationFailures
       expr: increase(tekton_kueue_cel_evaluations_total{result="failure"}[5m]) > 0
       for: 1m

--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -96,7 +96,7 @@ spec:
       annotations:
         summary: "Tekton Kueue pod is stuck in Pending: {{ $labels.pod }}"
         description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} has been in Pending state for more than 5 minutes. This may indicate a scheduling issue, resource constraint, or unresolvable volume."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsStuckInPending.md
+        # runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsStuckInPending.md
         alert_routing_key: infra
         team: konflux-infra
 
@@ -113,7 +113,7 @@ spec:
       annotations:
         summary: "Tekton Kueue pod is stuck in ContainerCreating: {{ $labels.pod }}"
         description: "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is stuck in ContainerCreating for more than 5 minutes. This typically points to infrastructure issues like Volume/Storage mounting failures or Network attachment delays."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodStuckInCreation.md
+        # runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodStuckInCreation.md
         alert_routing_key: infra
         team: konflux-infra
 
@@ -135,7 +135,7 @@ spec:
       annotations:
         summary: "Tekton Kueue pod was OOMKilled: {{ $labels.pod }}"
         description: "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} was terminated due to OOM. Memory limits may need to be increased in the deployment spec."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodOOMKilled.md
+        # runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodOOMKilled.md
         alert_routing_key: infra
         team: konflux-infra
 

--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -100,6 +100,23 @@ spec:
         alert_routing_key: infra
         team: konflux-infra
 
+    - alert: TektonKueuePodStuckInCreation
+      expr: |
+        kube_pod_container_status_waiting_reason{
+          namespace="tekton-kueue",
+          reason="ContainerCreating"
+        } == 1
+      for: 5m
+      labels:
+        severity: high
+        component: tekton-kueue
+      annotations:
+        summary: "Tekton Kueue pod is stuck in ContainerCreating: {{ $labels.pod }}"
+        description: "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is stuck in ContainerCreating for more than 5 minutes. This typically points to infrastructure issues like Volume/Storage mounting failures or Network attachment delays."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodStuckInCreation.md
+        alert_routing_key: infra
+        team: konflux-infra
+
     - alert: KueueCELEvaluationFailures
       expr: increase(tekton_kueue_cel_evaluations_total{result="failure"}[5m]) > 0
       for: 1m

--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -117,6 +117,23 @@ spec:
         alert_routing_key: infra
         team: konflux-infra
 
+    - alert: TektonKueuePodOOMKilled
+      expr: |
+        kube_pod_container_status_last_terminated_reason{
+          namespace="tekton-kueue",
+          reason="OOMKilled"
+        } == 1
+      for: 1m
+      labels:
+        severity: high
+        component: tekton-kueue
+      annotations:
+        summary: "Tekton Kueue pod was OOMKilled: {{ $labels.pod }}"
+        description: "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} was terminated due to OOM. Memory limits may need to be increased in the deployment spec."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodOOMKilled.md
+        alert_routing_key: infra
+        team: konflux-infra
+
     - alert: KueueCELEvaluationFailures
       expr: increase(tekton_kueue_cel_evaluations_total{result="failure"}[5m]) > 0
       for: 1m

--- a/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
@@ -36,7 +36,7 @@ spec:
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-crashLoopBackOff.md
     - alert: PodNotReady
       expr: |
-            kube_pod_status_phase{phase=~"Pending|Unknown|Failed", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci|mintmaker|multi-platform-.*|appstudio-probe-monitoring-grafana|clusters|clusters-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"} == 1
+            kube_pod_status_phase{phase=~"Pending|Unknown|Failed", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci|mintmaker|multi-platform-.*|appstudio-probe-monitoring-grafana|clusters|clusters-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|tekton-kueue)"} == 1
             unless ignoring (phase) (kube_pod_status_unschedulable == 1)
       for: 30m
       labels:
@@ -88,7 +88,7 @@ spec:
 
     - alert: PodOOMKilled
       expr: |
-        count(kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci|mintmaker)"}) by (source_cluster,namespace,container,pod) >= 1
+        count(kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci|mintmaker|tekton-kueue)"}) by (source_cluster,namespace,container,pod) >= 1
       for: 5m
       labels:
         severity: warning
@@ -102,7 +102,7 @@ spec:
 
     - alert: ControllerPodOOMKilled
       expr: |
-        count(kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci|mintmaker)", pod=~".*controller.*|.*manager.*"}) by (source_cluster,namespace,container,pod) >= 1
+        count(kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci|mintmaker|tekton-kueue)", pod=~".*controller.*|.*manager.*"}) by (source_cluster,namespace,container,pod) >= 1
       for: 5m
       labels:
         severity: critical

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -219,13 +219,15 @@ tests:
         alertname: TektonKueuePodStuckInCreation
         exp_alerts: []
 
-  # TektonKueuePodOOMKilled - should fire: container last terminated by OOMKilled for 1m
+  # TektonKueuePodOOMKilled - should fire: restart occurred and last terminated reason is OOMKilled
   - interval: 1m
     input_series:
+      - series: 'kube_pod_container_status_restarts_total{namespace="tekton-kueue", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
+        values: '0 1 1 1 1 1 1 1 1 1 1'
       - series: 'kube_pod_container_status_last_terminated_reason{namespace="tekton-kueue", reason="OOMKilled", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
         values: '1+0x10'
     alert_rule_test:
-      - eval_time: 1m
+      - eval_time: 2m
         alertname: TektonKueuePodOOMKilled
         exp_alerts:
           - exp_labels:
@@ -243,13 +245,15 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # TektonKueuePodOOMKilled - should NOT fire: last terminated reason is not OOMKilled
+  # TektonKueuePodOOMKilled - should NOT fire: no restarts occurred
   - interval: 1m
     input_series:
-      - series: 'kube_pod_container_status_last_terminated_reason{namespace="tekton-kueue", reason="OOMKilled", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
+      - series: 'kube_pod_container_status_restarts_total{namespace="tekton-kueue", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
         values: '0+0x10'
+      - series: 'kube_pod_container_status_last_terminated_reason{namespace="tekton-kueue", reason="OOMKilled", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
+        values: '1+0x10'
     alert_rule_test:
-      - eval_time: 1m
+      - eval_time: 2m
         alertname: TektonKueuePodOOMKilled
         exp_alerts: []
 

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -219,6 +219,40 @@ tests:
         alertname: TektonKueuePodStuckInCreation
         exp_alerts: []
 
+  # TektonKueuePodOOMKilled - should fire: container last terminated by OOMKilled for 1m
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_last_terminated_reason{namespace="tekton-kueue", reason="OOMKilled", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: TektonKueuePodOOMKilled
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              component: tekton-kueue
+              namespace: tekton-kueue
+              reason: OOMKilled
+              pod: tekton-kueue-controller-manager-abc123
+              container: manager
+              source_cluster: c1
+            exp_annotations:
+              summary: "Tekton Kueue pod was OOMKilled: tekton-kueue-controller-manager-abc123"
+              description: "Container manager in pod tekton-kueue-controller-manager-abc123 in namespace tekton-kueue on cluster c1 was terminated due to OOM. Memory limits may need to be increased in the deployment spec."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodOOMKilled.md
+              alert_routing_key: infra
+              team: konflux-infra
+
+  # TektonKueuePodOOMKilled - should NOT fire: last terminated reason is not OOMKilled
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_last_terminated_reason{namespace="tekton-kueue", reason="OOMKilled", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: TektonKueuePodOOMKilled
+        exp_alerts: []
+
   # TektonKueueRolloutStuck - should NOT fire at 10m: condition true but for: 20m not yet satisfied
   - interval: 1m
     input_series:

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -185,6 +185,40 @@ tests:
         alertname: TektonKueuePodsStuckInPending
         exp_alerts: []
 
+  # TektonKueuePodStuckInCreation - should fire: container in ContainerCreating for 5m
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="ContainerCreating", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: TektonKueuePodStuckInCreation
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              component: tekton-kueue
+              namespace: tekton-kueue
+              reason: ContainerCreating
+              pod: tekton-kueue-controller-manager-abc123
+              container: manager
+              source_cluster: c1
+            exp_annotations:
+              summary: "Tekton Kueue pod is stuck in ContainerCreating: tekton-kueue-controller-manager-abc123"
+              description: "Container manager in pod tekton-kueue-controller-manager-abc123 in namespace tekton-kueue on cluster c1 is stuck in ContainerCreating for more than 5 minutes. This typically points to infrastructure issues like Volume/Storage mounting failures or Network attachment delays."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodStuckInCreation.md
+              alert_routing_key: infra
+              team: konflux-infra
+
+  # TektonKueuePodStuckInCreation - should NOT fire: no containers in ContainerCreating
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="ContainerCreating", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: TektonKueuePodStuckInCreation
+        exp_alerts: []
+
   # TektonKueueRolloutStuck - should NOT fire at 10m: condition true but for: 20m not yet satisfied
   - interval: 1m
     input_series:

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -142,6 +142,49 @@ tests:
         alertname: TektonKueueRolloutStuck
         exp_alerts: []
 
+  # TektonKueuePodsStuckInPending - should fire: pod in Pending for 5m
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: TektonKueuePodsStuckInPending
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: tekton-kueue
+              namespace: tekton-kueue
+              phase: Pending
+              pod: tekton-kueue-controller-manager-abc123
+              source_cluster: c1
+            exp_annotations:
+              summary: "Tekton Kueue pod is stuck in Pending: tekton-kueue-controller-manager-abc123"
+              description: "Pod tekton-kueue-controller-manager-abc123 in namespace tekton-kueue on cluster c1 has been in Pending state for more than 5 minutes. This may indicate a scheduling issue, resource constraint, or unresolvable volume."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsStuckInPending.md
+              alert_routing_key: infra
+              team: konflux-infra
+
+  # TektonKueuePodsStuckInPending - should NOT fire: pod not in Pending
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: TektonKueuePodsStuckInPending
+        exp_alerts: []
+
+  # TektonKueuePodsStuckInPending - should NOT fire at 4m: for: 5m not yet satisfied
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: TektonKueuePodsStuckInPending
+        exp_alerts: []
+
   # TektonKueueRolloutStuck - should NOT fire at 10m: condition true but for: 20m not yet satisfied
   - interval: 1m
     input_series:

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -161,7 +161,6 @@ tests:
             exp_annotations:
               summary: "Tekton Kueue pod is stuck in Pending: tekton-kueue-controller-manager-abc123"
               description: "Pod tekton-kueue-controller-manager-abc123 in namespace tekton-kueue on cluster c1 has been in Pending state for more than 5 minutes. This may indicate a scheduling issue, resource constraint, or unresolvable volume."
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsStuckInPending.md
               alert_routing_key: infra
               team: konflux-infra
 
@@ -205,7 +204,6 @@ tests:
             exp_annotations:
               summary: "Tekton Kueue pod is stuck in ContainerCreating: tekton-kueue-controller-manager-abc123"
               description: "Container manager in pod tekton-kueue-controller-manager-abc123 in namespace tekton-kueue on cluster c1 is stuck in ContainerCreating for more than 5 minutes. This typically points to infrastructure issues like Volume/Storage mounting failures or Network attachment delays."
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodStuckInCreation.md
               alert_routing_key: infra
               team: konflux-infra
 
@@ -241,7 +239,6 @@ tests:
             exp_annotations:
               summary: "Tekton Kueue pod was OOMKilled: tekton-kueue-controller-manager-abc123"
               description: "Container manager in pod tekton-kueue-controller-manager-abc123 in namespace tekton-kueue on cluster c1 was terminated due to OOM. Memory limits may need to be increased in the deployment spec."
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodOOMKilled.md
               alert_routing_key: infra
               team: konflux-infra
 

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -142,14 +142,14 @@ tests:
         alertname: TektonKueueRolloutStuck
         exp_alerts: []
 
-  # TektonKueuePodsStuckInPending - should fire: pod in Pending for 5m
+  # TektonKueuePodStuckInPending - should fire: pod in Pending for 5m
   - interval: 1m
     input_series:
       - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
         values: '1+0x10'
     alert_rule_test:
       - eval_time: 5m
-        alertname: TektonKueuePodsStuckInPending
+        alertname: TektonKueuePodStuckInPending
         exp_alerts:
           - exp_labels:
               severity: warning
@@ -164,24 +164,24 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # TektonKueuePodsStuckInPending - should NOT fire: pod not in Pending
+  # TektonKueuePodStuckInPending - should NOT fire: pod not in Pending
   - interval: 1m
     input_series:
       - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
         values: '0+0x10'
     alert_rule_test:
       - eval_time: 5m
-        alertname: TektonKueuePodsStuckInPending
+        alertname: TektonKueuePodStuckInPending
         exp_alerts: []
 
-  # TektonKueuePodsStuckInPending - should NOT fire at 4m: for: 5m not yet satisfied
+  # TektonKueuePodStuckInPending - should NOT fire at 4m: for: 5m not yet satisfied
   - interval: 1m
     input_series:
       - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
         values: '1+0x10'
     alert_rule_test:
       - eval_time: 4m
-        alertname: TektonKueuePodsStuckInPending
+        alertname: TektonKueuePodStuckInPending
         exp_alerts: []
 
   # TektonKueuePodStuckInCreation - should fire: container in ContainerCreating for 5m


### PR DESCRIPTION
### Description
  Add tekton-kueue pod health alerts
  
  This PR adds three new alerts covering tekton-kueue pod lifecycle failure modes that were previously undetected, and fixes duplicate alerting against the generic pod alert rules.

  New alerts:

  - TektonKueuePodStuckInPending (SPRE-5417, warning): fires when a tekton-kueue pod has been in Pending phase for more than 5 minutes. Covers scheduling failures, resource constraints, and unresolvable
  volume/PVC claims.
  - TektonKueuePodStuckInCreation (SPRE-5415, high): fires when a container is stuck in ContainerCreating for more than 5 minutes. Typically indicates Volume/Storage mounting failures or Network attachment
  delays. Image pull failures are excluded by design as they produce distinct waiting reasons (ErrImagePull, ImagePullBackOff).
  - TektonKueuePodOOMKilled (SPRE-5416, high): fires when a container's last termination reason is OOMKilled and a restart occurred within the past 15 minutes. Uses a time-windowed expression
  (increase(...[15m])) to auto-resolve once the container has been stable for 15 minutes, avoiding long-lived alerts after recovery.

  Supporting changes:

  - Added tekton-kueue to the namespace exclusion list in PodNotReady, PodOOMKilled, and ControllerPodOOMKilled in prometheus.pod_alerts.yaml to prevent duplicate alerts firing alongside the new kueue-specific
  ones. Follows the same pattern already in place for the generic CrashLoopBackOff alert.
  - Runbook URLs are commented out pending SOP creation.
  - Unit tests included for each alert covering both fire and no-fire scenarios.

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
