### PR TITLE
PVO11Y-5317 Update kanary Grafana dashboard for V1 metrics

### DIFF
--- a/dashboards/grafana-dashboard-kanary-signal-v1.configmap.yaml
+++ b/dashboards/grafana-dashboard-kanary-signal-v1.configmap.yaml
@@ -2,13 +2,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  name: grafana-dashboard-kanary-signal.configmap
+  name: grafana-dashboard-kanary-signal-v1.configmap
   labels:
     grafana_dashboard: "true"
   annotations:
     grafana-folder: /grafana-dashboard-definitions/RHTAP
 data:
-  kanary-signal-dashboard.json: |-
+  kanary-signal-v1-dashboard.json: |-
     {
       "annotations": {
         "list": [
@@ -29,7 +29,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 1009521,
+      "id": null,
       "links": [],
       "panels": [
         {
@@ -42,7 +42,7 @@ data:
           },
           "id": 6,
           "panels": [],
-          "title": "Kanary Signals",
+          "title": "Kanary Signals V1",
           "type": "row"
         },
         {
@@ -114,7 +114,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -123,7 +123,7 @@ data:
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "min by (tested_cluster) (kanary_up{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\"})",
+              "expr": "min by (tested_cluster) (kanary_up{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\", namespace=\"konflux-otel\"})",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -205,7 +205,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -214,7 +214,7 @@ data:
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "max by (tested_cluster) (kanary_error{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\"})",
+              "expr": "max by (tested_cluster) (kanary_error{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\", namespace=\"konflux-otel\"})",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -228,12 +228,83 @@ data:
           "type": "stat"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${kanary_datasource}"
+          },
+          "description": "Minutes since last push of the kanary result",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "m"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 16
+          },
+          "id": 11,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.11",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${kanary_datasource}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "min by (tested_cluster, type) (\n  (\n    time() - kanary_last_push_timestamp{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\", namespace=\"konflux-otel\"}\n  ) / 60\n)",
+              "instant": false,
+              "legendFormat": "{{tested_cluster}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Kanary last push time",
+          "type": "stat"
+        },
+        {
           "collapsed": false,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 16
+            "y": 24
           },
           "id": 7,
           "panels": [],
@@ -272,7 +343,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 17
+            "y": 25
           },
           "id": 3,
           "options": {
@@ -290,7 +361,7 @@ data:
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -300,7 +371,7 @@ data:
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "avg by (tested_cluster) (avg_over_time(kanary_up{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\"}[$__range]))",
+              "expr": "avg by (tested_cluster) (avg_over_time(kanary_up{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\", namespace=\"konflux-otel\"}[$__range]))",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -345,7 +416,7 @@ data:
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 24
+            "y": 32
           },
           "id": 5,
           "options": {
@@ -363,7 +434,7 @@ data:
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -373,7 +444,7 @@ data:
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "avg by (tested_cluster, reason) (avg_over_time(kanary_error{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\"}[$__range]))",
+              "expr": "avg by (tested_cluster, reason) (avg_over_time(kanary_error{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\", namespace=\"konflux-otel\"}[$__range]))",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -425,7 +496,7 @@ data:
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 24
+            "y": 32
           },
           "id": 2,
           "options": {
@@ -440,7 +511,7 @@ data:
             },
             "showHeader": true
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -450,7 +521,7 @@ data:
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "max by (tested_cluster, reason) (kanary_error{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\"})",
+              "expr": "max by (tested_cluster, reason) (kanary_error{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\", namespace=\"konflux-otel\"})",
               "format": "table",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -503,7 +574,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 34
+            "y": 42
           },
           "id": 10,
           "panels": [],
@@ -520,7 +591,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 43
           },
           "id": 8,
           "options": {
@@ -543,7 +614,7 @@ data:
             },
             "viewMode": "list"
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "title": "Kanary Critical Alerts",
           "type": "alertlist"
         },
@@ -557,7 +628,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 43
           },
           "id": 9,
           "options": {
@@ -580,7 +651,7 @@ data:
             },
             "viewMode": "list"
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "title": "Kanary Warning Alerts",
           "type": "alertlist"
         }
@@ -668,7 +739,7 @@ data:
       },
       "timepicker": {},
       "timezone": "browser",
