### PR TITLE
chore(SRVKP-12264): Remove Tekton Events controller alerts

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -120,28 +120,6 @@ spec:
           alert_team_handle: <!subteam^S04PYECHCCU>
           team: pipelines
           runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
-    - name: tekton-events-controller-availability
-      interval: 1m
-      rules:
-      - alert: TektonEventsControllerDown
-        expr: |
-          konflux_up{
-            namespace="openshift-pipelines",
-            check="replicas-available",
-            service="tekton-events-controller",
-          } != 1
-        for: 5m
-        labels:
-          severity: high
-          component: tekton-pipelines
-        annotations:
-          summary: >-
-            Tekton Events controller is down in cluster {{ $labels.source_cluster }}
-          description: >
-            The Tekton Events controller pod has been down for 5min in cluster {{ $labels.source_cluster }}
-          alert_routing_key: <!subteam^S04PYECHCCU>
-          team: pipelines
-          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
     - name: tekton-operator-proxy-webhook-availability
       interval: 1m
       rules:

--- a/test/promql/tests/data_plane/pipelines_up_test.yaml
+++ b/test/promql/tests/data_plane/pipelines_up_test.yaml
@@ -27,10 +27,6 @@ tests:
         values: '1 1 1 1 1'
       - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-chains-controller", source_cluster="c_down"}'
         values: '1 1 1 1 1'
-      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-events-controller", source_cluster="c_up"}'
-        values: '1 1 1 1 1'
-      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-events-controller", source_cluster="c_down"}'
-        values: '1 1 1 1 1'
       - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-operator-proxy-webhook", source_cluster="c_up"}'
         values: '1 1 1 1 1'
       - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-operator-proxy-webhook", source_cluster="c_down"}'
@@ -84,9 +80,6 @@ tests:
         alertname: TektonChainsControllerDown
         exp_alerts: []
       - eval_time: 5m
-        alertname: TektonEventsControllerDown
-        exp_alerts: []
-      - eval_time: 5m
         alertname: TektonOperatorProxyWebhookDown
         exp_alerts: []
       - eval_time: 5m
@@ -129,10 +122,6 @@ tests:
       - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-chains-controller", check="replicas-available", source_cluster="c_up"}'
         values: '1 1 1 1 1'
       - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-chains-controller", check="replicas-available", source_cluster="c_down"}'
-        values: '0 0 0 0 0'
-      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-events-controller", check="replicas-available", source_cluster="c_up"}'
-        values: '1 1 1 1 1'
-      - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-events-controller", check="replicas-available", source_cluster="c_down"}'
         values: '0 0 0 0 0'
       - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-operator-proxy-webhook", check="replicas-available", source_cluster="c_up"}'
         values: '1 1 1 1 1'
@@ -257,23 +246,6 @@ tests:
               description: >
                 The Tekton Chains controller pod has been down for 5min in cluster c_down
               alert_team_handle: <!subteam^S04PYECHCCU>
-              team: pipelines
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
-      - eval_time: 5m
-        alertname: TektonEventsControllerDown
-        exp_alerts:
-          - exp_labels:
-              severity: high
-              check: replicas-available
-              namespace: openshift-pipelines
-              service: tekton-events-controller
-              source_cluster: c_down
-              component: tekton-pipelines
-            exp_annotations:
-              summary: Tekton Events controller is down in cluster c_down
-              description: >
-                The Tekton Events controller pod has been down for 5min in cluster c_down
-              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
       - eval_time: 5m

--- a/test/promql/tests/recording/pipelines_service_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/pipelines_service_availability_recording_rules_test.yaml
@@ -27,10 +27,6 @@ tests:
         values: '1 1 1 1 1'
       - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-chains-controller"}'
         values: '1 1 1 1 1'
-      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
-        values: '1 1 1 1 1'
-      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
-        values: '1 1 1 1 1'
       - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
         values: '1 1 1 1 1'
       - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
@@ -80,8 +76,6 @@ tests:
           - labels: konflux_up{deployment='pipelines-as-code-webhook', service='pipelines-as-code-webhook', check='replicas-available', namespace='openshift-pipelines'}
             value: 1
           - labels: konflux_up{deployment='tekton-chains-controller', service='tekton-chains-controller', check='replicas-available', namespace='openshift-pipelines'}
