### PR TITLE
SPRE(5450)-Tune EtcdCommitLatency alert duration

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.performance_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.performance_alerts.yaml
@@ -26,8 +26,8 @@ spec:
 
         - alert: EtcdCommitLatency
           expr: |
-            avg_over_time(histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{source_cluster!=""}[2m]))[10m:]) > 0.04
-          for: 10m
+            avg_over_time(histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{source_cluster!=""}[2m]))[15m:]) > 0.04
+          for: 15m
           labels:
             severity: warning
             component: etcd
@@ -35,7 +35,7 @@ spec:
             summary: >-
               ETCD slow writes observed.
             description: >-
-              10 minutes avg. 99th etcd commit latency on {{$labels.pod}} higher than 40ms in cluster {{ $labels.source_cluster }}.
+              15 minutes avg. 99th etcd commit latency on {{$labels.pod}} higher than 40ms in cluster {{ $labels.source_cluster }}.
             alert_routing_key: perfandscale
 
         - alert: EtcdProposalFailures

--- a/test/promql/tests/data_plane/performance_test.yaml
+++ b/test/promql/tests/data_plane/performance_test.yaml
@@ -43,13 +43,13 @@ tests:
     input_series:
       # Average commit latency higher than 40ms, so it will be alerted.
       - series: 'etcd_disk_backend_commit_duration_seconds_bucket{le="0.05", pod="etcd-pod-1", source_cluster="cluster01"}'
-        values: '0+0.01x15'
+        values: '0+0.01x30'
 
       - series: 'etcd_disk_backend_commit_duration_seconds_bucket{le="+Inf", pod="etcd-pod-1", source_cluster="cluster01"}'
-        values: '0+0.5x15'
+        values: '0+0.5x30'
 
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 30m
         alertname: EtcdCommitLatency
         exp_alerts:
           - exp_labels:
@@ -59,7 +59,7 @@ tests:
               source_cluster: cluster01
             exp_annotations:
               summary: "ETCD slow writes observed."
-              description: "10 minutes avg. 99th etcd commit latency on etcd-pod-1 higher than 40ms in cluster cluster01."
+              description: "15 minutes avg. 99th etcd commit latency on etcd-pod-1 higher than 40ms in cluster cluster01."
               alert_routing_key: perfandscale
 
   - interval: 1m


### PR DESCRIPTION
This PR tunes the existing EtcdCommitLatency warning alert to reduce noise from short-lived ETCD backend commit latency spikes.

Changes made:

Increased the averaging window from 10m to 15m
Increased the alert for duration from 10m to 15m
Updated the alert description from 10 minutes avg. to 15 minutes avg.
Updated the related PromQL unit test

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