-      "title": "Kanary Signal Dashboard",
-      "uid": "eeoimpx3yutq9f",
-      "version": 7
+      "title": "Kanary Signal V1 Dashboard",
+      "uid": "kanary-signals-v1",
+      "version": 9
     }

--- a/dashboards/grafana-dashboard-kanary-signal.configmap.yaml
+++ b/dashboards/grafana-dashboard-kanary-signal.configmap.yaml
@@ -29,7 +29,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 1009521,
+      "id": 1024969,
       "links": [],
       "panels": [
         {
@@ -114,7 +114,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -123,7 +123,7 @@ data:
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "min by (tested_cluster) (kanary_up{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\"})",
+              "expr": "min by (tested_cluster) (kanary_up{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\", namespace=\"konflux-otel\"})",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -205,7 +205,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -214,7 +214,7 @@ data:
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "max by (tested_cluster) (kanary_error{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\"})",
+              "expr": "max by (tested_cluster) (kanary_error{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\", namespace=\"konflux-otel\"})",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -228,12 +228,83 @@ data:
           "type": "stat"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${kanary_datasource}"
+          },
+          "description": "Minutes since last push of the kanary result",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "m"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 16
+          },
+          "id": 11,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.11",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${kanary_datasource}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "min by (tested_cluster, type) (\n  (\n    time() - kanary_last_push_timestamp{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\", namespace=\"konflux-otel\"}\n  ) / 60\n)",
+              "instant": false,
+              "legendFormat": "{{tested_cluster}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Kanary last push time",
+          "type": "stat"
+        },
+        {
           "collapsed": false,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 16
+            "y": 24
           },
           "id": 7,
           "panels": [],
@@ -272,7 +343,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 17
+            "y": 25
           },
           "id": 3,
           "options": {
@@ -290,7 +361,7 @@ data:
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -300,7 +371,7 @@ data:
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "avg by (tested_cluster) (avg_over_time(kanary_up{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\"}[$__range]))",
+              "expr": "avg by (tested_cluster) (avg_over_time(kanary_up{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\", namespace=\"konflux-otel\"}[$__range]))",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -345,7 +416,7 @@ data:
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 24
+            "y": 32
           },
           "id": 5,
           "options": {
@@ -363,7 +434,7 @@ data:
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -373,7 +444,7 @@ data:
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "avg by (tested_cluster, reason) (avg_over_time(kanary_error{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\"}[$__range]))",
+              "expr": "avg by (tested_cluster, reason) (avg_over_time(kanary_error{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\", namespace=\"konflux-otel\"}[$__range]))",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -425,7 +496,7 @@ data:
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 24
+            "y": 32
           },
           "id": 2,
           "options": {
@@ -440,7 +511,7 @@ data:
             },
             "showHeader": true
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -450,7 +521,7 @@ data:
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "max by (tested_cluster, reason) (kanary_error{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\"})",
+              "expr": "max by (tested_cluster, reason) (kanary_error{tested_cluster=~\"${kanary_clusters}\", type=~\"${kanary_type}\", namespace=\"konflux-otel\"})",
               "format": "table",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -503,7 +574,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 34
+            "y": 42
           },
           "id": 10,
           "panels": [],
@@ -520,7 +591,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 43
           },
           "id": 8,
           "options": {
@@ -543,7 +614,7 @@ data:
             },
             "viewMode": "list"
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "title": "Kanary Critical Alerts",
           "type": "alertlist"
         },
@@ -557,7 +628,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 43
           },
           "id": 9,
           "options": {
@@ -580,7 +651,7 @@ data:
             },
             "viewMode": "list"
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "title": "Kanary Warning Alerts",
           "type": "alertlist"
         }
@@ -670,5 +741,5 @@ data:
       "timezone": "browser",
       "title": "Kanary Signal Dashboard",
       "uid": "eeoimpx3yutq9f",
-      "version": 7
+      "version": 9
     }

--- a/dashboards/grafana-dashboard-konflux-status-page.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-status-page.configmap.yaml
@@ -53,7 +53,7 @@ data:
             "content": "&nbsp;\n# Konflux Status Page for **$cluster** cluster",
             "mode": "markdown"
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "title": "",
           "transparent": true,
           "type": "text"
