### PR TITLE
fix(PVO11Y-5279): Set startupProbe for KAExporter

### DIFF
--- a/config/exporters/monitoring/kaexporter/base/kaexporter-service.yaml
+++ b/config/exporters/monitoring/kaexporter/base/kaexporter-service.yaml
@@ -147,7 +147,7 @@ spec:
             httpGet:
               path: /healthz
               port: http-metrics
-            initialDelaySeconds: 10
+            initialDelaySeconds: 300
             periodSeconds: 30
           readinessProbe:
             httpGet:

--- a/config/exporters/monitoring/kaexporter/base/kaexporter-service.yaml
+++ b/config/exporters/monitoring/kaexporter/base/kaexporter-service.yaml
@@ -143,11 +143,17 @@ spec:
               value: "9101"
             - name: KA_COLLECTION_TIMEOUT_SECONDS
               value: "160"
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http-metrics
+            periodSeconds: 5
+            failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /healthz
               port: http-metrics
-            initialDelaySeconds: 300
+            initialDelaySeconds: 10
             periodSeconds: 30
           readinessProbe:
             httpGet:

--- a/config/exporters/monitoring/kaexporter/base/kaexporter-service.yaml
+++ b/config/exporters/monitoring/kaexporter/base/kaexporter-service.yaml
@@ -148,7 +148,7 @@ spec:
               path: /healthz
               port: http-metrics
             periodSeconds: 5
-            failureThreshold: 60
+            failureThreshold: 180
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
### Description

Increase initial delay for the KAExporter liveness probe. Recent changes to the exporter increased the time it takes for the exporter to finish its cold start and become ready. This resulted in the exporter being restarted continously as it failed liveness check

EDIT: Setting startupProbe instead of increasing initialDelaySeconds in livenessProbe.

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [x] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
