### PR TITLE
SPRE-4428: add KonfluxUIUpstream502 and NamespaceListerNotServingRequ…

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml
@@ -132,8 +132,13 @@ spec:
     rules:
     - alert: KonfluxUIUpstream502
       expr: |
+        # Uses raw metric (not the existing recording rule) because the recording rule drops
+        # the namespace label, which would cause false positives from other namespaces.
+        # rate[2m] matches the for: 2m pending period intentionally: a wider window (e.g. [5m])
+        # would allow a brief burst to keep the rate positive long enough to satisfy the
+        # pending period without sustained errors actually occurring.
         # threshold of 0.05/s (~1 error per 20s) filters brief rolling-deploy bursts
-        # while catching sustained upstream failures within the 2m pending period
+        # while catching sustained upstream failures within the 2m pending period.
         sum by (source_cluster) (
           rate(nginx_otel_http_request_errors_total{namespace="konflux-ui", status="502"}[2m])
         ) > 0.05
@@ -151,5 +156,4 @@ spec:
           is down or unreachable.
         alert_team_handle: <!subteam^S04HY632621>
         team: konflux-ui
-        # runbook_url: TODO create upstream-502 SOP in sop/konflux-ui/sre/
-        runbook_url: null
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/konflux-ui/sre/upstream-502.md

--- a/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml
@@ -133,7 +133,7 @@ spec:
     - alert: KonfluxUIUpstream502
       expr: |
         sum by (source_cluster) (
-          rate(nginx_otel_http_request_errors_total{namespace="konflux-ui", status="502"}[5m])
+          rate(nginx_otel_http_request_errors_total{namespace="konflux-ui", status="502"}[2m])
         ) > 0
       for: 2m
       labels:

--- a/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml
@@ -132,9 +132,11 @@ spec:
     rules:
     - alert: KonfluxUIUpstream502
       expr: |
+        # threshold of 0.05/s (~1 error per 20s) filters brief rolling-deploy bursts
+        # while catching sustained upstream failures within the 2m pending period
         sum by (source_cluster) (
           rate(nginx_otel_http_request_errors_total{namespace="konflux-ui", status="502"}[2m])
-        ) > 0
+        ) > 0.05
       for: 2m
       labels:
         severity: critical

--- a/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml
@@ -126,3 +126,28 @@ spec:
         alert_routing_key: <!subteam^S06V06A36F5>
         team: spre
         runbook_url: null
+
+  - name: konflux-ui-upstream-502
+    interval: 1m
+    rules:
+    - alert: KonfluxUIUpstream502
+      expr: |
+        sum by (source_cluster) (
+          rate(nginx_otel_http_request_errors_total{namespace="konflux-ui", status="502"}[5m])
+        ) > 0
+      for: 2m
+      labels:
+        severity: critical
+        slo: "true"
+        component: konflux-ui
+      annotations:
+        summary: >-
+          Konflux UI proxy returning 502 errors in cluster {{ $labels.source_cluster }}
+        description: >
+          The Konflux UI nginx proxy has been returning 502 errors for 2min in cluster
+          {{ $labels.source_cluster }}, indicating an upstream backend (e.g. namespace-lister)
+          is down or unreachable.
+        alert_team_handle: <!subteam^S04HY632621>
+        team: konflux-ui
+        # runbook_url: TODO create upstream-502 SOP in sop/konflux-ui/sre/
+        runbook_url: null

--- a/rhobs/alerting/data_plane/prometheus.namespace_lister_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.namespace_lister_alerts.yaml
@@ -60,3 +60,22 @@ spec:
         alert_team_handle: <!subteam^S05Q1P4Q2TG>
         team: konflux-infra
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/namespace-lister/README.md
+
+    - alert: NamespaceListerNotServingRequests
+      expr: |
+        sum by (source_cluster, pod) (rate(namespace_lister_api_counter[5m])) > 0
+        unless
+        sum by (source_cluster, pod) (rate(namespace_lister_api_counter{code=~"2.."}[5m])) > 0
+      for: 5m
+      labels:
+        severity: warning
+        component: namespace-lister
+      annotations:
+        summary: >-
+          namespace-lister is receiving requests but returning no successful responses in cluster {{ $labels.source_cluster }}
+        description: >
+          namespace-lister pod '{{ $labels.pod }}' on cluster '{{ $labels.source_cluster }}'
+          is receiving requests but returning no 2xx responses.
+        alert_routing_key: <!subteam^S06G3MJT516>
+        team: workspaces
+        runbook_url: null

--- a/rhobs/alerting/data_plane/prometheus.namespace_lister_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.namespace_lister_alerts.yaml
@@ -62,6 +62,10 @@ spec:
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/namespace-lister/README.md
 
     - alert: NamespaceListerNotServingRequests
