### PR TITLE
PVO11Y-5279 Add honorLabels to kaexporter ServiceMonitor

### DIFF
--- a/config/exporters/monitoring/kaexporter/base/kaexporter-service-monitor.yaml
+++ b/config/exporters/monitoring/kaexporter/base/kaexporter-service-monitor.yaml
@@ -53,6 +53,7 @@ spec:
         key: token
       tlsConfig:
         insecureSkipVerify: true
+      honorLabels: true
       interval: 300s
       scrapeTimeout: 180s
   selector:


### PR DESCRIPTION
## Summary

Add `honorLabels: true` to the kaexporter ServiceMonitor endpoint.

## Why

Without `honorLabels: true`, Prometheus overwrites the exporter's `namespace` label with the pod's namespace (`konflux-o11y-exporters`). The exporter emits metrics with `namespace` set to the tenant namespace (e.g., `rhtap-o11y-tenant`), but Prometheus replaces it with the scrape target's namespace, making all metrics appear to come from `konflux-o11y-exporters`.

With `honorLabels: true`, Prometheus preserves the exporter's labels, so tenant-level metrics correctly show their tenant namespace.

## Test plan

- [ ] Deploy to staging, verify metrics in RHOBS have the correct tenant namespace label (not `konflux-o11y-exporters`)

[PVO11Y-5279](https://redhat.atlassian.net/browse/PVO11Y-5279)

[PVO11Y-5279]: https://redhat.atlassian.net/browse/PVO11Y-5279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