@@ -79,7 +79,7 @@ data:
             "content": "Help us improve your experience - [feedback form](https://forms.gle/xZuYEac7s3Gk1xzcA)\n\nAny issues with the dashboard? Reach out in [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB)!",
             "mode": "markdown"
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "title": "Provide a feedback!",
           "transparent": true,
           "type": "text"
@@ -197,7 +197,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -205,7 +205,7 @@ data:
                 "uid": "P22466E8E7855F1E0"
               },
               "editorMode": "code",
-              "expr": "sum(kanary_error{tested_cluster=\"${cluster}\",type=\"container-single-arch\"} == bool 1) + sum(kanary_up{tested_cluster=\"${cluster}\", type=\"container-single-arch\"} == bool 0)",
+              "expr": "sum(kanary_error{tested_cluster=\"${cluster}\", type=\"container-single-arch\", namespace=\"konflux-otel\"} == bool 1) + sum(kanary_up{tested_cluster=\"${cluster}\", type=\"container-single-arch\", namespace=\"konflux-otel\"} == bool 0)",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -315,7 +315,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -323,7 +323,7 @@ data:
                 "uid": "P22466E8E7855F1E0"
               },
               "editorMode": "code",
-              "expr": "sum(kanary_error{tested_cluster=\"${cluster}\",type=\"container-multi-arch\"} == bool 1) + sum(kanary_up{tested_cluster=\"${cluster}\", type=\"container-multi-arch\"} == bool 0)",
+              "expr": "sum(kanary_error{tested_cluster=\"${cluster}\", type=\"container-multi-arch\", namespace=\"konflux-otel\"} == bool 1) + sum(kanary_up{tested_cluster=\"${cluster}\", type=\"container-multi-arch\", namespace=\"konflux-otel\"} == bool 0)",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -433,7 +433,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -441,7 +441,7 @@ data:
                 "uid": "P22466E8E7855F1E0"
               },
               "editorMode": "code",
-              "expr": "sum(kanary_error{tested_cluster=\"${cluster}\",type=\"rpm\"} == bool 1) + sum(kanary_up{tested_cluster=\"${cluster}\", type=\"rpm\"} == bool 0)",
+              "expr": "sum(kanary_error{tested_cluster=\"${cluster}\", type=\"rpm\", namespace=\"konflux-otel\"} == bool 1) + sum(kanary_up{tested_cluster=\"${cluster}\", type=\"rpm\", namespace=\"konflux-otel\"} == bool 0)",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -551,7 +551,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -688,7 +688,7 @@ data:
               }
             ]
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -828,7 +828,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -1007,7 +1007,7 @@ data:
             },
             "showHeader": true
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -1154,7 +1154,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -1206,7 +1206,7 @@ data:
             },
             "viewMode": "list"
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "title": "Active SLO Alerts",
           "type": "alertlist"
         }
@@ -1250,5 +1250,5 @@ data:
       "timezone": "UTC",
       "title": "Konflux Status Page",
       "uid": "aes1ns0htwni8a",
-      "version": 5
+      "version": 31
     }


### PR DESCRIPTION
## Summary
Add a new "Kanary Signals V1" Grafana dashboard for V1 metrics (pushed via OTEL to `konflux-otel` namespace) while keeping the original MVP dashboard unchanged. The MVP dashboard can be removed later once the full migration to Kanary V1 is complete.

### Changes
- **New file:** `grafana-dashboard-kanary-signal-v1.configmap.yaml` — V1 dashboard with `namespace="konflux-otel"` filters, `kanary_last_push_timestamp` panel, uid `kanary-signals-v1`
- **Unchanged:** `grafana-dashboard-kanary-signal.configmap.yaml` — original MVP dashboard (kept as-is)
- **Updated:** `grafana-dashboard-konflux-status-page.configmap.yaml` — added `namespace="konflux-otel"` to kanary queries

Jira: https://redhat.atlassian.net/browse/PVO11Y-5317

## Risk Assessment
**Risk Level:** Low
**Description:** Adds a new dashboard and updates status page queries. No changes to existing MVP dashboard.
**Rollback:** Revert PR