### PR TITLE
feat(PVO11Y-5166): add alerting for konflux-release-data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ kustomize:
 .PHONY: check-and-test
 check-and-test:
 	$(CMD) -t rhtap -d rhobs/alerting/data_plane -y -p --tests-dir test/promql/tests/data_plane
+	$(CMD) -t rhtap -d rhobs/alerting/konflux-release-data -y -p --tests-dir test/promql/tests/konflux-release-data
 	$(CMD) -t rhtap -d rhobs/recording -y -p --tests-dir test/promql/tests/recording
 
 .PHONY: check-alert-conventions

--- a/docs/ALERTS.md
+++ b/docs/ALERTS.md
@@ -15,6 +15,13 @@ make selective-check-and-test \
   TEST_CASE_FILES="test/promql/tests/data_plane/my_alert_test.yaml"
 ```
 
+For KRD (Konflux Release Data) alerts:
+```
+make selective-check-and-test \
+  RULE_FILES="rhobs/alerting/konflux-release-data/my_alert.yaml" \
+  TEST_CASE_FILES="test/promql/tests/konflux-release-data/my_alert_test.yaml"
+```
+
 ### Alert convention checks
 ```
 make check-alert-conventions
@@ -35,6 +42,8 @@ Alert rules are evaluated by RHOBS (Red Hat Observability Service), not by in-cl
 - **Non-SLO alerts** are grouped by `alertname` and `cluster` (`group_by: [alertname, cluster]`). Multiple instances of the same alert on the same cluster are batched into a single Slack message with team routings preserved — e.g. if `PodNotReady` fires for 5 pods on the same cluster for multiple teams, they appear as one message containing several team-specific alerts.
 
 **Metric forwarding:** Because alerts are evaluated by RHOBS (not in-cluster Prometheus), any metric used in an alert must first be forwarded from Konflux clusters to RHOBS via [infra-deployments](https://github.com/redhat-appstudio/infra-deployments). An alert referencing a metric that isn't forwarded will silently never fire. See [adding-alert SOP](https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/adding-alert.md) for the full checklist.
+
+**Exception — KRD alerts:** Konflux Release Data runner and pipeline metrics are not forwarded via infra-deployments. They are scraped and forwarded by an OTEL Collector defined in [krd-monitoring](https://gitlab.cee.redhat.com/konflux/o11y/krd-monitoring). ArgoCD `argocd_app_info` metrics are forwarded via the standard Prometheus remote-write path in [app-interface](https://gitlab.cee.redhat.com/service/app-interface/-/blob/dabd5d7a2dc8cc229941b4669bb9f2fd4413f3d7/data/services/observability/cicd/saas/saas-observability-per-cluster.yaml#L457). See the [KRD monitoring SOP](https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/monitoring/konflux-release-data-monitoring.md) for full architecture and alert details.
 
 ## Deployment Model
 Changes are deployed into rhobs based on [references defined in app-interface](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/stonesoup/cicd/saas-rhtap-rules.yaml?ref_type=heads).
@@ -60,6 +69,8 @@ Example mappings:
 | `o11y`, `appstudio-grafana`, `monitoring-workload.*` | O11y |
 
 If a key doesn't match any mapping, the o11y team is notified as fallback. See the [alerting guide SOP](https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alerting_guide.md) for the full routing matrix.
+
+**KRD (Konflux Release Data) alerts** are routed by the `component` label with a `krd-` prefix into a separate `#konflux-releng-alerts` Slack channel. See the [KRD monitoring SOP](https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/monitoring/konflux-release-data-monitoring.md) for details.
 
 **Severity levels:**
 | Severity | Usage |

--- a/rhobs/alerting/konflux-release-data/prometheus.krd_argocd_tenant_config_alerts.yaml
+++ b/rhobs/alerting/konflux-release-data/prometheus.krd_argocd_tenant_config_alerts.yaml
@@ -1,0 +1,77 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-krd-argocd-tenant-config-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: krd-argocd-tenant-config
+      interval: 1m
+      rules:
+        - alert: KRDTenantConfigAppDegraded
+          expr: |
+            last_over_time(
+              argocd_app_info{
+                health_status="Degraded",
+                namespace=~"konflux-tenants-config|konflux-tenants-config-stage"
+              }[2m]
+            ) == 1
+          for: 10m
+          labels:
+            severity: warning
+            slo: "false"
+            component: krd-tenants-config
+          annotations:
+            summary: >-
+              Tenant-config ArgoCD app {{ $labels.name }} is degraded for {{ $labels.dest_namespace }} namespace
+            description: >-
+              ArgoCD application {{ $labels.name }} in {{ $labels.namespace }} has been in Degraded health status
+              for more than 10 minutes.
+            alert_routing_key: krd-releng
+            team: releng
+
+        - alert: KRDTenantConfigAppOutOfSync
+          expr: |
+            last_over_time(
+              argocd_app_info{
+                health_status="Healthy",
+                sync_status="OutOfSync",
+                namespace=~"konflux-tenants-config|konflux-tenants-config-stage"
+              }[2m]
+            ) == 1
+          for: 10m
+          labels:
+            severity: warning
+            slo: "false"
+            component: krd-tenants-config
+          annotations:
+            summary: >-
+              Tenant-config ArgoCD app {{ $labels.name }} is OutOfSync for {{ $labels.dest_namespace }} namespace
+            description: >-
+              ArgoCD application {{ $labels.name }} in {{ $labels.namespace }} namespace
+              has been OutOfSync for more than 10 minutes.
+            alert_routing_key: krd-releng
+            team: releng
+
+        - alert: KRDTenantConfigAppMissingOrUnknown
+          expr: |
+            last_over_time(
+              argocd_app_info{
+                health_status=~"Missing|Unknown",
+                namespace=~"konflux-tenants-config|konflux-tenants-config-stage"
+              }[2m]
+            ) == 1
+          for: 10m
+          labels:
+            severity: warning
+            slo: "false"
+            component: krd-tenants-config
+          annotations:
+            summary: >-
+              Tenant-config ArgoCD app {{ $labels.name }} has {{ $labels.health_status }} health for {{ $labels.dest_namespace }} namespace
+            description: >-
+              ArgoCD application {{ $labels.name }} in {{ $labels.dest_namespace }} namespace
+              has been in {{ $labels.health_status }} health status for more than 10 minutes.
+            alert_routing_key: krd-releng
+            team: releng

--- a/rhobs/alerting/konflux-release-data/prometheus.krd_argocd_tenant_config_alerts.yaml
+++ b/rhobs/alerting/konflux-release-data/prometheus.krd_argocd_tenant_config_alerts.yaml
@@ -49,8 +49,8 @@ spec:
             summary: >-
               Tenant-config ArgoCD app {{ $labels.name }} is OutOfSync for {{ $labels.dest_namespace }} namespace
             description: >-
-              ArgoCD application {{ $labels.name }} in {{ $labels.namespace }} namespace
-              has been OutOfSync for more than 10 minutes.
+              ArgoCD application {{ $labels.name }} in {{ $labels.namespace }} has been in OutOfSync health status
+              for more than 10 minutes.
             alert_routing_key: krd-releng
             team: releng
 
@@ -71,7 +71,7 @@ spec:
             summary: >-
               Tenant-config ArgoCD app {{ $labels.name }} has {{ $labels.health_status }} health for {{ $labels.dest_namespace }} namespace
             description: >-
-              ArgoCD application {{ $labels.name }} in {{ $labels.dest_namespace }} namespace
-              has been in {{ $labels.health_status }} health status for more than 10 minutes.
+              ArgoCD application {{ $labels.name }} in {{ $labels.namespace }} has been in
+              {{ $labels.health_status }} health status for more than 10 minutes.
             alert_routing_key: krd-releng
             team: releng

--- a/rhobs/alerting/konflux-release-data/prometheus.krd_monitoring_alerts.yaml
+++ b/rhobs/alerting/konflux-release-data/prometheus.krd_monitoring_alerts.yaml
@@ -19,6 +19,7 @@ spec:
           labels:
             severity: high
             slo: "false"
+            component: krd-monitoring
           annotations:
             summary: >-
               KRD GitLab Runner metrics are absent
@@ -37,6 +38,7 @@ spec:
           labels:
             severity: high
             slo: "false"
+            component: krd-monitoring
           annotations:
             summary: >-
               KRD pipeline exporter metrics are absent

--- a/rhobs/alerting/konflux-release-data/prometheus.krd_monitoring_alerts.yaml
+++ b/rhobs/alerting/konflux-release-data/prometheus.krd_monitoring_alerts.yaml
@@ -22,9 +22,9 @@ spec:
             component: krd-monitoring
           annotations:
             summary: >-
-              KRD GitLab Runner metrics are absent
+              KRD GitLab Runner metrics are absent in {{ $labels.namespace }}
             description: >-
-              No metrics received from the GitLab runner in namespace krd-gitlab-runner--pipeline for more than 10 minutes.
+              No metrics received from the GitLab runner in {{ $labels.namespace }} namespace for more than 10 minutes.
             alert_routing_key: o11y
             team: o11y
 
@@ -41,9 +41,9 @@ spec:
             component: krd-monitoring
           annotations:
             summary: >-
-              KRD pipeline exporter metrics are absent
+              KRD pipeline exporter metrics are absent in {{ $labels.namespace }}
             description: >-
-              No metrics received from the GitLab CI pipelines exporter in namespace krd-gitlab-runner--pipeline
+              No metrics received from the GitLab CI pipelines exporter in {{ $labels.namespace }} namespace
               for more than 10 minutes.
             alert_routing_key: o11y
             team: o11y

--- a/rhobs/alerting/konflux-release-data/prometheus.krd_monitoring_alerts.yaml
+++ b/rhobs/alerting/konflux-release-data/prometheus.krd_monitoring_alerts.yaml
@@ -1,0 +1,47 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-krd-monitoring-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: krd-monitoring
+      interval: 1m
+      rules:
+        - alert: KRDRunnerMetricsAbsent
+          expr: |
+            absent(up{
+              job="gitlab-runner",
+              namespace="krd-gitlab-runner--pipeline"
+            })
+          for: 10m
+          labels:
+            severity: high
+            slo: "false"
+          annotations:
+            summary: >-
+              KRD GitLab Runner metrics are absent
+            description: >-
+              No metrics received from the GitLab runner in namespace krd-gitlab-runner--pipeline for more than 10 minutes.
+            alert_routing_key: o11y
+            team: o11y
+
+        - alert: KRDPipelineExporterMetricsAbsent
+          expr: |
+            absent(up{
+              job="gitlab-ci-pipelines-exporter",
+              namespace="krd-gitlab-runner--pipeline"
+            })
+          for: 10m
+          labels:
+            severity: high
+            slo: "false"
+          annotations:
+            summary: >-
+              KRD pipeline exporter metrics are absent
+            description: >-
+              No metrics received from the GitLab CI pipelines exporter in namespace krd-gitlab-runner--pipeline
+              for more than 10 minutes.
+            alert_routing_key: o11y
+            team: o11y

--- a/rhobs/alerting/konflux-release-data/prometheus.krd_pipeline_alerts.yaml
+++ b/rhobs/alerting/konflux-release-data/prometheus.krd_pipeline_alerts.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-krd-pipeline-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: krd-pipeline-status
+      interval: 1m
+      rules:
+        - alert: KRDPipelineJobFailed
+          expr: |
+            gitlab_ci_pipeline_job_status{
+              namespace="krd-gitlab-runner--pipeline",
+              status="failed"
+            } == 1
+          for: 5m
+          labels:
+            severity: warning
+            slo: "false"
+            component: krd-pipeline
+          annotations:
+            summary: >-
+              KRD pipeline job {{ $labels.job_name }} is failing the {{ $labels.ref }} branch pipeline.
+            description: >-
+              GitLab CI job {{ $labels.job_name }} in project {{ $labels.project }} has been in failed status
+              for more than 5 minutes. Failure reason: {{ $labels.failure_reason }}.
+            alert_routing_key: krd-releng
+            team: releng

--- a/rhobs/alerting/konflux-release-data/prometheus.krd_runner_alerts.yaml
+++ b/rhobs/alerting/konflux-release-data/prometheus.krd_runner_alerts.yaml
@@ -21,9 +21,9 @@ spec:
             component: krd-gitlab-runner
           annotations:
             summary: >-
-              KRD GitLab Runner is down
+              KRD GitLab Runner is down in {{ $labels.namespace }}
             description: >-
-              No metrics received from the GitLab runner in namespace krd-gitlab-runner--pipeline
+              No metrics received from the GitLab runner in {{ $labels.namespace }} namespace
               for more than 10 minutes. The runner pod may be absent, crash looping, or not ready.
             alert_routing_key: krd-releng
             team: releng
@@ -33,6 +33,7 @@ spec:
       rules:
         - alert: KRDRunnerHighMemoryUsage
           expr: |
+            # Limits need to be hardcoded for now as the values are not available in the metrics
             process_resident_memory_bytes{
               namespace="krd-gitlab-runner--pipeline"
             } > 545259520 # 80% of 650Mi limit
@@ -53,6 +54,7 @@ spec:
 
         - alert: KRDRunnerHighCPUUsage
           expr: |
+            # Limits need to be hardcoded for now as the values are not available in the metrics
             rate(process_cpu_seconds_total{
               namespace="krd-gitlab-runner--pipeline"
             }[5m]) > 0.48 # 80% of 600m limit
@@ -74,11 +76,15 @@ spec:
     - name: krd-runner-jobs
       interval: 1m
       rules:
-        - alert: KRDRunnerJobFailureSpike
+        - alert: KRDRunnerJobFailureRateHigh
           expr: |
             increase(gitlab_runner_failed_jobs_total{
               namespace="krd-gitlab-runner--pipeline"
-            }[15m]) > 15
+            }[15m])
+            / increase(gitlab_runner_jobs_total{
+              namespace="krd-gitlab-runner--pipeline"
+            }[15m])
+            > 0.3
           for: 5m
           labels:
             severity: warning
