### PR TITLE
PVO11Y-5329 - Update cold start limits to prevent truncation

### DIFF
--- a/config/exporters/monitoring/kaexporter/base/kaexporter-service.yaml
+++ b/config/exporters/monitoring/kaexporter/base/kaexporter-service.yaml
@@ -148,7 +148,7 @@ spec:
               path: /healthz
               port: http-metrics
             periodSeconds: 5
-            failureThreshold: 180
+            failureThreshold: 420
           livenessProbe:
             httpGet:
               path: /healthz

--- a/exporters/kaexporter/DESIGN.md
+++ b/exporters/kaexporter/DESIGN.md
@@ -15,7 +15,7 @@ This document explains the architectural decisions, implementation details, and 
 
 **Key Design Goals:**
 - Achieve 30-day SLO accuracy from the moment the exporter starts (cold-start bootstrapping)
-- Work within KubeArchive's 10,000-item pagination limit
+- Handle high-volume namespaces with up to 30,000 items per 30-day window
 - Handle multi-tenant environments with hundreds of namespaces
 - Minimize memory footprint and query load on KubeArchive
 - Maintain thread-safe concurrent collection without blocking Prometheus scrapes
@@ -34,9 +34,9 @@ This document explains the architectural decisions, implementation details, and 
 ```
 Cold Start Settings:
 - Query window: 720h (30 days)
-- Collection timeout: 600s (10 minutes)
+- Collection timeout: 1,800s (30 minutes)
 - Concurrency: 5 parallel requests
-- Per-namespace item cap: 10,000
+- Per-namespace item cap: 30,000
 
 Steady State Settings:
 - Query window: 36h (24h base + 50% safety margin)
@@ -52,37 +52,23 @@ Steady State Settings:
 
 **Trade-offs:**
 - **Pro:** Metrics are immediately accurate; no warm-up period
-- **Pro:** Pod restarts don't leave SLO gaps (cold start rebuilds state in ~95 seconds)
-- **Con:** Longer startup time (~95s vs instant)
+- **Pro:** Pod restarts don't leave SLO gaps (cold start rebuilds state in 10-15 minutes)
+- **Con:** Longer startup time (10-15min vs instant)
 - **Con:** Higher KubeArchive load during cold start (mitigated by reduced concurrency)
 
 ---
 
 ### 2. Gap-Filling for Busy Namespaces
 
-**Problem:** Namespaces with >10,000 PipelineRuns in 30 days hit KubeArchive's pagination limit during cold start, resulting in truncated data.
+**Problem:** Namespaces with >30,000 PipelineRuns in 30 days hit the cold-start item cap, resulting in truncated data.
 
 **Solution:** Progressive gap-filling mechanism that retries truncated namespaces with narrower time windows.
 
 **How It Works:**
-1. During cold start, if a namespace hits the 10K limit, mark it as "truncated" and record the oldest fetched timestamp
+1. During cold start, if a namespace hits the 30K limit, mark it as "truncated" and record the oldest fetched timestamp
 2. Schedule a background gap-fill attempt with a narrower time window (query older data before the truncation point)
-3. Limit gap-fill to **5 attempts per namespace** to prevent infinite retries
+3. Limit gap-fill to **5 attempts per namespace** to prevent infinite retries (total coverage up to 150K items)
 4. Track gap-fill attempts and exhaustion via Prometheus counters
-
-**Example:**
-```
-Initial query: 2026-05-25 → 2026-06-25 (30 days)
-  Result: Truncated at 10K items, oldest timestamp = 2026-06-10
-
-Gap-fill attempt #1: 2026-05-25 → 2026-06-10
-  Result: Truncated at 10K items, oldest timestamp = 2026-05-28
-
-Gap-fill attempt #2: 2026-05-25 → 2026-05-28
-  Result: Success, 3,500 items fetched
-
-Total coverage: ~13,500 items across 30 days
-```
 
 **Trade-offs:**
 - **Pro:** Captures more data for busy namespaces (instead of dropping 30-day history)
@@ -229,19 +215,19 @@ Typical deployment (500 label combinations):
 
 ---
 
-### 2. KubeArchive Item Cap (10,000 per query)
+### 2. Cold Start Item Cap (30,000 per query)
 
-**Limitation:** Busy namespaces with >10,000 PLRs in 30 days will be truncated during cold start.
+**Limitation:** Extremely busy namespaces with >30,000 PLRs in 30 days will be truncated during cold start.
 
 **Mitigations:**
-- Gap-fill mechanism retries with narrower time windows
+- Gap-fill mechanism retries with narrower time windows (up to 5 attempts = 150K total coverage)
 - Truncation metrics track occurrences: `kaexporter_truncations_total{resource="pipelineruns"}`
 - Per-namespace bootstrap state prevents repeated failures
 
 **When This Happens:**
 - Typical namespace: ~100-500 PLRs/day → no issue
-- Busy namespace: >300 PLRs/day → may hit 10K limit over 30 days
-- Very busy namespace: >500 PLRs/day → gap-fill may also truncate
+- Busy namespace: 500-1,000 PLRs/day → may hit 30K limit over 30 days
+- Very busy namespace: >1,000 PLRs/day → gap-fill may also truncate (uses additional 5 attempts)
 
 ---
 
@@ -252,7 +238,7 @@ Typical deployment (500 label combinations):
 **Why:** Stateless design (no PVC, no external storage).
 
 **Mitigations:**
-- Cold start rebuilds state in ~95 seconds
+- Cold start rebuilds state in 10-15 minutes
 - Acceptable for SLO aggregates (not critical raw events)
 - Future enhancement: Optional persistence to PVC or remote storage
 
@@ -281,7 +267,7 @@ err := e.collectMetrics(ctx) // Queries all namespaces in parallel
 **Trade-offs:**
 - **Pro:** Prevents cascading delays from slow namespaces
 - **Con:** One slow namespace can cause all namespaces to skip a cycle
-- **Mitigation:** Use generous timeout (10min cold start, 2min steady state)
+- **Mitigation:** Use generous timeout (30min cold start, 2min steady state)
 
 ---
 

--- a/exporters/kaexporter/collector.go
+++ b/exporters/kaexporter/collector.go
@@ -232,9 +232,9 @@ func (e *KAExporter) collectMetrics(ctx context.Context) (*releaseIndex, error) 
 
 			if !bootstrapped {
 				windowHours = coldStartWindowHours // 720h (30 days)
-				maxItems = coldStartMaxItems       // 10,000
-				// Give each non-bootstrapped namespace its own independent 10-minute timeout.
-				// Derive from Background() to get full 600s independent of the 120s steady-state
+				maxItems = coldStartMaxItems       // 30,000
+				// Give each non-bootstrapped namespace its own independent 30-minute timeout.
+				// Derive from Background() to get full 1800s independent of the 120s steady-state
 				// collection timeout, but use AfterFunc to ensure SIGTERM cancels immediately.
 				nsCtx, nsCancel = context.WithTimeout(context.Background(), time.Duration(defaultColdStartTimeoutSecs)*time.Second)
 				defer nsCancel()
@@ -331,7 +331,7 @@ func (e *KAExporter) collectMetrics(ctx context.Context) (*releaseIndex, error) 
 					defer func() { <-gapSem }() // Release
 
 					// Use cold-start per-namespace timeout for gap-fill queries (30-day window).
-					// Derive from Background() to get full 600s independent of the 120s steady-state
+					// Derive from Background() to get full 1800s independent of the 120s steady-state
 					// collection timeout, but use AfterFunc to ensure SIGTERM cancels immediately.
 					gapCtx, cancel := context.WithTimeout(context.Background(), time.Duration(defaultColdStartTimeoutSecs)*time.Second)
 					defer cancel()
@@ -583,7 +583,6 @@ func (e *KAExporter) fillNamespaceGap(ctx context.Context, namespace string) {
 		log.Printf("namespace %q: bootstrap COMPLETE (%d builds, %d tests fetched in gap-fill)",
 			namespace, buildCnt, testCnt)
 	} else {
-		// Gap is still >10K, narrow the window further
 		updatedState.OldestSeenCreationTS = oldestTS
 		updatedState.GapAttempts++
 		log.Printf("namespace %q: gap-fill incomplete (%d builds, %d tests, still truncated, oldest now %s)",

--- a/exporters/kaexporter/exporter.go
+++ b/exporters/kaexporter/exporter.go
@@ -68,8 +68,8 @@ const (
 	// Cold-start configuration: on first boot the exporter queries 30 days of history
 	// to bootstrap full rolling-window accuracy, then switches to the steady-state window.
 	coldStartWindowHours        = 720   // 30 days
-	coldStartMaxItems           = 10000 // higher cap during bootstrap (busy namespaces exceed 1500 over 30d)
-	defaultColdStartTimeoutSecs = 600   // 10 min - allows busy namespaces to complete 30-day bootstrap
+	coldStartMaxItems           = 30000 // higher cap during bootstrap (handles high-volume namespaces with >10K PLRs/30d)
+	defaultColdStartTimeoutSecs = 1800  // 30 min - allows time for 60+ pages at 500 items/page
 
 	// parallelism for KubeArchive API calls.
 	defaultMaxConcurrent   = 10
@@ -96,7 +96,7 @@ const (
 	retryBackoffMultiplier   = 2.0
 
 	// maxGapFillAttempts limits gap-fill retries for truncated namespaces.
-	// With coldStartMaxItems=10,000, this allows up to 50,000 PLRs to be covered.
+	// With coldStartMaxItems=30,000, this allows up to 150,000 PLRs to be covered across 5 attempts.
 	maxGapFillAttempts = 5
 )
 


### PR DESCRIPTION
# Description

High-volume production namespaces (v5-0-openshift-virtualization-tenant, telco-5g-tenant, hummingbird-tenant) exceed the 10K PLR cold-start cap, causing truncated 30-day bootstrap. Affected namespaces have incomplete SLO metrics (missing 5-11 days of data) until gap-fill progressively recovers.

## What
Increases coldStartMaxItems from 10,000 → 30,000 and defaultColdStartTimeoutSecs from 600s (10 min) → 1800s (30 min) to accommodate namespaces with high pipeline volume during the initial 30-day backfill.

## Why is this change needed?
Based on the logs observation in the production logs

The busiest observed namespace: ~12K raw PLRs over 25 days (~14.5K extrapolated to 30d). 30K gives >2× headroom.
30K items / 500 per page = 60 pages. At ~1s/page + retry overhead, a single busy namespace may take ~90s. 
With 5 concurrency slots and 272 namespaces (most small), 30 min timeout provides adequate margin.
Steady-state (kaMaxItems = 1500) is unchanged and this only affects first-boot bootstrap.


## Testing
Unit tests pass no behavioral change to streaming/pagination logic, only constant values.

Observability validation: After deploy, confirm cold-start log shows "30-day bootstrap complete" (not "TRUNCATED") for previously-affected namespaces. Key log line: First collection complete in XXXs should be < 1800s.

Memory: No concern here as streamPLRs processes page-by-page via callback (no accumulation). 
Peak is bounded to one 500-item page in memory at a time per goroutine.

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
