### PR TITLE
SPRE-5418 feat(dashboard): add Tekton Kueue Unhealthy Pods panel

### DIFF
--- a/dashboards/grafana-dashboard-konflux-kueue.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-kueue.configmap.yaml
@@ -713,7 +713,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "label_replace(\n  max_over_time(kube_pod_container_status_waiting_reason{namespace=\"tekton-kueue\", reason=\"CrashLoopBackOff\", source_cluster=~\"$cluster\"}[$__rate_interval]) > 0,\n  \"state\", \"CrashLoopBackOff\", \"\", \"\"\n)",
+              "expr": "label_replace(\n  max_over_time(kube_pod_container_status_waiting_reason{namespace=\"tekton-kueue\", reason=\"CrashLoopBackOff\", source_cluster=~\"$cluster\"}[$__interval]) > 0,\n  \"state\", \"CrashLoopBackOff\", \"\", \"\"\n)",
               "format": "table",
               "instant": false,
               "legendFormat": "CrashLoopBackOff",
@@ -726,7 +726,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "label_replace(\n  max_over_time(kube_pod_container_status_terminated_reason{namespace=\"tekton-kueue\", reason=\"OOMKilled\", source_cluster=~\"$cluster\"}[$__rate_interval]) > 0,\n  \"state\", \"OOMKilled\", \"\", \"\"\n)",
+              "expr": "label_replace(\n  max_over_time(kube_pod_container_status_terminated_reason{namespace=\"tekton-kueue\", reason=\"OOMKilled\", source_cluster=~\"$cluster\"}[$__interval]) > 0,\n  \"state\", \"OOMKilled\", \"\", \"\"\n)",
               "format": "table",
               "instant": false,
               "legendFormat": "OOMKilled",

--- a/dashboards/grafana-dashboard-konflux-kueue.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-kueue.configmap.yaml
@@ -99,7 +99,7 @@ data:
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "le": 1e-09
             },
             "legend": {
               "show": true
@@ -581,12 +581,199 @@ data:
           "type": "stat"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "Pending": {
+                      "color": "orange",
+                      "index": 0,
+                      "text": "Pending"
+                    },
+                    "ContainerCreating": {
+                      "color": "yellow",
+                      "index": 1,
+                      "text": "ContainerCreating"
+                    },
+                    "CrashLoopBackOff": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "CrashLoopBackOff"
+                    },
+                    "OOMKilled": {
+                      "color": "purple",
+                      "index": 3,
+                      "text": "OOMKilled"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "state"
+                },
+                "properties": [
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "mode": "basic",
+                      "type": "color-background"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 47
+          },
+          "id": 201,
+          "interval": "3000",
+          "maxDataPoints": 3000,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Time"
+              }
+            ]
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "label_replace(\n  kube_pod_status_phase{namespace=\"tekton-kueue\", phase=\"Pending\", source_cluster=~\"$cluster\"} > 0,\n  \"state\", \"Pending\", \"\", \"\"\n)",
+              "format": "table",
+              "instant": false,
+              "legendFormat": "Pending",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "label_replace(\n  kube_pod_container_status_waiting_reason{namespace=\"tekton-kueue\", reason=\"ContainerCreating\", source_cluster=~\"$cluster\"} > 0,\n  \"state\", \"ContainerCreating\", \"\", \"\"\n)",
+              "format": "table",
+              "instant": false,
+              "legendFormat": "ContainerCreating",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "label_replace(\n  max_over_time(kube_pod_container_status_waiting_reason{namespace=\"tekton-kueue\", reason=\"CrashLoopBackOff\", source_cluster=~\"$cluster\"}[$__rate_interval]) > 0,\n  \"state\", \"CrashLoopBackOff\", \"\", \"\"\n)",
+              "format": "table",
+              "instant": false,
+              "legendFormat": "CrashLoopBackOff",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "label_replace(\n  max_over_time(kube_pod_container_status_terminated_reason{namespace=\"tekton-kueue\", reason=\"OOMKilled\", source_cluster=~\"$cluster\"}[$__rate_interval]) > 0,\n  \"state\", \"OOMKilled\", \"\", \"\"\n)",
+              "format": "table",
+              "instant": false,
+              "legendFormat": "OOMKilled",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "timeFrom": "7d",
+          "title": "Tekton Kueue - Unhealthy Pods",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "__name__": true,
+                  "container": true,
+                  "job": true,
+                  "namespace": true,
+                  "phase": true,
+                  "reason": true,
+                  "receive": true,
+                  "service": true,
+                  "source_environment": true,
+                  "tenant_id": true,
+                  "Value": true
+                },
+                "indexByName": {
+                  "Time": 0,
+                  "pod": 1,
+                  "source_cluster": 2,
+                  "state": 3
+                },
+                "renameByName": {
+                  "source_cluster": "cluster"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
           "collapsed": true,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 47
+            "y": 57
           },
           "id": 6,
           "panels": [
@@ -696,15 +883,15 @@ data:
                       "options": {
                         "active": {
                           "index": 0,
-                          "text": "🟢 Active"
+                          "text": "\ud83d\udfe2 Active"
                         },
                         "pending": {
                           "index": 1,
-                          "text": "🟡 Pending"
+                          "text": "\ud83d\udfe1 Pending"
                         },
                         "terminated": {
                           "index": 2,
-                          "text": "🔴 Terminated"
+                          "text": "\ud83d\udd34 Terminated"
                         }
                       },
                       "type": "value"
@@ -1306,7 +1493,7 @@ data:
                   "color": "rgba(255,0,255,0.7)"
                 },
                 "filterValues": {
-                  "le": 1e-9
+                  "le": 1e-09
                 },
                 "legend": {
                   "show": true
@@ -1384,7 +1571,7 @@ data:
                   "color": "rgba(255,0,255,0.7)"
                 },
                 "filterValues": {
-                  "le": 1e-9
+                  "le": 1e-09
                 },
                 "legend": {
                   "show": true
@@ -1431,7 +1618,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 48
+            "y": 58
           },
           "id": 4,
           "panels": [
@@ -1542,7 +1729,7 @@ data:
                   "color": "rgba(255,0,255,0.7)"
                 },
                 "filterValues": {
-                  "le": 1e-9
+                  "le": 1e-09
                 },
                 "legend": {
                   "show": true
@@ -1923,7 +2110,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 49
+            "y": 59
           },
           "id": 100,
           "panels": [

--- a/dashboards/grafana-dashboard-konflux-kueue.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-kueue.configmap.yaml
@@ -659,8 +659,7 @@ data:
             "y": 47
           },
           "id": 201,
-          "interval": "3000",
-          "maxDataPoints": 3000,
+          "maxDataPoints": 500,
           "options": {
             "cellHeight": "sm",
             "footer": {
@@ -742,7 +741,6 @@ data:
               "options": {
                 "excludeByName": {
                   "__name__": true,
-                  "container": true,
                   "job": true,
                   "namespace": true,
                   "phase": true,
@@ -756,8 +754,9 @@ data:
                 "indexByName": {
                   "Time": 0,
                   "pod": 1,
-                  "source_cluster": 2,
-                  "state": 3
+                  "container": 2,
+                  "source_cluster": 3,
+                  "state": 4
                 },
                 "renameByName": {
                   "source_cluster": "cluster"


### PR DESCRIPTION
Add a table panel to the Konflux Kueue dashboard showing pods in problematic states: Pending, ContainerCreating, CrashLoopBackOff, and OOMKilled. Each state is color-coded and the panel defaults to a 7-day time window with 3000 max data points for consistent resolution across time ranges.

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