@@ -86,9 +92,9 @@ spec:
             component: krd-gitlab-runner
           annotations:
             summary: >-
-              KRD GitLab Runner job failure spike.
+              KRD GitLab Runner job failure rate exceeds 30%.
             description: >-
-              More than 15 runner job failures in the last 15 minutes in {{ $labels.namespace }} namespace.
-              Failure reason: {{ $labels.failure_reason }}.
+              More than 30% of runner jobs have failed in the last 15 minutes
+              in {{ $labels.namespace }} namespace. Failure reason: {{ $labels.failure_reason }}.
             alert_routing_key: krd-releng
             team: releng

--- a/rhobs/alerting/konflux-release-data/prometheus.krd_runner_alerts.yaml
+++ b/rhobs/alerting/konflux-release-data/prometheus.krd_runner_alerts.yaml
@@ -1,0 +1,94 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-krd-runner-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: krd-runner-health
+      interval: 1m
+      rules:
+        - alert: KRDRunnerDown
+          expr: |
+            absent(gitlab_runner_concurrent{
+              namespace="krd-gitlab-runner--pipeline"
+            })
+          for: 10m
+          labels:
+            severity: warning
+            slo: "false"
+            component: krd-gitlab-runner
+          annotations:
+            summary: >-
+              KRD GitLab Runner is down
+            description: >-
+              No metrics received from the GitLab runner in namespace krd-gitlab-runner--pipeline
+              for more than 10 minutes. The runner pod may be absent, crash looping, or not ready.
+            alert_routing_key: krd-releng
+            team: releng
+
+    - name: krd-runner-resources
+      interval: 1m
+      rules:
+        - alert: KRDRunnerHighMemoryUsage
+          expr: |
+            process_resident_memory_bytes{
+              namespace="krd-gitlab-runner--pipeline"
+            } > 545259520
+          for: 30m
+          labels:
+            severity: warning
+            slo: "false"
+            component: krd-gitlab-runner
+          annotations:
+            summary: >-
+              KRD GitLab Runner memory usage exceeds 80% of limit on cluster {{ $labels.source_cluster }}
+            description: >-
+              The GitLab runner process in namespace {{ $labels.namespace }} on cluster
+              {{ $labels.source_cluster }} has been using more than 80% of its 650Mi memory limit
+              for 30 minutes.
+            alert_routing_key: krd-releng
+            team: releng
+
+        - alert: KRDRunnerHighCPUUsage
+          expr: |
+            rate(process_cpu_seconds_total{
+              namespace="krd-gitlab-runner--pipeline"
+            }[5m]) > 0.48
+          for: 30m
+          labels:
+            severity: warning
+            slo: "false"
+            component: krd-gitlab-runner
+          annotations:
+            summary: >-
+              KRD GitLab Runner CPU usage exceeds 80% of limit on cluster {{ $labels.source_cluster }}
+            description: >-
+              The GitLab runner process in namespace {{ $labels.namespace }} on cluster
+              {{ $labels.source_cluster }} has been using more than 80% of its 600m CPU limit
+              for 30 minutes.
+            alert_routing_key: krd-releng
+            team: releng
+
+    - name: krd-runner-jobs
+      interval: 1m
+      rules:
+        - alert: KRDRunnerJobFailureSpike
+          expr: |
+            increase(gitlab_runner_failed_jobs_total{
+              namespace="krd-gitlab-runner--pipeline"
+            }[15m]) > 15
+          for: 15m
+          labels:
+            severity: warning
+            slo: "false"
+            component: krd-gitlab-runner
+          annotations:
+            summary: >-
+              KRD GitLab Runner job failure spike.
+            description: >-
+              More than 15 runner job failures in the last 15 minutes in {{ $labels.namespace }} namespace.
+              Failure reason: {{ $labels.failure_reason }}.
+            alert_routing_key: krd-releng
+            team: releng