+      # The unless operator is binary: any nonzero 2xx rate fully suppresses the alert.
+      # This assumes health probes (/healthz, /readyz) are NOT counted in
+      # namespace_lister_api_counter. If health probes are later found to be included,
+      # switch to a ratio-based approach: rate(2xx) / rate(total) < threshold.
       expr: |
         sum by (source_cluster, pod) (rate(namespace_lister_api_counter[5m])) > 0
         unless

--- a/rhobs/alerting/data_plane/prometheus.namespace_lister_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.namespace_lister_alerts.yaml
@@ -66,7 +66,6 @@ spec:
         sum by (source_cluster, pod) (rate(namespace_lister_api_counter[5m])) > 0
         unless
         sum by (source_cluster, pod) (rate(namespace_lister_api_counter{code=~"2.."}[5m])) > 0
-      for: 5m
       labels:
         severity: warning
         component: namespace-lister

--- a/rhobs/alerting/data_plane/prometheus.namespace_lister_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.namespace_lister_alerts.yaml
@@ -66,6 +66,7 @@ spec:
         sum by (source_cluster, pod) (rate(namespace_lister_api_counter[5m])) > 0
         unless
         sum by (source_cluster, pod) (rate(namespace_lister_api_counter{code=~"2.."}[5m])) > 0
+      for: 2m
       labels:
         severity: warning
         component: namespace-lister

--- a/test/promql/tests/data_plane/konflux_ui_alerts_test.yaml
+++ b/test/promql/tests/data_plane/konflux_ui_alerts_test.yaml
@@ -264,6 +264,9 @@ tests:
       # Only 404s, no 502s - should not fire
       - series: 'nginx_otel_http_request_errors_total{namespace="konflux-ui", status="404", source_cluster="c_upstream_ok", job="proxy"}'
         values: '0+10x10'
+      # Brief 502 burst during rolling deploy then stops - should not fire
+      - series: 'nginx_otel_http_request_errors_total{namespace="konflux-ui", status="502", source_cluster="c_upstream_burst", job="proxy"}'
+        values: '0 1 2 2 2 2 2 2 2 2'
 
     alert_rule_test:
       - eval_time: 3m
@@ -282,4 +285,22 @@ tests:
                 is down or unreachable.
               alert_team_handle: <!subteam^S04HY632621>
               team: konflux-ui
-              runbook_url: null
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/konflux-ui/sre/upstream-502.md
+      # Brief burst should not fire after it ends
+      - eval_time: 5m
+        alertname: KonfluxUIUpstream502
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: konflux-ui
+              slo: "true"
+              source_cluster: c_upstream_502
+            exp_annotations:
+              summary: Konflux UI proxy returning 502 errors in cluster c_upstream_502
+              description: >
+                The Konflux UI nginx proxy has been returning 502 errors for 2min in cluster
+                c_upstream_502, indicating an upstream backend (e.g. namespace-lister)
+                is down or unreachable.
+              alert_team_handle: <!subteam^S04HY632621>
+              team: konflux-ui
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/konflux-ui/sre/upstream-502.md

--- a/test/promql/tests/data_plane/konflux_ui_alerts_test.yaml
+++ b/test/promql/tests/data_plane/konflux_ui_alerts_test.yaml
@@ -255,3 +255,31 @@ tests:
       - eval_time: 7m
         alertname: KonfluxUIHttpHigh5xxErrorRate
         exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      # Sustained 502s - should fire
+      - series: 'nginx_otel_http_request_errors_total{namespace="konflux-ui", status="502", source_cluster="c_upstream_502", job="proxy"}'
+        values: '0+10x10'
+      # Only 404s, no 502s - should not fire
+      - series: 'nginx_otel_http_request_errors_total{namespace="konflux-ui", status="404", source_cluster="c_upstream_ok", job="proxy"}'
+        values: '0+10x10'
+
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: KonfluxUIUpstream502
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: konflux-ui
+              slo: "true"
+              source_cluster: c_upstream_502
+            exp_annotations:
+              summary: Konflux UI proxy returning 502 errors in cluster c_upstream_502
+              description: >
+                The Konflux UI nginx proxy has been returning 502 errors for 2min in cluster
+                c_upstream_502, indicating an upstream backend (e.g. namespace-lister)
+                is down or unreachable.
+              alert_team_handle: <!subteam^S04HY632621>
+              team: konflux-ui
+              runbook_url: null

--- a/test/promql/tests/data_plane/namespace_lister_test.yaml
+++ b/test/promql/tests/data_plane/namespace_lister_test.yaml
@@ -188,6 +188,19 @@ tests:
     alertname: NamespaceListerNotServingRequests
     exp_alerts: []
 