-            value: 1
-          - labels: konflux_up{deployment='tekton-events-controller', service='tekton-events-controller', check='replicas-available', namespace='openshift-pipelines'}
             value: 1
           - labels: konflux_up{deployment='tekton-operator-proxy-webhook', service='tekton-operator-proxy-webhook', check='replicas-available', namespace='openshift-pipelines'}
             value: 1
@@ -125,10 +119,6 @@ tests:
         values: '1 1 1 1 1'
       - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-chains-controller"}'
         values: '0 1 0 1 0'
-      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
-        values: '1 1 1 1 1'
-      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
-        values: '0 1 0 1 0'
       - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
         values: '1 1 1 1 1'
       - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
@@ -178,8 +168,6 @@ tests:
           - labels: konflux_up{deployment='pipelines-as-code-webhook', service='pipelines-as-code-webhook', check='replicas-available', namespace='openshift-pipelines'}
             value: 0
           - labels: konflux_up{deployment='tekton-chains-controller', service='tekton-chains-controller', check='replicas-available', namespace='openshift-pipelines'}
-            value: 0
-          - labels: konflux_up{deployment='tekton-events-controller', service='tekton-events-controller', check='replicas-available', namespace='openshift-pipelines'}
             value: 0
           - labels: konflux_up{deployment='tekton-operator-proxy-webhook', service='tekton-operator-proxy-webhook', check='replicas-available', namespace='openshift-pipelines'}
             value: 0
@@ -223,10 +211,6 @@ tests:
         values: '1 1 1 1 1'
       - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-chains-controller"}'
         values: '0 0 0 0 0'
-      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
-        values: '1 1 1 1 1'
-      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
-        values: '0 0 0 0 0'
       - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
         values: '1 1 1 1 1'
       - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
@@ -276,8 +260,6 @@ tests:
           - labels: konflux_up{deployment='pipelines-as-code-webhook', service='pipelines-as-code-webhook', check='replicas-available', namespace='openshift-pipelines'}
             value: 0
           - labels: konflux_up{deployment='tekton-chains-controller', service='tekton-chains-controller', check='replicas-available', namespace='openshift-pipelines'}
-            value: 0
-          - labels: konflux_up{deployment='tekton-events-controller', service='tekton-events-controller', check='replicas-available', namespace='openshift-pipelines'}
             value: 0
           - labels: konflux_up{deployment='tekton-operator-proxy-webhook', service='tekton-operator-proxy-webhook', check='replicas-available', namespace='openshift-pipelines'}
             value: 0
@@ -321,10 +303,6 @@ tests:
         values: '0 0 0 0 0'
       - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-chains-controller"}'
         values: '0 0 0 0 0'
-      - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
-        values: '0 0 0 0 0'
-      - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-events-controller"}'
-        values: '0 0 0 0 0'
       - series: 'kube_deployment_spec_replicas{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
         values: '0 0 0 0 0'
       - series: 'kube_deployment_status_replicas_available{namespace="openshift-pipelines", deployment="tekton-operator-proxy-webhook"}'
@@ -374,8 +352,6 @@ tests:
           - labels: konflux_up{deployment='pipelines-as-code-webhook', service='pipelines-as-code-webhook', check='replicas-available', namespace='openshift-pipelines'}
             value: 0
           - labels: konflux_up{deployment='tekton-chains-controller', service='tekton-chains-controller', check='replicas-available', namespace='openshift-pipelines'}
-            value: 0
-          - labels: konflux_up{deployment='tekton-events-controller', service='tekton-events-controller', check='replicas-available', namespace='openshift-pipelines'}
             value: 0
           - labels: konflux_up{deployment='tekton-operator-proxy-webhook', service='tekton-operator-proxy-webhook', check='replicas-available', namespace='openshift-pipelines'}
             value: 0


### PR DESCRIPTION
### Description

The Tekton Events controller is not used by Konflux and is being disabled

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [x] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
