### PR TITLE
Update kueue alerts and tests for KueueHighAdmissionWaitTimePreMerge 

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -217,7 +217,7 @@ spec:
           cluster_queue="cluster-pipeline-queue",
           priority_class=~"konflux-pre-merge-.*"
         }[10m])) by (le, source_cluster)) > 900
-      for: 5m
+      for: 40m
       labels:
         severity: high
         component: kueue

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -3,6 +3,7 @@ rule_files:
   - 'prometheus.kueue_alerts.yaml'
 
 tests:
+  # KueueHighAdmissionWaitTimeMintmaker - should fire: 99th percentile wait time above 12h
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-dependency-update", le="43200", source_cluster="c1"}'
@@ -26,13 +27,14 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
+  # KueueHighAdmissionWaitTimePreMerge - should fire: 99th percentile wait time above 15m for 40m
   - interval: 1m
     input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue",priority_class="konflux-pre-merge-test",le="900",source_cluster="c1"}'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="900", source_cluster="c1"}'
         values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue",priority_class="konflux-pre-merge-test",le="1000",source_cluster="c1"}'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1000", source_cluster="c1"}'
         values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue",priority_class="konflux-pre-merge-test",le="+Inf",source_cluster="c1"}'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="c1"}'
         values: '0+10x60'
     alert_rule_test:
       - eval_time: 45m
@@ -49,6 +51,21 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
+  # KueueHighAdmissionWaitTimePreMerge - should NOT fire: eval time (35m) is less than 'for' duration (40m)
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="900", source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1000", source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="c1"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: KueueHighAdmissionWaitTimePreMerge
+        exp_alerts: []
+
+  # KueueHighAdmissionWaitTimePostMerge - should fire: 99th percentile wait time above 15m
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="900", source_cluster="c1"}'
@@ -72,6 +89,7 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
+  # TektonKueuePodsCrashLoopBackOff - should fire: pod in CrashLoopBackOff
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="CrashLoopBackOff", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
@@ -95,6 +113,7 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
+  # TektonKueuePodsCrashLoopBackOff - should NOT fire: pod not in CrashLoopBackOff
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="CrashLoopBackOff", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
@@ -104,6 +123,7 @@ tests:
         alertname: TektonKueuePodsCrashLoopBackOff
         exp_alerts: []
 
+  # TektonKueueRolloutStuck - should fire: rollout stuck for 20m
   - interval: 1m
     input_series:
       - series: 'kube_deployment_spec_replicas{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
@@ -127,6 +147,7 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
+  # TektonKueueRolloutStuck - should NOT fire: replicas updated matches spec
   - interval: 1m
     input_series:
       - series: 'kube_deployment_spec_replicas{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
@@ -138,6 +159,7 @@ tests:
         alertname: TektonKueueRolloutStuck
         exp_alerts: []
 
+  # TektonKueuePodStuckInPending - should fire: pod in Pending for 5m
   - interval: 1m
     input_series:
       - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
@@ -159,6 +181,7 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
+  # TektonKueuePodStuckInPending - should NOT fire: pod not in Pending
   - interval: 1m
     input_series:
       - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
@@ -168,6 +191,7 @@ tests:
         alertname: TektonKueuePodStuckInPending
         exp_alerts: []
 
+  # TektonKueuePodStuckInPending - should NOT fire: eval time (4m) is less than 'for' duration (5m)
   - interval: 1m
     input_series:
       - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
@@ -177,6 +201,7 @@ tests:
         alertname: TektonKueuePodStuckInPending
         exp_alerts: []
 
+  # TektonKueuePodStuckInCreation - should fire: pod in ContainerCreating for 5m
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="ContainerCreating", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
@@ -199,6 +224,7 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
+  # TektonKueuePodStuckInCreation - should NOT fire: pod not in ContainerCreating
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="ContainerCreating", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
@@ -208,6 +234,7 @@ tests:
         alertname: TektonKueuePodStuckInCreation
         exp_alerts: []
 
+  # TektonKueuePodOOMKilled - should fire: pod OOMKilled
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_restarts_total{namespace="tekton-kueue", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
@@ -232,6 +259,7 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
+  # TektonKueuePodOOMKilled - should NOT fire: pod not OOMKilled
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_restarts_total{namespace="tekton-kueue", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
@@ -243,6 +271,7 @@ tests:
         alertname: TektonKueuePodOOMKilled
         exp_alerts: []
 
+  # TektonKueueRolloutStuck - should NOT fire: eval time (10m) is less than 'for' duration (20m)
   - interval: 1m
     input_series:
       - series: 'kube_deployment_spec_replicas{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -28,14 +28,14 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="900", source_cluster="c1"}'
-        values: '0+0x20'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1000", source_cluster="c1"}'
-        values: '0+0x20'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="c1"}'
-        values: '0 10 20 30 40 50 60 70 80 90 100'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue",priority_class="konflux-pre-merge-test",le="900",source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue",priority_class="konflux-pre-merge-test",le="1000",source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue",priority_class="konflux-pre-merge-test",le="+Inf",source_cluster="c1"}'
+        values: '0+10x60'
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 45m
         alertname: KueueHighAdmissionWaitTimePreMerge
         exp_alerts:
           - exp_labels:
@@ -72,7 +72,6 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # TektonKueuePodsCrashLoopBackOff - should fire: pod in CrashLoopBackOff for 3m
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="CrashLoopBackOff", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
@@ -96,7 +95,6 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # TektonKueuePodsCrashLoopBackOff - should NOT fire: no CrashLoopBackOff pods
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="CrashLoopBackOff", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
@@ -106,7 +104,6 @@ tests:
         alertname: TektonKueuePodsCrashLoopBackOff
         exp_alerts: []
 
-  # TektonKueueRolloutStuck - should fire: updated < desired for 20m
   - interval: 1m
     input_series:
       - series: 'kube_deployment_spec_replicas{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
@@ -130,7 +127,6 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # TektonKueueRolloutStuck - should NOT fire: updated == desired (healthy)
   - interval: 1m
     input_series:
       - series: 'kube_deployment_spec_replicas{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
@@ -142,7 +138,6 @@ tests:
         alertname: TektonKueueRolloutStuck
         exp_alerts: []
 
-  # TektonKueuePodStuckInPending - should fire: pod in Pending for 5m
   - interval: 1m
     input_series:
       - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
@@ -164,7 +159,6 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # TektonKueuePodStuckInPending - should NOT fire: pod not in Pending
   - interval: 1m
     input_series:
       - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
@@ -174,7 +168,6 @@ tests:
         alertname: TektonKueuePodStuckInPending
         exp_alerts: []
 
-  # TektonKueuePodStuckInPending - should NOT fire at 4m: for: 5m not yet satisfied
   - interval: 1m
     input_series:
       - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
@@ -184,7 +177,6 @@ tests:
         alertname: TektonKueuePodStuckInPending
         exp_alerts: []
 
-  # TektonKueuePodStuckInCreation - should fire: container in ContainerCreating for 5m
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="ContainerCreating", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
@@ -207,7 +199,6 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # TektonKueuePodStuckInCreation - should NOT fire: no containers in ContainerCreating
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="ContainerCreating", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
@@ -217,7 +208,6 @@ tests:
         alertname: TektonKueuePodStuckInCreation
         exp_alerts: []
 
-  # TektonKueuePodOOMKilled - should fire: restart occurred and last terminated reason is OOMKilled
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_restarts_total{namespace="tekton-kueue", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
@@ -242,7 +232,6 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # TektonKueuePodOOMKilled - should NOT fire: no restarts occurred
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_restarts_total{namespace="tekton-kueue", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
@@ -254,7 +243,6 @@ tests:
         alertname: TektonKueuePodOOMKilled
         exp_alerts: []
 
-  # TektonKueueRolloutStuck - should NOT fire at 10m: condition true but for: 20m not yet satisfied
   - interval: 1m
     input_series:
       - series: 'kube_deployment_spec_replicas{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'


### PR DESCRIPTION
from this :
https://redhat-internal.slack.com/archives/C04FDFTF8EB/p1780226759924959
and
https://redhat-internal.slack.com/archives/C04F4NE15U1/p1780305384428709

Description
Changes:
Increased the for duration for the KueueHighAdmissionWaitTimePreMerge alert from 5m to 40m.

Updated the corresponding unit tests in kueue_alerts_test.yaml to match the new duration and ensure correct evaluation time for the alert.

Why:
The previous duration was too short, leading to excessive alerting on transient spikes. Increasing the threshold to 40 minutes ensures that the alert triggers only during sustained periods of high admission wait times, reducing noise and aligning with operational requirements.

Pre-Submission Checklist
[x] Jira Ticket: SPRE 5382
https://redhat.atlassian.net/browse/SPRE-5382

[x] Alert Tests: Modified existing tests to cover the new for duration.

[x] SOP / Runbook: No changes required to the existing runbook (/infra/queue/queue.md).

[x] Dashboards Addition: N/A (Alert only).

[x] Contribution Guides: Yes, followed the guidelines.

[x] Pipeline Finished Successfully

Deployment Notice
[x] Production Deployment: I understand that updating app-interface with the new commit reference is required for production deployment.