### PR TITLE
fix: Adjust krd argocd alerts as per relengs request

### DIFF
--- a/rhobs/alerting/konflux-release-data/prometheus.krd_argocd_tenant_config_alerts.yaml
+++ b/rhobs/alerting/konflux-release-data/prometheus.krd_argocd_tenant_config_alerts.yaml
@@ -14,7 +14,8 @@ spec:
             last_over_time(
               argocd_app_info{
                 health_status="Degraded",
-                namespace=~"konflux-tenants-config|konflux-tenants-config-stage"
+                namespace=~"konflux-tenants-config|konflux-tenants-config-stage",
+                dest_namespace=~"releng-dev-tenant|releng-dev-tools-tenant|releng-integration-tenant|releng-test-product-tenant|ibm-asmw-releng-tenant|rhtap-releng-tenant"
               }[2m]
             ) == 1
           for: 10m
@@ -37,7 +38,8 @@ spec:
               argocd_app_info{
                 health_status="Healthy",
                 sync_status="OutOfSync",
-                namespace=~"konflux-tenants-config|konflux-tenants-config-stage"
+                namespace=~"konflux-tenants-config|konflux-tenants-config-stage",
+                dest_namespace=~"releng-dev-tenant|releng-dev-tools-tenant|releng-integration-tenant|releng-test-product-tenant|ibm-asmw-releng-tenant|rhtap-releng-tenant"
               }[2m]
             ) == 1
           for: 10m
@@ -59,7 +61,8 @@ spec:
             last_over_time(
               argocd_app_info{
                 health_status=~"Missing|Unknown",
-                namespace=~"konflux-tenants-config|konflux-tenants-config-stage"
+                namespace=~"konflux-tenants-config|konflux-tenants-config-stage",
+                dest_namespace=~"releng-dev-tenant|releng-dev-tools-tenant|releng-integration-tenant|releng-test-product-tenant|ibm-asmw-releng-tenant|rhtap-releng-tenant"
               }[2m]
             ) == 1
           for: 10m

--- a/test/promql/tests/konflux-release-data/krd_argocd_tenant_config_alerts_test.yaml
+++ b/test/promql/tests/konflux-release-data/krd_argocd_tenant_config_alerts_test.yaml
@@ -7,20 +7,24 @@ tests:
   # ==================== KRDTenantConfigAppDegraded ====================
   - interval: 1m
     input_series:
-      # Degraded app in tenant-config namespace — should fire
-      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="infra-deployments-stone-prd-rh01", health_status="Degraded", sync_status="Synced", dest_namespace="stone-prd-rh01-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+      # Degraded app in tenant-config namespace for monitored tenant — should fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="infra-deployments-stone-prd-rh01", health_status="Degraded", sync_status="Synced", dest_namespace="rhtap-releng-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
         values: "1x15"
 
-      # Degraded app in stage namespace — should fire
-      - series: 'argocd_app_info{namespace="konflux-tenants-config-stage", name="infra-deployments-stone-stg-rh01", health_status="Degraded", sync_status="Synced", dest_namespace="stone-stg-rh01-tenant", dest_server="https://api.stone-stg-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+      # Degraded app in stage namespace for monitored tenant — should fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config-stage", name="infra-deployments-stone-stg-rh01", health_status="Degraded", sync_status="Synced", dest_namespace="ibm-asmw-releng-tenant", dest_server="https://api.stone-stg-rh01.example.com:6443", source_cluster="appsres09ue1"}'
         values: "1x15"
 
       # Healthy app — should NOT fire
-      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="healthy-app", health_status="Healthy", sync_status="Synced", dest_namespace="healthy-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="healthy-app", health_status="Healthy", sync_status="Synced", dest_namespace="rhtap-releng-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
         values: "1x15"
 
       # Degraded app in different namespace — should NOT fire
-      - series: 'argocd_app_info{namespace="argocd", name="other-app", health_status="Degraded", sync_status="Synced", dest_namespace="other-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+      - series: 'argocd_app_info{namespace="argocd", name="other-app", health_status="Degraded", sync_status="Synced", dest_namespace="rhtap-releng-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+        values: "1x15"
+
+      # Degraded app for unmonitored tenant — should NOT fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="unmonitored-app", health_status="Degraded", sync_status="Synced", dest_namespace="stone-prd-rh01-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
         values: "1x15"
 
     alert_rule_test:
@@ -35,12 +39,12 @@ tests:
               name: infra-deployments-stone-prd-rh01
               health_status: Degraded
               sync_status: Synced
-              dest_namespace: stone-prd-rh01-tenant
+              dest_namespace: rhtap-releng-tenant
               dest_server: "https://api.stone-prd-rh01.example.com:6443"
               source_cluster: appsres09ue1
             exp_annotations:
               summary: >-
-                Tenant-config ArgoCD app infra-deployments-stone-prd-rh01 is degraded for stone-prd-rh01-tenant namespace
+                Tenant-config ArgoCD app infra-deployments-stone-prd-rh01 is degraded for rhtap-releng-tenant namespace
               description: >-
                 ArgoCD application infra-deployments-stone-prd-rh01 in konflux-tenants-config has been in Degraded health status for more than 10 minutes.
               alert_routing_key: krd-releng
@@ -53,12 +57,12 @@ tests:
               name: infra-deployments-stone-stg-rh01
               health_status: Degraded
               sync_status: Synced
-              dest_namespace: stone-stg-rh01-tenant
+              dest_namespace: ibm-asmw-releng-tenant
               dest_server: "https://api.stone-stg-rh01.example.com:6443"
               source_cluster: appsres09ue1
             exp_annotations:
               summary: >-
-                Tenant-config ArgoCD app infra-deployments-stone-stg-rh01 is degraded for stone-stg-rh01-tenant namespace
+                Tenant-config ArgoCD app infra-deployments-stone-stg-rh01 is degraded for ibm-asmw-releng-tenant namespace
               description: >-
                 ArgoCD application infra-deployments-stone-stg-rh01 in konflux-tenants-config-stage has been in Degraded health status for more than 10 minutes.
               alert_routing_key: krd-releng
@@ -67,16 +71,20 @@ tests:
   # ==================== KRDTenantConfigAppOutOfSync ====================
   - interval: 1m
     input_series:
-      # Healthy but OutOfSync — should fire
-      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="tenants-config-stone-prd-rh01", health_status="Healthy", sync_status="OutOfSync", dest_namespace="stone-prd-rh01-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+      # Healthy but OutOfSync for monitored tenant — should fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="tenants-config-stone-prd-rh01", health_status="Healthy", sync_status="OutOfSync", dest_namespace="releng-dev-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
         values: "1x15"
 
       # Healthy and Synced — should NOT fire
-      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="synced-app", health_status="Healthy", sync_status="Synced", dest_namespace="synced-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="synced-app", health_status="Healthy", sync_status="Synced", dest_namespace="releng-dev-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
         values: "1x15"
 
       # Degraded and OutOfSync — should NOT fire (only Healthy+OutOfSync)
-      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="degraded-oos-app", health_status="Degraded", sync_status="OutOfSync", dest_namespace="degraded-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="degraded-oos-app", health_status="Degraded", sync_status="OutOfSync", dest_namespace="releng-dev-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+        values: "1x15"
+
+      # Healthy but OutOfSync for unmonitored tenant — should NOT fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="unmonitored-oos-app", health_status="Healthy", sync_status="OutOfSync", dest_namespace="stone-prd-rh01-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
         values: "1x15"
 
     alert_rule_test:
@@ -91,12 +99,12 @@ tests:
               name: tenants-config-stone-prd-rh01
               health_status: Healthy
               sync_status: OutOfSync
-              dest_namespace: stone-prd-rh01-tenant
+              dest_namespace: releng-dev-tenant
               dest_server: "https://api.stone-prd-rh01.example.com:6443"
               source_cluster: appsres09ue1
             exp_annotations:
               summary: >-
-                Tenant-config ArgoCD app tenants-config-stone-prd-rh01 is OutOfSync for stone-prd-rh01-tenant namespace
+                Tenant-config ArgoCD app tenants-config-stone-prd-rh01 is OutOfSync for releng-dev-tenant namespace
               description: >-
                 ArgoCD application tenants-config-stone-prd-rh01 in konflux-tenants-config has been in OutOfSync health status for more than 10 minutes.
               alert_routing_key: krd-releng
@@ -105,16 +113,20 @@ tests:
   # ==================== KRDTenantConfigAppMissingOrUnknown ====================
   - interval: 1m
     input_series:
-      # Missing health status — should fire
-      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="missing-app", health_status="Missing", sync_status="Synced", dest_namespace="missing-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+      # Missing health status for monitored tenant — should fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="missing-app", health_status="Missing", sync_status="Synced", dest_namespace="releng-integration-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
         values: "1x15"
 
-      # Unknown health status in stage — should fire
-      - series: 'argocd_app_info{namespace="konflux-tenants-config-stage", name="unknown-app", health_status="Unknown", sync_status="Synced", dest_namespace="unknown-tenant", dest_server="https://api.stone-stg-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+      # Unknown health status in stage for monitored tenant — should fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config-stage", name="unknown-app", health_status="Unknown", sync_status="Synced", dest_namespace="releng-test-product-tenant", dest_server="https://api.stone-stg-rh01.example.com:6443", source_cluster="appsres09ue1"}'
         values: "1x15"
 
       # Healthy app — should NOT fire
-      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="healthy-app", health_status="Healthy", sync_status="Synced", dest_namespace="healthy-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="healthy-app", health_status="Healthy", sync_status="Synced", dest_namespace="releng-dev-tools-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
+        values: "1x15"
+
+      # Missing health for unmonitored tenant — should NOT fire
+      - series: 'argocd_app_info{namespace="konflux-tenants-config", name="unmonitored-missing-app", health_status="Missing", sync_status="Synced", dest_namespace="stone-prd-rh01-tenant", dest_server="https://api.stone-prd-rh01.example.com:6443", source_cluster="appsres09ue1"}'
         values: "1x15"
 
     alert_rule_test:
@@ -129,12 +141,12 @@ tests:
               name: missing-app
               health_status: Missing
               sync_status: Synced
-              dest_namespace: missing-tenant
+              dest_namespace: releng-integration-tenant
               dest_server: "https://api.stone-prd-rh01.example.com:6443"
               source_cluster: appsres09ue1
             exp_annotations:
               summary: >-
-                Tenant-config ArgoCD app missing-app has Missing health for missing-tenant namespace
+                Tenant-config ArgoCD app missing-app has Missing health for releng-integration-tenant namespace
               description: >-
                 ArgoCD application missing-app in konflux-tenants-config has been in Missing health status for more than 10 minutes.
               alert_routing_key: krd-releng
@@ -147,12 +159,12 @@ tests:
               name: unknown-app
               health_status: Unknown
               sync_status: Synced
-              dest_namespace: unknown-tenant
+              dest_namespace: releng-test-product-tenant
               dest_server: "https://api.stone-stg-rh01.example.com:6443"
               source_cluster: appsres09ue1
             exp_annotations:
               summary: >-
-                Tenant-config ArgoCD app unknown-app has Unknown health for unknown-tenant namespace
+                Tenant-config ArgoCD app unknown-app has Unknown health for releng-test-product-tenant namespace
               description: >-
                 ArgoCD application unknown-app in konflux-tenants-config-stage has been in Unknown health status for more than 10 minutes.
               alert_routing_key: krd-releng


### PR DESCRIPTION
### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

Adjusting krd argocd alerts to only be for releng namespaces. Tenant namespaces are not managed by them at all.

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [X] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [X] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [X] **Pipeline Finished Successfully**

---

### Deployment Notice

- [X] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
