### PR TITLE
fix(PVO11Y-5168): Include krd monitoring overview as runbook to o11y alerts

### DIFF
--- a/rhobs/alerting/konflux-release-data/prometheus.krd_monitoring_alerts.yaml
+++ b/rhobs/alerting/konflux-release-data/prometheus.krd_monitoring_alerts.yaml
@@ -27,6 +27,7 @@ spec:
               No metrics received from the GitLab runner in {{ $labels.namespace }} namespace for more than 10 minutes.
             alert_routing_key: o11y
             team: o11y
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/monitoring/konflux-release-data-monitoring.md
 
         - alert: KRDPipelineExporterMetricsAbsent
           expr: |
@@ -47,3 +48,4 @@ spec:
               for more than 10 minutes.
             alert_routing_key: o11y
             team: o11y
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/monitoring/konflux-release-data-monitoring.md

--- a/test/promql/tests/konflux-release-data/krd_monitoring_alerts_test.yaml
+++ b/test/promql/tests/konflux-release-data/krd_monitoring_alerts_test.yaml
@@ -26,6 +26,7 @@ tests:
                 No metrics received from the GitLab runner in krd-gitlab-runner--pipeline namespace for more than 10 minutes.
               alert_routing_key: o11y
               team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/monitoring/konflux-release-data-monitoring.md
 
   # Runner up metric present — should NOT fire
   - interval: 1m
@@ -60,6 +61,7 @@ tests:
                 No metrics received from the GitLab CI pipelines exporter in krd-gitlab-runner--pipeline namespace for more than 10 minutes.
               alert_routing_key: o11y
               team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/monitoring/konflux-release-data-monitoring.md
 
   # Exporter up metric present — should NOT fire
   - interval: 1m


### PR DESCRIPTION

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

Monitoring overview of Konflux-release-data repository has enough information to be able to figure out what could be issues and where to find them and has minimal instructions for most apparent problems that could happen with our setup.

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [x] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [x] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [x] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
