### PR TITLE
PVO11Y-5279 - Increase namespace cap and streamline metrics

### DIFF
--- a/exporters/kaexporter/DESIGN.md
+++ b/exporters/kaexporter/DESIGN.md
@@ -42,7 +42,7 @@ Steady State Settings:
 - Query window: 36h (24h base + 50% safety margin)
 - Collection timeout: 120s (2 minutes)
 - Concurrency: 10 parallel requests
-- Per-namespace item cap: 1,000
+- Per-namespace item cap: 1,500
 ```
 
 **Why 36h for steady state?**

--- a/exporters/kaexporter/README.md
+++ b/exporters/kaexporter/README.md
@@ -35,7 +35,7 @@ On first boot, the exporter queries **720 hours (30 days)** of historical data t
 | Query window | 720h (30 days) | `KA_WINDOW_HOURS` + 50% |
 | Collection timeout | 600s | `KA_COLLECTION_TIMEOUT_SECONDS` |
 | Concurrency | 5 | `KA_MAX_CONCURRENT` |
-| Per-namespace item cap | 10,000 | 1,000 |
+| Per-namespace item cap | 10,000 | 1,500 |
 
 **Note:** `/metrics` endpoint is not served until cold start completes (~90-120 seconds). For architectural details on why this is necessary, see [DESIGN.md](DESIGN.md#1-cold-start-bootstrapping).
 

--- a/exporters/kaexporter/README.md
+++ b/exporters/kaexporter/README.md
@@ -49,36 +49,32 @@ All metrics are **Gauges** over a rolling 30-day window of daily aggregated buck
 
 | Metric | Phase | Labels |
 |--------|-------|--------|
-| `konflux_build_mean_duration_30d_seconds` | build | `cluster, namespace, application, component, build_type, event_type` |
-| `konflux_build_mean_wait_30d_seconds` | build | `cluster, namespace, application, component, build_type, event_type` |
-| `konflux_build_success_rate_30d` | build | `cluster, namespace, application, component, build_type, event_type` |
-| `konflux_build_failure_rate_30d` | build | `cluster, namespace, application, component, build_type, event_type` |
+| `konflux_build_mean_duration_seconds_30d` | build | `cluster, namespace, application, component, build_type, event_type` |
+| `konflux_build_mean_wait_seconds_30d` | build | `cluster, namespace, application, component, build_type, event_type` |
 | `konflux_build_total_count_30d` | build | `cluster, namespace, application, component, build_type, event_type` |
 | `konflux_build_success_count_30d` | build | `cluster, namespace, application, component, build_type, event_type` |
 | `konflux_build_failure_count_30d` | build | `cluster, namespace, application, component, build_type, event_type, reason` |
-| `konflux_integration_mean_duration_30d_seconds` | integration | `cluster, namespace, application, component, scenario, optional, test_type, event_type` |
-| `konflux_integration_mean_wait_30d_seconds` | integration | `cluster, namespace, application, component, scenario, optional, test_type, event_type` |
-| `konflux_integration_success_rate_30d` | integration | `cluster, namespace, application, component, scenario, optional, test_type, event_type` |
-| `konflux_integration_failure_rate_30d` | integration | `cluster, namespace, application, component, scenario, optional, test_type, event_type` |
+| `konflux_integration_mean_duration_seconds_30d` | integration | `cluster, namespace, application, component, scenario, optional, test_type, event_type` |
+| `konflux_integration_mean_wait_seconds_30d` | integration | `cluster, namespace, application, component, scenario, optional, test_type, event_type` |
 | `konflux_integration_total_count_30d` | integration | `cluster, namespace, application, component, scenario, optional, test_type, event_type` |
 | `konflux_integration_success_count_30d` | integration | `cluster, namespace, application, component, scenario, optional, test_type, event_type` |
 | `konflux_integration_failure_count_30d` | integration | `cluster, namespace, application, component, scenario, optional, test_type, event_type, reason` |
-| `konflux_release_cr_mean_duration_30d_seconds` | release | `cluster, namespace, application, component, automated, event_type` |
-| `konflux_release_cr_mean_wait_30d_seconds` | release | `cluster, namespace, application, component, automated, event_type` |
-| `konflux_release_cr_success_rate_30d` | release | `cluster, namespace, application, component, automated, event_type` |
-| `konflux_release_cr_failure_rate_30d` | release | `cluster, namespace, application, component, automated, event_type` |
+| `konflux_release_cr_mean_duration_seconds_30d` | release | `cluster, namespace, application, component, automated, event_type` |
+| `konflux_release_cr_mean_wait_seconds_30d` | release | `cluster, namespace, application, component, automated, event_type` |
 | `konflux_release_cr_total_count_30d` | release | `cluster, namespace, application, component, automated, event_type` |
 | `konflux_release_cr_success_count_30d` | release | `cluster, namespace, application, component, automated, event_type` |
 | `konflux_release_cr_failure_count_30d` | release | `cluster, namespace, application, component, automated, event_type, reason` |
 
 **Metric definitions**:
-- **Duration metrics** (`mean_duration_30d_seconds`): Mean execution time for successful workloads (startTime to completionTime for PipelineRuns; startTime to completionTime for Releases)
-- **Wait metrics** (`mean_wait_30d_seconds`): Mean waiting time before execution starts (creationTimestamp to startTime). Useful for identifying scheduling delays and resource constraints.
-- **Success rate** (`success_rate_30d`): Ratio of successful workloads to total completed (0.0 to 1.0)
-- **Error rate** (`failure_rate_30d`): Ratio of failed workloads to total completed (0.0 to 1.0). Inverse of success rate.
+- **Duration metrics** (`mean_duration_seconds_30d`): Mean execution time for **successful workloads only** (startTime to completionTime for PipelineRuns; startTime to completionTime for Releases). Failed workloads are excluded from this average.
+- **Wait metrics** (`mean_wait_seconds_30d`): Mean waiting time before execution starts (creationTimestamp to startTime) for **successful workloads only**. Useful for identifying scheduling delays and resource constraints. Failed workloads are excluded from this average.
 - **Total count** (`total_count_30d`): Count of all completed workloads (successful + failed) in the rolling window
 - **Success count** (`success_count_30d`): Count of successful workloads in the rolling window. Enables correct volume-weighted aggregation across dimensions: `sum(success_count) / sum(total_count)`.
 - **Failure count** (`failure_count_30d`): Count of failed workloads, broken down by failure reason. Useful for root cause analysis.
+
+**Derived metrics** (can be computed from the above):
+- **Success rate**: `success_count_30d / total_count_30d` (or 0 when total_count_30d == 0)
+- **Failure rate**: `(total_count_30d - success_count_30d) / total_count_30d` or `1 - success_rate`
 
 **Failure Reasons**:
 

--- a/exporters/kaexporter/collector.go
+++ b/exporters/kaexporter/collector.go
@@ -242,7 +242,7 @@ func (e *KAExporter) collectMetrics(ctx context.Context) (*releaseIndex, error) 
 				defer stop()
 			} else {
 				windowHours = e.queryWindowHours // 36h (steady state with safety margin)
-				maxItems = kaMaxItems            // 1,000
+				maxItems = kaMaxItems
 				// Bootstrapped namespaces share the parent context (global timeout)
 				nsCtx = ctx
 			}

--- a/exporters/kaexporter/exporter.go
+++ b/exporters/kaexporter/exporter.go
@@ -63,12 +63,12 @@ const (
 	kaPageLimit = 500
 
 	// kaMaxItems is the steady-state safety cap on total items fetched per endpoint per scrape.
-	kaMaxItems = 1000
+	kaMaxItems = 1500
 
 	// Cold-start configuration: on first boot the exporter queries 30 days of history
 	// to bootstrap full rolling-window accuracy, then switches to the steady-state window.
 	coldStartWindowHours        = 720   // 30 days
-	coldStartMaxItems           = 10000 // higher cap during bootstrap (busy namespaces exceed 1000 over 30d)
+	coldStartMaxItems           = 10000 // higher cap during bootstrap (busy namespaces exceed 1500 over 30d)
 	defaultColdStartTimeoutSecs = 600   // 10 min - allows busy namespaces to complete 30-day bootstrap
 
 	// parallelism for KubeArchive API calls.

--- a/exporters/kaexporter/metrics_test.go
+++ b/exporters/kaexporter/metrics_test.go
@@ -54,9 +54,9 @@ func TestBuildRecordObservation(t *testing.T) {
 					assertEqual(t, "EventType", ls.EventType, tt.wantEventType)
 					assertEqual(t, "TotalCount", window.ComputeTotalCount(), int64(1))
 					if tt.wantSucceeded {
-						assertFloat(t, "SuccessRate", window.ComputeSuccessRate(), 1.0)
+						assertEqual(t, "SuccessCount", window.ComputeSuccessCount(), int64(1))
 					} else {
-						assertFloat(t, "SuccessRate", window.ComputeSuccessRate(), 0.0)
+						assertEqual(t, "SuccessCount", window.ComputeSuccessCount(), int64(0))
 					}
 				}
 			})
@@ -208,9 +208,9 @@ func TestReleaseRecordObservation(t *testing.T) {
 					assertEqual(t, "Automated", ls.Automated, tt.wantAutomated)
 					assertEqual(t, "EventType", ls.EventType, tt.wantEventType)
 					if tt.wantSucceeded {
-						assertFloat(t, "SuccessRate", window.ComputeSuccessRate(), 1.0)
+						assertEqual(t, "SuccessCount", window.ComputeSuccessCount(), int64(1))
 					} else {
-						assertFloat(t, "SuccessRate", window.ComputeSuccessRate(), 0.0)
+						assertEqual(t, "SuccessCount", window.ComputeSuccessCount(), int64(0))
 					}
 				}
 			})
@@ -294,12 +294,13 @@ func TestUpdateGauges(t *testing.T) {
 		metricCount := 0
 		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
 			metricCount++
-			if window.ComputeTotalCount() == 0 {
+			totalCount := window.ComputeTotalCount()
+			if totalCount == 0 {
 				t.Error("TotalCount should not be 0")
 			}
-			sr := window.ComputeSuccessRate()
-			if sr < 0 || sr > 1 {
-				t.Errorf("SuccessRate %f out of range [0, 1]", sr)
+			successCount := window.ComputeSuccessCount()
+			if successCount < 0 || successCount > totalCount {
+				t.Errorf("SuccessCount %d out of valid range [0, %d]", successCount, totalCount)
 			}
 		})
 		if metricCount == 0 {
@@ -326,8 +327,6 @@ func TestUpdateGauges(t *testing.T) {
 		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
 			assertEqual(t, "TotalCount", window.ComputeTotalCount(), int64(5))
 			assertEqual(t, "SuccessCount", window.ComputeSuccessCount(), int64(0))
-			assertFloat(t, "SuccessRate", window.ComputeSuccessRate(), 0.0)
-			assertFloat(t, "FailureRate", window.ComputeFailureRate(), 1.0)
 		})
 	})
 }
@@ -518,7 +517,8 @@ func TestStoreCleanup(t *testing.T) {
 		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
 			assertFloat(t, "SuccessMean", window.ComputeSuccessMean(), 150.0)
 			assertFloat(t, "WaitMean", window.ComputeWaitMean(), 4.0)
-			assertFloat(t, "SuccessRate", window.ComputeSuccessRate(), 1.0)
+			assertEqual(t, "SuccessCount", window.ComputeSuccessCount(), int64(2))
+			assertEqual(t, "TotalCount", window.ComputeTotalCount(), int64(2))
 		})
 	})
 

--- a/exporters/kaexporter/rolling_store.go
+++ b/exporters/kaexporter/rolling_store.go
@@ -160,24 +160,6 @@ func (w *MetricWindow) ComputeSuccessMean() float64 {
 	return sum / float64(count)
 }
 
-// ComputeSuccessRate returns SuccessCount / Count across all buckets.
-// Skips stale buckets (older than 30 days from today).
-func (w *MetricWindow) ComputeSuccessRate() float64 {
-	cutoff := time.Now().UTC().AddDate(0, 0, -30).Format("2006-01-02")
-	var success, count int64
-	for i := range w.Buckets {
-		if w.Buckets[i].Day == "" || w.Buckets[i].Day <= cutoff {
-			continue
-		}
-		success += w.Buckets[i].SuccessCount
-		count += w.Buckets[i].Count
-	}
-	if count == 0 {
-		return 0
-	}
-	return float64(success) / float64(count)
-}
-
 // ComputeWaitMean returns the mean wait time across successful observations only.
 func (w *MetricWindow) ComputeWaitMean() float64 {
 	cutoff := time.Now().UTC().AddDate(0, 0, -30).Format("2006-01-02")
@@ -222,25 +204,6 @@ func (w *MetricWindow) ComputeSuccessCount() int64 {
 		count += w.Buckets[i].SuccessCount
 	}
 	return count
-}
-
-// ComputeFailureRate returns the failure rate (FailureCount / TotalCount).
-// Returns 0 if no data.
-func (w *MetricWindow) ComputeFailureRate() float64 {
-	cutoff := time.Now().UTC().AddDate(0, 0, -30).Format("2006-01-02")
-	var success, count int64
-	for i := range w.Buckets {
-		if w.Buckets[i].Day == "" || w.Buckets[i].Day <= cutoff {
-			continue
-		}
-		success += w.Buckets[i].SuccessCount
-		count += w.Buckets[i].Count
-	}
-	if count == 0 {
-		return 0
-	}
-	failureCount := count - success
-	return float64(failureCount) / float64(count)
 }
 
 // ComputeFailureReasons returns aggregated failure counts by reason across all buckets.
@@ -305,13 +268,11 @@ func (s *Store) getOrCreateLocked(metricName string, labelSet LabelSet) *MetricW
 // build, integration, and release metrics. Domain-specific modules embed
 // this struct and add their own record logic + any extra gauges.
 type SLOGaugeSet struct {
-	mean30d          *prometheus.GaugeVec
-	meanWait30d      *prometheus.GaugeVec
-	successRate30d   *prometheus.GaugeVec
-	totalCount30d    *prometheus.GaugeVec
-	successCount30d  *prometheus.GaugeVec
-	failureRate30d   *prometheus.GaugeVec
-	failureCount30d  *prometheus.GaugeVec
+	mean30d         *prometheus.GaugeVec
+	meanWait30d     *prometheus.GaugeVec
+	totalCount30d   *prometheus.GaugeVec
+	successCount30d *prometheus.GaugeVec
+	failureCount30d *prometheus.GaugeVec
 }
 
 // newSLOGaugeSet creates the common gauge set. The failureCount gauge
@@ -323,16 +284,12 @@ func newSLOGaugeSet(prefix, helpContext string, labels []string) SLOGaugeSet {
 
 	return SLOGaugeSet{
 		mean30d: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: prefix + "_mean_duration_30d_seconds",
+			Name: prefix + "_mean_duration_seconds_30d",
 			Help: fmt.Sprintf("Mean %s duration over the past 30 days for successful completions only (completion-time based).", helpContext),
 		}, labels),
 		meanWait30d: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: prefix + "_mean_wait_30d_seconds",
+			Name: prefix + "_mean_wait_seconds_30d",
 			Help: fmt.Sprintf("Mean %s wait time over the past 30 days for successful completions.", helpContext),
-		}, labels),
-		successRate30d: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: prefix + "_success_rate_30d",
-			Help: fmt.Sprintf("%s success rate over the past 30 days (Succeeded / total completed).", helpContext),
 		}, labels),
 		totalCount30d: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: prefix + "_total_count_30d",
@@ -341,10 +298,6 @@ func newSLOGaugeSet(prefix, helpContext string, labels []string) SLOGaugeSet {
 		successCount30d: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: prefix + "_success_count_30d",
 			Help: fmt.Sprintf("Count of successful %s over the past 30 days. Use for volume-weighted aggregation: sum(success_count) / sum(total_count).", helpContext),
-		}, labels),
-		failureRate30d: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: prefix + "_failure_rate_30d",
-			Help: fmt.Sprintf("%s failure rate over the past 30 days (FailureCount / TotalCount).", helpContext),
 		}, labels),
 		failureCount30d: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: prefix + "_failure_count_30d",
@@ -358,10 +311,8 @@ func newSLOGaugeSet(prefix, helpContext string, labels []string) SLOGaugeSet {
 func (s *SLOGaugeSet) UpdateFromStore(store *Store, metricName string, labelExtractor func(LabelSet) []string) {
 	s.mean30d.Reset()
 	s.meanWait30d.Reset()
-	s.successRate30d.Reset()
 	s.totalCount30d.Reset()
 	s.successCount30d.Reset()
-	s.failureRate30d.Reset()
 	s.failureCount30d.Reset()
 
 	store.ForEachWindow(metricName, func(ls LabelSet, window *MetricWindow) {
@@ -376,8 +327,6 @@ func (s *SLOGaugeSet) UpdateFromStore(store *Store, metricName string, labelExtr
 
 		s.totalCount30d.WithLabelValues(labels...).Set(float64(totalCount))
 		s.successCount30d.WithLabelValues(labels...).Set(float64(successCount))
-		s.successRate30d.WithLabelValues(labels...).Set(window.ComputeSuccessRate())
-		s.failureRate30d.WithLabelValues(labels...).Set(window.ComputeFailureRate())
 
 		if successCount > 0 {
 			s.mean30d.WithLabelValues(labels...).Set(window.ComputeSuccessMean())
@@ -397,10 +346,8 @@ func (s *SLOGaugeSet) UpdateFromStore(store *Store, metricName string, labelExtr
 func (s *SLOGaugeSet) Describe(ch chan<- *prometheus.Desc) {
 	s.mean30d.Describe(ch)
 	s.meanWait30d.Describe(ch)
-	s.successRate30d.Describe(ch)
 	s.totalCount30d.Describe(ch)
 	s.successCount30d.Describe(ch)
-	s.failureRate30d.Describe(ch)
 	s.failureCount30d.Describe(ch)
 }
 
@@ -408,10 +355,8 @@ func (s *SLOGaugeSet) Describe(ch chan<- *prometheus.Desc) {
 func (s *SLOGaugeSet) Collect(ch chan<- prometheus.Metric) {
 	s.mean30d.Collect(ch)
 	s.meanWait30d.Collect(ch)
-	s.successRate30d.Collect(ch)
 	s.totalCount30d.Collect(ch)
 	s.successCount30d.Collect(ch)
-	s.failureRate30d.Collect(ch)
 	s.failureCount30d.Collect(ch)
 }
 


### PR DESCRIPTION
### Description

 - Increase steady-state per-namespace item cap from 1,000 to 1,500
  - Rename duration metrics to follow standard naming convention:
    - mean_duration_30d_seconds -> mean_duration_seconds_30d
    - mean_wait_30d_seconds -> mean_wait_seconds_30d
  - Remove redundant success_rate_30d and failure_rate_30d metrics
    (can be derived from success_count_30d / total_count_30d)
  - Update README.md with derivation formulas and DESIGN.md with new cap

There is currently no existing Grafana dashboards, recording rules, alerting rules, RHOBS queries.
This is the first phase of deploying it to stage.

---

### JIRA

[PVO11Y-5279](https://redhat.atlassian.net/browse/PVO11Y-5279)

---


### Test Plan

Deploy to staging, verify metrics in RHOBS have the correct tenant namespace label (not konflux-o11y-exporters)


[PVO11Y-5279]: https://redhat.atlassian.net/browse/PVO11Y-5279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