--- a/rhobs/alerting/konflux-release-data/prometheus.krd_runner_alerts.yaml
+++ b/rhobs/alerting/konflux-release-data/prometheus.krd_runner_alerts.yaml
@@ -35,7 +35,7 @@ spec:
           expr: |
             process_resident_memory_bytes{
               namespace="krd-gitlab-runner--pipeline"
-            } > 545259520
+            } > 545259520 # 80% of 650Mi limit
           for: 30m
           labels:
             severity: warning
@@ -55,7 +55,7 @@ spec:
           expr: |
             rate(process_cpu_seconds_total{
               namespace="krd-gitlab-runner--pipeline"
-            }[5m]) > 0.48
+            }[5m]) > 0.48 # 80% of 600m limit
           for: 30m
           labels:
             severity: warning
@@ -79,7 +79,7 @@ spec:
             increase(gitlab_runner_failed_jobs_total{
               namespace="krd-gitlab-runner--pipeline"
             }[15m]) > 15
-          for: 15m
+          for: 5m
           labels:
             severity: warning
             slo: "false"

--- a/scripts/check-alert-conventions.py
+++ b/scripts/check-alert-conventions.py
@@ -4,10 +4,7 @@ import glob
 import sys
 import yaml
 
-ALERT_DIRS = [
-    "rhobs/alerting/data_plane",
-    "rhobs/alerting/konflux-release-data",
-]
+ALERT_DIR = "rhobs/alerting"
 VALID_SEVERITIES = {"critical", "high", "warning", "info"}
 
 def check_rules(path):
@@ -32,13 +29,9 @@ def check_rules(path):
     return errors
 
 def main():
-    files = []
-    for alert_dir in ALERT_DIRS:
-        files.extend(glob.glob(f"{alert_dir}/**/*.yaml", recursive=True))
-        files.extend(glob.glob(f"{alert_dir}/*.yaml"))
-    files = sorted(set(files))
+    files = sorted(glob.glob(f"{ALERT_DIR}/**/*.yaml", recursive=True))
     if not files:
-        print(f"No alert files found in {ALERT_DIRS}")
+        print(f"No alert files found in {ALERT_DIR}/")
         sys.exit(1)
 
     all_errors = []

--- a/scripts/check-alert-conventions.py
+++ b/scripts/check-alert-conventions.py
@@ -4,7 +4,10 @@ import glob
 import sys
 import yaml
 
-ALERT_DIR = "rhobs/alerting/data_plane"
+ALERT_DIRS = [
+    "rhobs/alerting/data_plane",
+    "rhobs/alerting/konflux-release-data",
+]
 VALID_SEVERITIES = {"critical", "high", "warning", "info"}
 
 def check_rules(path):
@@ -29,9 +32,13 @@ def check_rules(path):
     return errors
 
 def main():
-    files = sorted(glob.glob(f"{ALERT_DIR}/*.yaml"))
+    files = []
+    for alert_dir in ALERT_DIRS:
+        files.extend(glob.glob(f"{alert_dir}/**/*.yaml", recursive=True))
+        files.extend(glob.glob(f"{alert_dir}/*.yaml"))
+    files = sorted(set(files))
     if not files:
-        print(f"No alert files found in {ALERT_DIR}/")
+        print(f"No alert files found in {ALERT_DIRS}")
         sys.exit(1)
 
     all_errors = []

--- a/test/promql/tests/konflux-release-data/krd_argocd_tenant_config_alerts_test.yaml
+++ b/test/promql/tests/konflux-release-data/krd_argocd_tenant_config_alerts_test.yaml
@@ -98,7 +98,7 @@ tests:
               summary: >-
                 Tenant-config ArgoCD app tenants-config-stone-prd-rh01 is OutOfSync for stone-prd-rh01-tenant namespace
               description: >-
-                ArgoCD application tenants-config-stone-prd-rh01 in konflux-tenants-config namespace has been OutOfSync for more than 10 minutes.
+                ArgoCD application tenants-config-stone-prd-rh01 in konflux-tenants-config has been in OutOfSync health status for more than 10 minutes.
               alert_routing_key: krd-releng
               team: releng
 
@@ -136,7 +136,7 @@ tests:
               summary: >-
                 Tenant-config ArgoCD app missing-app has Missing health for missing-tenant namespace
               description: >-
-                ArgoCD application missing-app in missing-tenant namespace has been in Missing health status for more than 10 minutes.
+                ArgoCD application missing-app in konflux-tenants-config has been in Missing health status for more than 10 minutes.
               alert_routing_key: krd-releng
               team: releng
           - exp_labels:
@@ -154,6 +154,6 @@ tests:
               summary: >-
                 Tenant-config ArgoCD app unknown-app has Unknown health for unknown-tenant namespace
               description: >-
-                ArgoCD application unknown-app in unknown-tenant namespace has been in Unknown health status for more than 10 minutes.
+                ArgoCD application unknown-app in konflux-tenants-config-stage has been in Unknown health status for more than 10 minutes.
               alert_routing_key: krd-releng
               team: releng

--- a/test/promql/tests/konflux-release-data/krd_argocd_tenant_config_alerts_test.yaml
+++ b/test/promql/tests/konflux-release-data/krd_argocd_tenant_config_alerts_test.yaml
@@ -1,0 +1,159 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.krd_argocd_tenant_config_alerts.yaml
+
+tests:
+  # ==================== KRDTenantConfigAppDegraded ====================
+  - interval: 1m
+    input_series:
+      # Degraded app in tenant-config namespace — should fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="infra-deployments-stone-prd-rh01", health_status="Degraded", sync_status="Synced", dest_namespace="stone-prd-rh01-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+        values: "1x15"
+
+      # Degraded app in stage namespace — should fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config-stage", name="infra-deployments-stone-stg-rh01", health_status="Degraded", sync_status="Synced", dest_namespace="stone-stg-rh01-tenant", dest_server="https://api.stone-stg-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+        values: "1x15"
+
+      # Healthy app — should NOT fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="healthy-app", health_status="Healthy", sync_status="Synced", dest_namespace="healthy-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+        values: "1x15"
+
+      # Degraded app in different namespace — should NOT fire
+      - series: 'argocd_app_info{namespace="argocd", name="other-app", health_status="Degraded", sync_status="Synced", dest_namespace="other-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+        values: "1x15"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: KRDTenantConfigAppDegraded
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: krd-tenants-config
+              namespace: konflux-tenants-config
+              name: infra-deployments-stone-prd-rh01
+              health_status: Degraded
+              sync_status: Synced
+              dest_namespace: stone-prd-rh01-tenant
+              dest_server: "https://api.stone-prd-rh01.example.com:6443"
+              source_cluster: appsres09ue1
+            exp_annotations:
+              summary: >-
+                Tenant-config ArgoCD app infra-deployments-stone-prd-rh01 is degraded for stone-prd-rh01-tenant namespace
+              description: >-
+                ArgoCD application infra-deployments-stone-prd-rh01 in konflux-tenants-config has been in Degraded health status for more than 10 minutes.
+              alert_routing_key: krd-releng
+              team: releng
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: krd-tenants-config
+              namespace: konflux-tenants-config-stage
+              name: infra-deployments-stone-stg-rh01
+              health_status: Degraded
+              sync_status: Synced
+              dest_namespace: stone-stg-rh01-tenant
+              dest_server: "https://api.stone-stg-rh01.example.com:6443"
+              source_cluster: appsres09ue1
+            exp_annotations:
+              summary: >-
+                Tenant-config ArgoCD app infra-deployments-stone-stg-rh01 is degraded for stone-stg-rh01-tenant namespace
+              description: >-
+                ArgoCD application infra-deployments-stone-stg-rh01 in konflux-tenants-config-stage has been in Degraded health status for more than 10 minutes.
+              alert_routing_key: krd-releng
+              team: releng
+
+  # ==================== KRDTenantConfigAppOutOfSync ====================
+  - interval: 1m
+    input_series:
+      # Healthy but OutOfSync — should fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="tenants-config-stone-prd-rh01", health_status="Healthy", sync_status="OutOfSync", dest_namespace="stone-prd-rh01-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+        values: "1x15"
+
+      # Healthy and Synced — should NOT fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="synced-app", health_status="Healthy", sync_status="Synced", dest_namespace="synced-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+        values: "1x15"
+
+      # Degraded and OutOfSync — should NOT fire (only Healthy+OutOfSync)
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="degraded-oos-app", health_status="Degraded", sync_status="OutOfSync", dest_namespace="degraded-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+        values: "1x15"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: KRDTenantConfigAppOutOfSync
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: krd-tenants-config
+              namespace: konflux-tenants-config
+              name: tenants-config-stone-prd-rh01
+              health_status: Healthy
+              sync_status: OutOfSync
+              dest_namespace: stone-prd-rh01-tenant
+              dest_server: "https://api.stone-prd-rh01.example.com:6443"
+              source_cluster: appsres09ue1
+            exp_annotations:
+              summary: >-
+                Tenant-config ArgoCD app tenants-config-stone-prd-rh01 is OutOfSync for stone-prd-rh01-tenant namespace
+              description: >-
+                ArgoCD application tenants-config-stone-prd-rh01 in konflux-tenants-config namespace has been OutOfSync for more than 10 minutes.
+              alert_routing_key: krd-releng
+              team: releng
+
+  # ==================== KRDTenantConfigAppMissingOrUnknown ====================
+  - interval: 1m
+    input_series:
+      # Missing health status — should fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="missing-app", health_status="Missing", sync_status="Synced", dest_namespace="missing-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+        values: "1x15"
+
+      # Unknown health status in stage — should fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config-stage", name="unknown-app", health_status="Unknown", sync_status="Synced", dest_namespace="unknown-tenant", dest_server="https://api.stone-stg-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+        values: "1x15"
+
+      # Healthy app — should NOT fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="healthy-app", health_status="Healthy", sync_status="Synced", dest_namespace="healthy-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+        values: "1x15"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: KRDTenantConfigAppMissingOrUnknown
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: krd-tenants-config
+              namespace: konflux-tenants-config
+              name: missing-app
+              health_status: Missing
+              sync_status: Synced
+              dest_namespace: missing-tenant
+              dest_server: "https://api.stone-prd-rh01.example.com:6443"
+              source_cluster: appsres09ue1
+            exp_annotations:
+              summary: >-
+                Tenant-config ArgoCD app missing-app has Missing health for missing-tenant namespace
+              description: >-
+                ArgoCD application missing-app in missing-tenant namespace has been in Missing health status for more than 10 minutes.
+              alert_routing_key: krd-releng
+              team: releng
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: krd-tenants-config
+              namespace: konflux-tenants-config-stage
+              name: unknown-app
+              health_status: Unknown
+              sync_status: Synced
+              dest_namespace: unknown-tenant
+              dest_server: "https://api.stone-stg-rh01.example.com:6443"
+              source_cluster: appsres09ue1
+            exp_annotations:
+              summary: >-
+                Tenant-config ArgoCD app unknown-app has Unknown health for unknown-tenant namespace
+              description: >-
+                ArgoCD application unknown-app in unknown-tenant namespace has been in Unknown health status for more than 10 minutes.
+              alert_routing_key: krd-releng
+              team: releng

