### PR TITLE
Revert "chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker tag to v1.26.3-1781757851"

### DIFF
--- a/.tekton/o11y-pull-request.yaml
+++ b/.tekton/o11y-pull-request.yaml
@@ -350,7 +350,7 @@ spec:
           image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
           name: use-trusted-artifact
         - computeResources: {}
-          image: registry.access.redhat.com/ubi9/go-toolset:1.26.3-1781757851
+          image: registry.access.redhat.com/ubi9/go-toolset:1.25.9-1777537863
           name: go-unit-tests
           script: |
             go test -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3-1781757851 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1777537863 AS builder
 
 USER root
 


### PR DESCRIPTION
Reverts redhat-appstudio/o11y#1121