+# namespace-lister serving equal rates of 2xx and 5xx - should not fire (any nonzero 2xx suppresses the alert)
+- interval: 1m
+  input_series:
+  - series: 'namespace_lister_api_counter{source_cluster="c4", code="200", pod="pod-4"}'
+    values: '0+1x15'
+  - series: 'namespace_lister_api_counter{source_cluster="c4", code="500", pod="pod-4"}'
+    values: '0+1x15'
+
+  alert_rule_test:
+  - eval_time: 8m
+    alertname: NamespaceListerNotServingRequests
+    exp_alerts: []
+
 # namespace-lister idle, no incoming traffic - should not fire
 - interval: 1m
   input_series:

--- a/test/promql/tests/data_plane/namespace_lister_test.yaml
+++ b/test/promql/tests/data_plane/namespace_lister_test.yaml
@@ -150,3 +150,51 @@ tests:
             alert_team_handle: <!subteam^S05Q1P4Q2TG>
             team: konflux-infra
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/namespace-lister/README.md
+
+# namespace-lister serving only errors - should fire
+- interval: 1m
+  input_series:
+  - series: 'namespace_lister_api_counter{source_cluster="c1", code="500", pod="pod-1"}'
+    values: '0+1x15'
+
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: NamespaceListerNotServingRequests
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        component: namespace-lister
+        source_cluster: c1
+        pod: pod-1
+      exp_annotations:
+        summary: namespace-lister is receiving requests but returning no successful responses in cluster c1
+        description: >
+          namespace-lister pod 'pod-1' on cluster 'c1'
+          is receiving requests but returning no 2xx responses.
+        alert_routing_key: <!subteam^S06G3MJT516>
+        team: workspaces
+        runbook_url: null
+
+# namespace-lister serving mix of 200 and 500 - should not fire
+- interval: 1m
+  input_series:
+  - series: 'namespace_lister_api_counter{source_cluster="c2", code="200", pod="pod-2"}'
+    values: '0+10x15'
+  - series: 'namespace_lister_api_counter{source_cluster="c2", code="500", pod="pod-2"}'
+    values: '0+1x15'
+
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: NamespaceListerNotServingRequests
+    exp_alerts: []
+
+# namespace-lister idle, no incoming traffic - should not fire
+- interval: 1m
+  input_series:
+  - series: 'namespace_lister_api_counter{source_cluster="c3", code="200", pod="pod-3"}'
+    values: '5x15'
+
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: NamespaceListerNotServingRequests
+    exp_alerts: []

--- a/test/promql/tests/data_plane/namespace_lister_test.yaml
+++ b/test/promql/tests/data_plane/namespace_lister_test.yaml
@@ -158,7 +158,7 @@ tests:
     values: '0+1x15'
 
   alert_rule_test:
-  - eval_time: 6m
+  - eval_time: 8m
     alertname: NamespaceListerNotServingRequests
     exp_alerts:
     - exp_labels:
@@ -184,7 +184,7 @@ tests:
     values: '0+1x15'
 
   alert_rule_test:
-  - eval_time: 6m
+  - eval_time: 8m
     alertname: NamespaceListerNotServingRequests
     exp_alerts: []
 
@@ -195,6 +195,6 @@ tests:
     values: '5x15'
 
   alert_rule_test:
-  - eval_time: 6m
+  - eval_time: 8m
     alertname: NamespaceListerNotServingRequests
     exp_alerts: []

--- a/test/promql/tests/data_plane/namespace_lister_test.yaml
+++ b/test/promql/tests/data_plane/namespace_lister_test.yaml
@@ -158,7 +158,7 @@ tests:
     values: '0+1x15'
 
   alert_rule_test:
-  - eval_time: 10m
+  - eval_time: 6m
     alertname: NamespaceListerNotServingRequests
     exp_alerts:
     - exp_labels:
@@ -184,7 +184,7 @@ tests:
     values: '0+1x15'
 
   alert_rule_test:
-  - eval_time: 10m
+  - eval_time: 6m
     alertname: NamespaceListerNotServingRequests
     exp_alerts: []
 
@@ -195,6 +195,6 @@ tests:
     values: '5x15'
 
   alert_rule_test:
-  - eval_time: 10m
+  - eval_time: 6m
     alertname: NamespaceListerNotServingRequests
     exp_alerts: []


### PR DESCRIPTION
  Description:
  ## Summary

  - Add `KonfluxUIUpstream502` alert: fires when the nginx proxy in the `konflux-ui` namespace returns 502 errors for 2 minutes, indicating an upstream backend (e.g. namespace-lister) is down or unreachable. This covers the monitoring gap exposed by the namespace-lister incident
  where proxy pods were healthy but the backend was not serving requests.
  - Add `NamespaceListerNotServingRequests` alert: fires when namespace-lister pods are receiving traffic but returning no 2xx responses for 5 minutes.

  ## Jira Ticket
  
  SPRE-4428


---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
