### PR TITLE
Add SRE subteam to KubeArchive alert_team_handle

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml
@@ -26,7 +26,7 @@ spec:
               KubeArchive Operator pod is down in cluster {{ $labels.source_cluster }}
             description: >
               KubeArchive Operator pod has been down for 5min in cluster {{ $labels.source_cluster }}
-            alert_team_handle: '<!subteam^S088TRDUGG0> <!subteam^S06V06A36F5>'
+            alert_team_handle: '<!subteam^S088TRDUGG0> <!subteam^S07SW2EEW3D>'
             team: kubearchive
             runbook_url: null
     - name: kubearchive-api-availability
@@ -48,7 +48,7 @@ spec:
               KubeArchive API Server pod is down in cluster {{ $labels.source_cluster }}
             description: >
               KubeArchive API Server pod has been down for 5min in cluster {{ $labels.source_cluster }}
-            alert_team_handle: '<!subteam^S088TRDUGG0> <!subteam^S06V06A36F5>'
+            alert_team_handle: '<!subteam^S088TRDUGG0> <!subteam^S07SW2EEW3D>'
             team: kubearchive
             runbook_url: null
     - name: kubearchive-sink-availability
@@ -70,6 +70,6 @@ spec:
               KubeArchive Sink pod is down in cluster {{ $labels.source_cluster }}
             description: >
               KubeArchive Sink pod has been down for 5min in cluster {{ $labels.source_cluster }}
-            alert_team_handle: '<!subteam^S088TRDUGG0> <!subteam^S06V06A36F5>'
+            alert_team_handle: '<!subteam^S088TRDUGG0> <!subteam^S07SW2EEW3D>'
             team: kubearchive
             runbook_url: null

--- a/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml
@@ -26,7 +26,7 @@ spec:
               KubeArchive Operator pod is down in cluster {{ $labels.source_cluster }}
             description: >
               KubeArchive Operator pod has been down for 5min in cluster {{ $labels.source_cluster }}
-            alert_team_handle: <!subteam^S088TRDUGG0>
+            alert_team_handle: '<!subteam^S088TRDUGG0> <!subteam^S06V06A36F5>'
             team: kubearchive
             runbook_url: null
     - name: kubearchive-api-availability
@@ -48,7 +48,7 @@ spec:
               KubeArchive API Server pod is down in cluster {{ $labels.source_cluster }}
             description: >
               KubeArchive API Server pod has been down for 5min in cluster {{ $labels.source_cluster }}
-            alert_team_handle: <!subteam^S088TRDUGG0>
+            alert_team_handle: '<!subteam^S088TRDUGG0> <!subteam^S06V06A36F5>'
             team: kubearchive
             runbook_url: null
     - name: kubearchive-sink-availability
@@ -70,6 +70,6 @@ spec:
               KubeArchive Sink pod is down in cluster {{ $labels.source_cluster }}
             description: >
               KubeArchive Sink pod has been down for 5min in cluster {{ $labels.source_cluster }}
-            alert_team_handle: <!subteam^S088TRDUGG0>
+            alert_team_handle: '<!subteam^S088TRDUGG0> <!subteam^S06V06A36F5>'
             team: kubearchive
             runbook_url: null


### PR DESCRIPTION
### Description

SRE team to be aware of alerts KubeArchive

---

Add kubearchive alerts to SRE team
https://redhat.atlassian.net/browse/SPRE-5772

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.


