### PR TITLE
Fix KueueHighAdmissionWaitTimePostMerge alert duration to 45m

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -234,7 +234,7 @@ spec:
           cluster_queue="cluster-pipeline-queue",
           priority_class=~"konflux-post-merge-.*"
         }[10m])) by (le, source_cluster)) > 900
-      for: 5m
+      for: 45m
       labels:
         severity: high
         component: kueue

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -65,7 +65,7 @@ tests:
         alertname: KueueHighAdmissionWaitTimePreMerge
         exp_alerts: []
 
-  # KueueHighAdmissionWaitTimePostMerge - should fire: 99th percentile wait time above 15m
+  # KueueHighAdmissionWaitTimePostMerge - should fire: 99th percentile wait time above 15m for 45m
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="900", source_cluster="c1"}'
@@ -88,6 +88,20 @@ tests:
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
               alert_routing_key: infra
               team: konflux-infra
+
+  # KueueHighAdmissionWaitTimePostMerge - should NOT fire: eval time (40m) is less than 'for' duration (45m)
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="900", source_cluster="c1"}'
+        values: '0+0x70'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1000", source_cluster="c1"}'
+        values: '0+0x70'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="c1"}'
+        values: '0+10x70'
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: KueueHighAdmissionWaitTimePostMerge
+        exp_alerts: []
 
   # TektonKueuePodsCrashLoopBackOff - should fire: pod in CrashLoopBackOff
   - interval: 1m

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -69,13 +69,13 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="900", source_cluster="c1"}'
-        values: '0+0x20'
+        values: '0+0x70'
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1000", source_cluster="c1"}'
-        values: '0+0x20'
+        values: '0+0x70'
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="c1"}'
-        values: '0 10 20 30 40 50 60 70 80 90 100'
+        values: '0+10x70'
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 50m
         alertname: KueueHighAdmissionWaitTimePostMerge
         exp_alerts:
           - exp_labels:


### PR DESCRIPTION

### Description

This PR increases the `for` duration for the `KueueHighAdmissionWaitTimePostMerge` alert from **5 minutes to 45 minutes** to mitigate substantial alert fatigue and eliminate transient noise in Slack.

Approved by the authorities:
https://redhat-internal.slack.com/archives/C04F4NE15U1/p1781001531303419
and:
https://redhat-internal.slack.com/archives/C04FDFTF8EB/p1780997937560199

#### Rationale & Data-Driven Insights:
* **Flapping & Toil Analysis:** Historical duration graphs and "Net Difference" metrics over the past week showed a high volume of short-lived spikes (~60 to 70 transient alerts per week). These alerts regularly resolve on their own within 30 to 45 minutes without requiring human intervention.
* **Service Impact:** Unlike Pre-Merge workloads, Post-Merge pipeline runs (code already safely merged into main) are not actively blocking developer workflows in real-time. Temporary queue backlogs during massive merge waves are expected and self-correcting.

---

### Pre-Submission Checklist

- [x] **Jira Ticket:** SPRE-5444 is linked in the PR title and commit message.
https://redhat.atlassian.net/browse/SPRE-5444
- [x] **Alert Tests:** Updated the underlying PromQL unit tests (`kueue_alerts_test.yaml`) to accommodate the new `45m` window and extended the evaluation interval to `50m`. Verified locally via `make check-and-test` -> **Passed successfully.**
- [ ] **SOP / Runbook:** Existing runbook covers this alert; no structural changes required.
- [ ] **Dashboards Addition:** N/A (no dashboard layout changes).
- [x] **Contribution Guides:** Followed commit and PR conventions.
- [x] **Pipeline Finished Successfully**





