### PR TITLE
PVO11Y-5279 Grant kaexporter SA read access to KubeArchive resources

### DIFF
--- a/config/exporters/monitoring/kaexporter/base/kaexporter-service.yaml
+++ b/config/exporters/monitoring/kaexporter/base/kaexporter-service.yaml
@@ -38,26 +38,31 @@ subjects:
     name: kaexporter-sa
     namespace: konflux-o11y-exporters
 ---
-# Namespace discovery — exporter must list tenant namespaces via Kubernetes API.
-# Scope: cluster-wide list of namespaces filtered by label konflux-ci.dev/type=tenant.
-# Only "list" permission is required (exporter uses List(), not Get()).
+# Cluster-wide read access for multi-tenant metric collection — the exporter
+# discovers all tenant namespaces and queries KubeArchive for their resources.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kaexporter-namespace-reader
+  name: kaexporter-kubearchive-reader
 rules:
   - apiGroups: [""]
     resources: ["namespaces"]
+    verbs: ["list"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns"]
+    verbs: ["list"]
+  - apiGroups: ["appstudio.redhat.com"]
+    resources: ["releases"]
     verbs: ["list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kaexporter-namespace-reader-binding
+  name: kaexporter-kubearchive-reader-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kaexporter-namespace-reader
+  name: kaexporter-kubearchive-reader
 subjects:
   - kind: ServiceAccount
     name: kaexporter-sa


### PR DESCRIPTION
## Summary

- Add `kaexporter-kubearchive-reader` ClusterRole granting `get`/`list` on PipelineRuns (`tekton.dev`), Snapshots and Releases (`appstudio.redhat.com`)
- Bind to `kaexporter-sa` ServiceAccount via ClusterRoleBinding

## Why

The exporter authenticates to KubeArchive using its ServiceAccount token (`/var/run/secrets/kubernetes.io/serviceaccount/token`). KubeArchive performs a SubjectAccessReview to verify the caller can access the requested resources. Without these permissions, all API calls return 401:

```
releases fetch namespace "abiton-tenant": API returned status 401: {"message":"unauthorized"}
```

## Test plan

- [ ] Deploy to staging and verify exporter can fetch PipelineRuns, Snapshots, and Releases from KubeArchive without 401 errors
- [ ] `make all` passes

[PVO11Y-5279](https://redhat.atlassian.net/browse/PVO11Y-5279)

[PVO11Y-5279]: https://redhat.atlassian.net/browse/PVO11Y-5279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