### PR TITLE
feat: add runbook in kubearchive alert

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml
@@ -28,7 +28,7 @@ spec:
               KubeArchive Operator pod has been down for 5min in cluster {{ $labels.source_cluster }}
             alert_team_handle: <!subteam^S088TRDUGG0>
             team: kubearchive
-            runbook_url: null
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/tree/main/kubearchive?ref_type=heads
     - name: kubearchive-api-availability
       interval: 1m
       rules:
@@ -50,7 +50,7 @@ spec:
               KubeArchive API Server pod has been down for 5min in cluster {{ $labels.source_cluster }}
             alert_team_handle: <!subteam^S088TRDUGG0>
             team: kubearchive
-            runbook_url: null
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/tree/main/kubearchive?ref_type=heads
     - name: kubearchive-sink-availability
       interval: 1m
       rules:
@@ -72,4 +72,4 @@ spec:
               KubeArchive Sink pod has been down for 5min in cluster {{ $labels.source_cluster }}
             alert_team_handle: <!subteam^S088TRDUGG0>
             team: kubearchive
-            runbook_url: null
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/tree/main/kubearchive?ref_type=heads

--- a/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml
@@ -28,7 +28,7 @@ spec:
               KubeArchive Operator pod has been down for 5min in cluster {{ $labels.source_cluster }}
             alert_team_handle: <!subteam^S088TRDUGG0>
             team: kubearchive
-            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/tree/main/kubearchive?ref_type=heads
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kubearchive/README.md?ref_type=heads
     - name: kubearchive-api-availability
       interval: 1m
       rules:
@@ -50,7 +50,7 @@ spec:
               KubeArchive API Server pod has been down for 5min in cluster {{ $labels.source_cluster }}
             alert_team_handle: <!subteam^S088TRDUGG0>
             team: kubearchive
-            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/tree/main/kubearchive?ref_type=heads
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kubearchive/README.md?ref_type=heads
     - name: kubearchive-sink-availability
       interval: 1m
       rules:
@@ -72,4 +72,4 @@ spec:
               KubeArchive Sink pod has been down for 5min in cluster {{ $labels.source_cluster }}
             alert_team_handle: <!subteam^S088TRDUGG0>
             team: kubearchive
-            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/tree/main/kubearchive?ref_type=heads
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/kubearchive/README.md?ref_type=heads


### PR DESCRIPTION
### Description

<!-- Adding runbook to alert for troubleshooting -->

---

### Pre-Submission Checklist



- [ ] **Jira Ticket:** [https://redhat.atlassian.net/browse/SPRE-5259](url)
- [ ] **Alert Tests:** Not required
- [ ] **SOP / Runbook:** [https://gitlab.cee.redhat.com/konflux/docs/sop/-/tree/main/kubearchive?ref_type=heads](url)
- [ ] **Dashboards Addition:** N/A 
- [ ] **Contribution Guides:** Followed
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---