--- a/test/promql/tests/konflux-release-data/krd_monitoring_alerts_test.yaml
+++ b/test/promql/tests/konflux-release-data/krd_monitoring_alerts_test.yaml
@@ -21,9 +21,9 @@ tests:
               namespace: krd-gitlab-runner--pipeline
             exp_annotations:
               summary: >-
-                KRD GitLab Runner metrics are absent
+                KRD GitLab Runner metrics are absent in krd-gitlab-runner--pipeline
               description: >-
-                No metrics received from the GitLab runner in namespace krd-gitlab-runner--pipeline for more than 10 minutes.
+                No metrics received from the GitLab runner in krd-gitlab-runner--pipeline namespace for more than 10 minutes.
               alert_routing_key: o11y
               team: o11y
 
@@ -55,9 +55,9 @@ tests:
               namespace: krd-gitlab-runner--pipeline
             exp_annotations:
               summary: >-
-                KRD pipeline exporter metrics are absent
+                KRD pipeline exporter metrics are absent in krd-gitlab-runner--pipeline
               description: >-
-                No metrics received from the GitLab CI pipelines exporter in namespace krd-gitlab-runner--pipeline for more than 10 minutes.
+                No metrics received from the GitLab CI pipelines exporter in krd-gitlab-runner--pipeline namespace for more than 10 minutes.
               alert_routing_key: o11y
               team: o11y
 

--- a/test/promql/tests/konflux-release-data/krd_monitoring_alerts_test.yaml
+++ b/test/promql/tests/konflux-release-data/krd_monitoring_alerts_test.yaml
@@ -16,6 +16,7 @@ tests:
           - exp_labels:
               severity: high
               slo: "false"
+              component: krd-monitoring
               job: gitlab-runner
               namespace: krd-gitlab-runner--pipeline
             exp_annotations:
@@ -49,6 +50,7 @@ tests:
           - exp_labels:
               severity: high
               slo: "false"
+              component: krd-monitoring
               job: gitlab-ci-pipelines-exporter
               namespace: krd-gitlab-runner--pipeline
             exp_annotations:

--- a/test/promql/tests/konflux-release-data/krd_monitoring_alerts_test.yaml
+++ b/test/promql/tests/konflux-release-data/krd_monitoring_alerts_test.yaml
@@ -1,0 +1,71 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.krd_monitoring_alerts.yaml
+
+tests:
+  # ==================== KRDRunnerMetricsAbsent ====================
+  # No runner up metric — should fire
+  - interval: 1m
+    input_series: []
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: KRDRunnerMetricsAbsent
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              slo: "false"
+              job: gitlab-runner
+              namespace: krd-gitlab-runner--pipeline
+            exp_annotations:
+              summary: >-
+                KRD GitLab Runner metrics are absent
+              description: >-
+                No metrics received from the GitLab runner in namespace krd-gitlab-runner--pipeline for more than 10 minutes.
+              alert_routing_key: o11y
+              team: o11y
+
+  # Runner up metric present — should NOT fire
+  - interval: 1m
+    input_series:
+      - series: 'up{job="gitlab-runner", namespace="krd-gitlab-runner--pipeline", source_cluster="cluster01"}'
+        values: "1x15"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: KRDRunnerMetricsAbsent
+        exp_alerts: []
+
+  # ==================== KRDPipelineExporterMetricsAbsent ====================
+  # No exporter up metric — should fire
+  - interval: 1m
+    input_series: []
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: KRDPipelineExporterMetricsAbsent
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              slo: "false"
+              job: gitlab-ci-pipelines-exporter
+              namespace: krd-gitlab-runner--pipeline
+            exp_annotations:
+              summary: >-
+                KRD pipeline exporter metrics are absent
+              description: >-
+                No metrics received from the GitLab CI pipelines exporter in namespace krd-gitlab-runner--pipeline for more than 10 minutes.
+              alert_routing_key: o11y
+              team: o11y
+
+  # Exporter up metric present — should NOT fire
+  - interval: 1m
+    input_series:
+      - series: 'up{job="gitlab-ci-pipelines-exporter", namespace="krd-gitlab-runner--pipeline", source_cluster="cluster01"}'
+        values: "1x15"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: KRDPipelineExporterMetricsAbsent
+        exp_alerts: []

--- a/test/promql/tests/konflux-release-data/krd_pipeline_alerts_test.yaml
+++ b/test/promql/tests/konflux-release-data/krd_pipeline_alerts_test.yaml
@@ -1,0 +1,43 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.krd_pipeline_alerts.yaml
+
+tests:
+  # ==================== KRDPipelineJobFailed ====================
+  - interval: 1m
+    input_series:
+      # Job in failed status — should fire
+      - series: 'gitlab_ci_pipeline_job_status{namespace="krd-gitlab-runner--pipeline", project="konflux-release-data", ref="main", job_name="test", status="failed", failure_reason="script_failure", source_cluster="cluster01"}'
+        values: "1x10"
+
+      # Job in success status — should NOT fire
+      - series: 'gitlab_ci_pipeline_job_status{namespace="krd-gitlab-runner--pipeline", project="konflux-release-data", ref="main", job_name="build", status="success", failure_reason="", source_cluster="cluster01"}'
+        values: "1x10"
+
+      # Failed job in different namespace — should NOT fire
+      - series: 'gitlab_ci_pipeline_job_status{namespace="other-namespace", project="other-project", ref="main", job_name="deploy", status="failed", failure_reason="script_failure", source_cluster="cluster01"}'
+        values: "1x10"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: KRDPipelineJobFailed
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: krd-pipeline
+              namespace: krd-gitlab-runner--pipeline
+              project: konflux-release-data
+              ref: main
+              job_name: test
+              status: failed
+              failure_reason: script_failure
+              source_cluster: cluster01
+            exp_annotations:
+              summary: >-
+                KRD pipeline job test is failing the main branch pipeline.
+              description: >-
+                GitLab CI job test in project konflux-release-data has been in failed status for more than 5 minutes. Failure reason: script_failure.
+              alert_routing_key: krd-releng
+              team: releng

--- a/test/promql/tests/konflux-release-data/krd_runner_alerts_test.yaml
+++ b/test/promql/tests/konflux-release-data/krd_runner_alerts_test.yaml
@@ -1,0 +1,126 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.krd_runner_alerts.yaml
+
+tests:
+  # ==================== KRDRunnerDown ====================
+  # No runner metrics — should fire
+  - interval: 1m
+    input_series: []
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: KRDRunnerDown
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: krd-gitlab-runner
+              namespace: krd-gitlab-runner--pipeline
+            exp_annotations:
+              summary: >-
+                KRD GitLab Runner is down
+              description: >-
+                No metrics received from the GitLab runner in namespace krd-gitlab-runner--pipeline for more than 10 minutes. The runner pod may be absent, crash looping, or not ready.
+              alert_routing_key: krd-releng
+              team: releng
+
+  # Runner metrics present — should NOT fire
+  - interval: 1m
+    input_series:
+      - series: 'gitlab_runner_concurrent{namespace="krd-gitlab-runner--pipeline", source_cluster="cluster01"}'
+        values: "60x15"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: KRDRunnerDown
+        exp_alerts: []
+
+  # ==================== KRDRunnerHighMemoryUsage ====================
+  - interval: 1m
+    input_series:
+      # Memory at 90% of 650Mi (~613Mi = 643825664 bytes) — should fire
+      - series: 'process_resident_memory_bytes{namespace="krd-gitlab-runner--pipeline", source_cluster="cluster01"}'
+        values: "643825664x35"
+
+      # Memory at 50% of 650Mi (~325Mi) — should NOT fire
+      - series: 'process_resident_memory_bytes{namespace="krd-gitlab-runner--pipeline", source_cluster="cluster02"}'
+        values: "340787200x35"
+
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: KRDRunnerHighMemoryUsage
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: krd-gitlab-runner
+              namespace: krd-gitlab-runner--pipeline
+              source_cluster: cluster01
+            exp_annotations:
+              summary: >-
+                KRD GitLab Runner memory usage exceeds 80% of limit on cluster cluster01
+              description: >-
+                The GitLab runner process in namespace krd-gitlab-runner--pipeline on cluster cluster01 has been using more than 80% of its 650Mi memory limit for 30 minutes.
+              alert_routing_key: krd-releng
+              team: releng
+
+  # ==================== KRDRunnerHighCPUUsage ====================
+  - interval: 1m
+    input_series:
+      # CPU usage above 0.48 (80% of 600m) — rate of 0.5 per second
+      - series: 'process_cpu_seconds_total{namespace="krd-gitlab-runner--pipeline", source_cluster="cluster01"}'
+        values: "0+30x35"
+
+      # CPU usage below threshold — rate of 0.2 per second
+      - series: 'process_cpu_seconds_total{namespace="krd-gitlab-runner--pipeline", source_cluster="cluster02"}'
+        values: "0+12x35"
+
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: KRDRunnerHighCPUUsage
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: krd-gitlab-runner
+              namespace: krd-gitlab-runner--pipeline
+              source_cluster: cluster01
+            exp_annotations:
+              summary: >-
+                KRD GitLab Runner CPU usage exceeds 80% of limit on cluster cluster01
+              description: >-
+                The GitLab runner process in namespace krd-gitlab-runner--pipeline on cluster cluster01 has been using more than 80% of its 600m CPU limit for 30 minutes.
+              alert_routing_key: krd-releng
+              team: releng
+
+  # ==================== KRDRunnerJobFailureSpike ====================
+  - interval: 1m
+    input_series:
+      # 20 failures in 15 minutes — should fire (threshold > 15)
+      - series: 'gitlab_runner_failed_jobs_total{namespace="krd-gitlab-runner--pipeline", failure_reason="script_failure", source_cluster="cluster01"}'
+        values: "0+2x35"
+
+      # Only 5 failures in 15 minutes — should NOT fire
+      - series: 'gitlab_runner_failed_jobs_total{namespace="krd-gitlab-runner--pipeline", failure_reason="runner_system_failure", source_cluster="cluster01"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 2 2 2 2 2 3 3 3 3 3 4 4 4 4 4 5 5 5 5 5"
+
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: KRDRunnerJobFailureSpike
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: krd-gitlab-runner
+              namespace: krd-gitlab-runner--pipeline
+              failure_reason: script_failure
+              source_cluster: cluster01
+            exp_annotations:
+              summary: >-
+                KRD GitLab Runner job failure spike.
+              description: >-
+                More than 15 runner job failures in the last 15 minutes in krd-gitlab-runner--pipeline namespace. Failure reason: script_failure.
+              alert_routing_key: krd-releng
+              team: releng

--- a/test/promql/tests/konflux-release-data/krd_runner_alerts_test.yaml
+++ b/test/promql/tests/konflux-release-data/krd_runner_alerts_test.yaml
@@ -20,9 +20,9 @@ tests:
               namespace: krd-gitlab-runner--pipeline
             exp_annotations:
               summary: >-
-                KRD GitLab Runner is down
+                KRD GitLab Runner is down in krd-gitlab-runner--pipeline
               description: >-
-                No metrics received from the GitLab runner in namespace krd-gitlab-runner--pipeline for more than 10 minutes. The runner pod may be absent, crash looping, or not ready.
+                No metrics received from the GitLab runner in krd-gitlab-runner--pipeline namespace for more than 10 minutes. The runner pod may be absent, crash looping, or not ready.
               alert_routing_key: krd-releng
               team: releng
 
@@ -106,20 +106,18 @@ tests:
         alertname: KRDRunnerHighCPUUsage
         exp_alerts: []
 
-  # ==================== KRDRunnerJobFailureSpike ====================
+  # ==================== KRDRunnerJobFailureRateHigh ====================
+  # 50% failure rate (5 failed out of 10 total) — should fire (threshold > 30%)
   - interval: 1m
     input_series:
-      # 20 failures in 15 minutes — should fire (threshold > 15)
       - series: 'gitlab_runner_failed_jobs_total{namespace="krd-gitlab-runner--pipeline", failure_reason="script_failure", source_cluster="cluster01"}'
+        values: "0+1x25"
+      - series: 'gitlab_runner_jobs_total{namespace="krd-gitlab-runner--pipeline", failure_reason="script_failure", source_cluster="cluster01"}'
         values: "0+2x25"
-
-      # Only 5 failures in 15 minutes — should NOT fire
-      - series: 'gitlab_runner_failed_jobs_total{namespace="krd-gitlab-runner--pipeline", failure_reason="runner_system_failure", source_cluster="cluster01"}'
-        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 2 2 2 2 2 3 3 3 3 3"
 
     alert_rule_test:
       - eval_time: 20m
-        alertname: KRDRunnerJobFailureSpike
+        alertname: KRDRunnerJobFailureRateHigh
         exp_alerts:
           - exp_labels:
               severity: warning
@@ -130,8 +128,34 @@ tests:
               source_cluster: cluster01
             exp_annotations:
               summary: >-
-                KRD GitLab Runner job failure spike.
+                KRD GitLab Runner job failure rate exceeds 30%.
               description: >-
-                More than 15 runner job failures in the last 15 minutes in krd-gitlab-runner--pipeline namespace. Failure reason: script_failure.
+                More than 30% of runner jobs have failed in the last 15 minutes in krd-gitlab-runner--pipeline namespace. Failure reason: script_failure.
               alert_routing_key: krd-releng
               team: releng
+
+  # 10% failure rate (1 failed out of 10 total) — should NOT fire
+  - interval: 1m
+    input_series:
+      - series: 'gitlab_runner_failed_jobs_total{namespace="krd-gitlab-runner--pipeline", failure_reason="script_failure", source_cluster="cluster02"}'
+        values: "0+1x25"
+      - series: 'gitlab_runner_jobs_total{namespace="krd-gitlab-runner--pipeline", failure_reason="script_failure", source_cluster="cluster02"}'
+        values: "0+10x25"
+
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KRDRunnerJobFailureRateHigh
+        exp_alerts: []
+
+  # No jobs running (0 total) — should NOT fire
+  - interval: 1m
+    input_series:
+      - series: 'gitlab_runner_failed_jobs_total{namespace="krd-gitlab-runner--pipeline", failure_reason="script_failure", source_cluster="cluster03"}'
+        values: "0x25"
+      - series: 'gitlab_runner_jobs_total{namespace="krd-gitlab-runner--pipeline", failure_reason="script_failure", source_cluster="cluster03"}'
+        values: "0x25"
+
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KRDRunnerJobFailureRateHigh
+        exp_alerts: []

--- a/test/promql/tests/konflux-release-data/krd_runner_alerts_test.yaml
+++ b/test/promql/tests/konflux-release-data/krd_runner_alerts_test.yaml
@@ -95,19 +95,30 @@ tests:
               alert_routing_key: krd-releng
               team: releng
 
+  # CPU spike lasting only 15 minutes then dropping — should NOT fire (for: 30m)
+  - interval: 1m
+    input_series:
+      - series: 'process_cpu_seconds_total{namespace="krd-gitlab-runner--pipeline", source_cluster="cluster03"}'
+        values: "0+30x15 450+12x20"
+
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: KRDRunnerHighCPUUsage
+        exp_alerts: []
+
   # ==================== KRDRunnerJobFailureSpike ====================
   - interval: 1m
     input_series:
       # 20 failures in 15 minutes — should fire (threshold > 15)
       - series: 'gitlab_runner_failed_jobs_total{namespace="krd-gitlab-runner--pipeline", failure_reason="script_failure", source_cluster="cluster01"}'
-        values: "0+2x35"
+        values: "0+2x25"
 
       # Only 5 failures in 15 minutes — should NOT fire
       - series: 'gitlab_runner_failed_jobs_total{namespace="krd-gitlab-runner--pipeline", failure_reason="runner_system_failure", source_cluster="cluster01"}'
-        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 2 2 2 2 2 3 3 3 3 3 4 4 4 4 4 5 5 5 5 5"
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 2 2 2 2 2 3 3 3 3 3"
 
     alert_rule_test:
-      - eval_time: 30m
+      - eval_time: 20m
         alertname: KRDRunnerJobFailureSpike
         exp_alerts:
           - exp_labels:


### PR DESCRIPTION


### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

Adds 10 alerts divided into 4 groups. Runner, ArgoCD tenant-configs, pipeline, and monitoring alerts - all routed to new #konflux-releng-alerts channel via the "krd-.*" component label prefix.

Monitoring alerts (metric forwarding health) are owned by o11y but routed to the same channel for visibility.

Everything is "TBD" fully before going to production and being handed over to relengs so changes might still be needed.

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [X] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [X] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [X] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [x] **Pipeline Finished Successfully**

---

### Deployment Notice

- [X] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
