### PR TITLE
feat(SPRE-5386): tune EtcdProposalFailures threshold

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.performance_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.performance_alerts.yaml
@@ -40,7 +40,7 @@ spec:
 
         - alert: EtcdProposalFailures
           expr: |
-            max by (source_cluster) (rate(etcd_server_proposals_failed_total[1h])) > 0.05
+            max by (source_cluster) (rate(etcd_server_proposals_failed_total[1h])) > 0.10
           for: 15m
           labels:
             severity: warning
@@ -50,7 +50,7 @@ spec:
               ETCD raft proposal failures.
             description: >-
               Etcd high number of failed proposals on some etcd pod in cluster {{ $labels.source_cluster }}.
-            alert_routing_key: perfandscale
+            alert_routing_key: spreandinfra
 
         - alert: EtcdSlowNetworkRTT
           expr: |

--- a/test/promql/tests/data_plane/performance_test.yaml
+++ b/test/promql/tests/data_plane/performance_test.yaml
@@ -182,7 +182,7 @@ tests:
     input_series:
       # Increase in Etcd raft proposal failures over time, so it will be alerted.
       - series: 'etcd_server_proposals_failed_total{pod="etcd-pod-1", source_cluster="cluster01"}'
-        values: '0+5x60'
+        values: '0+10x60'
 
       - series: 'etcd_server_proposals_failed_total{pod="etcd-pod-2", source_cluster="cluster01"}'
         values: '0+0x60'
@@ -201,7 +201,7 @@ tests:
             exp_annotations:
               summary: "ETCD raft proposal failures."
               description: "Etcd high number of failed proposals on some etcd pod in cluster cluster01."
-              alert_routing_key: perfandscale
+              alert_routing_key: spreandinfra
 
   - interval: 1m
     input_series:


### PR DESCRIPTION
### Description

This PR tunes the EtcdProposalFailures alert to reduce noisy transient firings.

Changes included:

Increased the alert threshold from 0.05 to 0.10.
Updated alert_routing_key from perfandscale to spreandinfra.
Updated the Prometheus unit test input data from 0+5x60 to 0+10x60 so the alert still validates correctly with the new threshold.
Updated the expected test annotation to use spreandinfra.

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
