### PR TITLE
 SPRE-5786  Alert Review & Tuning: KonfluxAlert: Prometheus.availability metric konflux alerts.yaml

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml
@@ -11,7 +11,7 @@ spec:
     rules:
     - alert: KonfluxAlert
       expr: (konflux_up offset 1h) unless on(service, check, source_cluster) konflux_up
-      for: 15m
+      for: 30m
       labels:
         severity: warning
       annotations:

--- a/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
+++ b/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
@@ -15,7 +15,7 @@ tests:
       - eval_time: 70m
         alertname: KonfluxAlert
 
-      - eval_time: 90m
+      - eval_time: 105m
         alertname: KonfluxAlert
         exp_alerts:
           - exp_labels:


### PR DESCRIPTION
### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

The alert fires ~125 times/day. Most of those are transient gaps — a pod restarts during a rollout, a scrape times out, a node reschedules workloads. The metric disappears briefly, then comes back.

  - Prior tuning (SPRE-5244) moved for from 5m to 15m. That filtered out gaps under 15 minutes, but 1,745 firings still remained in 14 days.
  - That tells you a lot of gaps last 15-30 minutes per deployment rollouts, scrape timeout cascades, pod rescheduling across nodes.
  - Raising to 30m means the metric must be continuously absent for 30 straight minutes before the alert fires. Transient gaps that recover within that window are silently absorbed.

[https://redhat.atlassian.net/issues?jql=assignee%20%3D%20currentUser()%20AND%20project%3D%27SPRE%27%20AND%20statusCategory%20!%3D%203&selectedIssue=SPRE-5786](url)


---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.

Bash(make selective-check-and-test RULE_FILES="rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml" TEST_CASE_FILES="test/promql/tests/data_plane/availability_metric_konflux_test.yaml"
      2>&1)
  ⎿  Executing selective-check-and-test...
     Setting up temporary directories /home/gwinn/prometheus/o11y/selective_rules_check_temp.7Vmj5D/rules/ and /home/gwinn/prometheus/o11y/selective_rules_check_temp.7Vmj5D/tests/...
     Full temporary directory path: /home/gwinn/prometheus/o11y/selective_rules_check_temp.7Vmj5D
     Basename of temporary directory: selective_rules_check_temp.7Vmj5D
     Copying rule files: rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml
     Copying test files: test/promql/tests/data_plane/availability_metric_konflux_test.yaml
     Running checker command: /usr/bin/podman run -v /home/gwinn/prometheus/o11y:/work --rm --privileged -t quay.io/rhobs/obsctl-reloader-rules-checker:1.0.4 -t rhtap ...
     INFO[0000] checking rules...
     INFO[0000] [/work/selective_rules_check_temp.7Vmj5D/rules/prometheus.availability_metric_konflux_alerts.yaml] done
     INFO[0000] running YAML linter...
     INFO[0000] [/work/selective_rules_check_temp.7Vmj5D/rules/prometheus.availability_metric_konflux_alerts.yaml] done
     INFO[0000] [/work/selective_rules_check_temp.7Vmj5D/tests/availability_metric_konflux_test.yaml] done
     INFO[0000] running 'pint' linter...
     INFO[0000] [/work/selective_rules_check_temp.7Vmj5D/rules/prometheus.availability_metric_konflux_alerts.yaml] done
     INFO[0000] running the unit tests...
     INFO[0000] [/work/selective_rules_check_temp.7Vmj5D/tests/availability_metric_konflux_test.yaml] done
     INFO[0000] ALL DONE OK! :-)
     Checker command processing finished.
     Cleaning up /home/gwinn/prometheus/o11y/selective_rules_check_temp.7Vmj5D/ directory...
     Cleanup finished.
     Execution completed.
                                                                                                                                                                             

- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
