### PR TITLE
feat(SPRE-5469) Include new Admission Wait Time alert for release workloads

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -266,7 +266,7 @@ spec:
       expr: |
         histogram_quantile(0.99, sum(increase(kueue_admission_wait_time_seconds_bucket{
           cluster_queue="cluster-pipeline-queue",
-          priority_class!~"konflux-pre-merge-.*|konflux-post-merge-.*|konflux-dependency-update"
+          priority_class!~"konflux-pre-merge-.*|konflux-post-merge-.*|konflux-dependency-update|konflux-release|konflux-tenant-release"
         }[10m])) by (le, source_cluster)) > 7200
       for: 5m
       labels:
@@ -278,3 +278,20 @@ spec:
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
         alert_routing_key: infra
         team: konflux-infra
+
+    - alert: KueueHighAdmissionWaitTimeReleases
+      expr: |
+        histogram_quantile(0.99, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-release|konflux-tenant-release"
+        }[10m])) by (le, source_cluster)) > 4800
+      for: 20m
+      labels:
+        severity: critical
+        component: kueue
+        slo: "true"
+      annotations:
+        summary: "High admission wait time for Release workloads"
+        description: "99th percentile admission wait time for konflux and tenant release workloads is {{ $value | humanizeDuration }}, which is above 1.33 hours in cluster {{ $labels.source_cluster }}"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -296,3 +296,55 @@ tests:
       - eval_time: 10m
         alertname: TektonKueueRolloutStuck
         exp_alerts: []
+
+  # KueueHighAdmissionWaitTimeReleases - should fire: 99th percentile wait time above 1.33h (4800s) for 20m
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="4800", source_cluster="c1"}'
+        values: '0+0x30'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="5000", source_cluster="c1"}'
+        values: '0+0x30'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="+Inf", source_cluster="c1"}'
+        values: '0+10x30'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: KueueHighAdmissionWaitTimeReleases
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: kueue
+              slo: "true"
+              source_cluster: c1
+            exp_annotations:
+              summary: "High admission wait time for Release workloads"
+              description: "99th percentile admission wait time for konflux and tenant release workloads is 1h 23m 20s, which is above 1.33 hours in cluster c1"
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
+
+  # KueueHighAdmissionWaitTimeReleases - should NOT fire: eval time (15m) is less than 'for' duration (20m)
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-tenant-release", le="4800", source_cluster="c1"}'
+        values: '0+0x30'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-tenant-release", le="5000", source_cluster="c1"}'
+        values: '0+0x30'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-tenant-release", le="+Inf", source_cluster="c1"}'
+        values: '0+10x30'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: KueueHighAdmissionWaitTimeReleases
+        exp_alerts: []
+
+  # KueueHighAdmissionWaitTimeReleases - should NOT fire: wait time below threshold (4800s)
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="4000", source_cluster="c1"}'
+        values: '0+0x30'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="4800", source_cluster="c1"}'
+        values: '0+0x30'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="+Inf", source_cluster="c1"}'
+        values: '0+10x30'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: KueueHighAdmissionWaitTimeReleases
+        exp_alerts: []


### PR DESCRIPTION
### Description

- New admission wait time alert for release workloads

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [X] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [X] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [X] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [X] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

