### PR TITLE
chore(SRVKP-12264): omit Tekton Events Controller from konflux_up

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -258,29 +258,6 @@ spec:
           alert_team_handle: <!subteam^S04PYECHCCU>
           team: pipelines
           runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
-    - name: tekton-results-retention-policy-agent-availability
-      interval: 1m
-      rules:
-      - alert: TektonResultsRetentionPolicyAgentDown
-        expr: |
-          konflux_up{
-            namespace="tekton-results",
-            check="replicas-available",
-            service="tekton-results-retention-policy-agent",
-          } != 1
-        for: 5m
-        labels:
-          # Only affects record pruning
-          severity: warning
-          component: tekton-results
-        annotations:
-          summary: >-
-            Tekton Results Retention Policy Agent is down in cluster {{ $labels.source_cluster }}
-          description: >
-            The Tekton Results Retention Policy Agent pod has been down for 5min in cluster {{ $labels.source_cluster }}
-          alert_routing_key: <!subteam^S04PYECHCCU>
-          team: pipelines
-          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
     - name: tekton-pipelines-controller-availability
       interval: 1m
       rules:

--- a/rhobs/recording/pipelines_availability_recording_rules.yaml
+++ b/rhobs/recording/pipelines_availability_recording_rules.yaml
@@ -18,8 +18,16 @@ spec:
                 label_replace(
                   floor(
                     kube_deployment_status_replicas_available{
-                      namespace=~"openshift-pipelines|tekton-results"
-                    } / clamp_min(kube_deployment_spec_replicas{namespace=~"openshift-pipelines|tekton-results"}, 1)
+                      namespace=~"openshift-pipelines|tekton-results",
+                      # Disable recording the konflux_up signal for deployments which are scaled to zero
+                      deployment!~"tekton-events-controller|tekton-results-retention-policy-agent"
+                    } /
+                    clamp_min(
+                      kube_deployment_spec_replicas{
+                        namespace=~"openshift-pipelines|tekton-results"
+                      },
+                      1
+                    )
                   ), "check", "replicas-available", "",""
                 ), "service", "$1", "deployment","(.*)"
               ), 1
@@ -33,8 +41,14 @@ spec:
                 label_replace(
                   floor(
                     kube_statefulset_status_replicas_available{
-                      namespace=~"openshift-pipelines|tekton-results"
-                    } / clamp_min(kube_statefulset_replicas{namespace=~"openshift-pipelines|tekton-results"},1)
+                      namespace=~"openshift-pipelines|tekton-results",
+                    } /
+                    clamp_min(
+                        kube_statefulset_replicas{
+                          namespace=~"openshift-pipelines|tekton-results"
+                        },
+                      1
+                    )
                   ), "check", "replicas-available", "",""
                 ), "service", "$1", "statefulset","(.*)"
               ), 1

--- a/test/promql/tests/data_plane/pipelines_up_test.yaml
+++ b/test/promql/tests/data_plane/pipelines_up_test.yaml
@@ -51,10 +51,6 @@ tests:
         values: '1 1 1 1 1'
       - series: 'konflux_up{namespace="tekton-results", service="tekton-results-watcher", source_cluster="c_down"}'
         values: '1 1 1 1 1'
-      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-retention-policy-agent", source_cluster="c_up"}'
-        values: '1 1 1 1 1'
-      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-retention-policy-agent", source_cluster="c_down"}'
-        values: '1 1 1 1 1'
       - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-pipelines-controller", source_cluster="c_up"}'
         values: '1 1 1 1 1'
       - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-pipelines-controller", source_cluster="c_down"}'
@@ -96,9 +92,6 @@ tests:
         exp_alerts: []
       - eval_time: 5m
         alertname: TektonResultsWatcherDown
-        exp_alerts: []
-      - eval_time: 5m
-        alertname: TektonResultsRetentionPolicyAgentDown
         exp_alerts: []
   - name: PipelinesAlertsFiring
     interval: 1m
@@ -146,10 +139,6 @@ tests:
       - series: 'konflux_up{namespace="tekton-results", service="tekton-results-watcher", check="replicas-available", source_cluster="c_up"}'
         values: '1 1 1 1 1'
       - series: 'konflux_up{namespace="tekton-results", service="tekton-results-watcher", check="replicas-available", source_cluster="c_down"}'
-        values: '0 0 0 0 0'
-      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-retention-policy-agent", check="replicas-available", source_cluster="c_up"}'
-        values: '1 1 1 1 1'
-      - series: 'konflux_up{namespace="tekton-results", service="tekton-results-retention-policy-agent", check="replicas-available", source_cluster="c_down"}'
         values: '0 0 0 0 0'
       - series: 'konflux_up{namespace="openshift-pipelines", service="tekton-pipelines-controller", check="replicas-available", source_cluster="c_up"}'
         values: '1 1 1 1 1'
@@ -356,23 +345,6 @@ tests:
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
       - eval_time: 5m
-        alertname: TektonResultsRetentionPolicyAgentDown
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              check: replicas-available
-              namespace: tekton-results
-              service: tekton-results-retention-policy-agent
-              source_cluster: c_down
-              component: tekton-results
-            exp_annotations:
-              summary: Tekton Results Retention Policy Agent is down in cluster c_down
-              description: >
-                The Tekton Results Retention Policy Agent pod has been down for 5min in cluster c_down
-              alert_routing_key: <!subteam^S04PYECHCCU>
-              team: pipelines
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
-      - eval_time: 5m
         alertname: TektonResultsWatcherDown
         exp_alerts:
           - exp_labels:
@@ -388,23 +360,6 @@ tests:
               description: >
                 The Tekton Results watcher pod has been down for 5min in cluster c_down
               alert_team_handle: <!subteam^S04PYECHCCU>
-              team: pipelines
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
-      - eval_time: 5m
-        alertname: TektonResultsRetentionPolicyAgentDown
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              check: replicas-available
-              namespace: tekton-results
-              service: tekton-results-retention-policy-agent
-              source_cluster: c_down
-              component: tekton-results
-            exp_annotations:
-              summary: Tekton Results Retention Policy Agent is down in cluster c_down
-              description: >
-                The Tekton Results Retention Policy Agent pod has been down for 5min in cluster c_down
-              alert_routing_key: <!subteam^S04PYECHCCU>
               team: pipelines
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/pipeline-service/faq.md
       - eval_time: 5m

--- a/test/promql/tests/recording/pipelines_service_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/pipelines_service_availability_recording_rules_test.yaml
@@ -51,10 +51,6 @@ tests:
         values: '1 1 1 1 1'
       - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-watcher"}'
         values: '1 1 1 1 1'
-      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
-        values: '1 1 1 1 1'
-      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
-        values: '1 1 1 1 1'
       - series: 'kube_statefulset_replicas{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
         values: '1 1 1 1 1'
       - series: 'kube_statefulset_status_replicas_available{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
@@ -88,8 +84,6 @@ tests:
           - labels: konflux_up{deployment='tekton-results-api-for-watcher', service='tekton-results-api-for-watcher', check='replicas-available', namespace='tekton-results'}
             value: 1
           - labels: konflux_up{deployment='tekton-results-watcher', service='tekton-results-watcher', check='replicas-available', namespace='tekton-results'}
-            value: 1
-          - labels: konflux_up{deployment='tekton-results-retention-policy-agent', service='tekton-results-retention-policy-agent', check='replicas-available', namespace='tekton-results'}
             value: 1
           - labels: konflux_up{statefulset='tekton-pipelines-controller', service='tekton-pipelines-controller', check='replicas-available', namespace='openshift-pipelines'}
             value: 1
@@ -143,10 +137,6 @@ tests:
         values: '1 1 1 1 1'
       - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-watcher"}'
         values: '0 1 0 1 0'
-      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
-        values: '1 1 1 1 1'
-      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
-        values: '0 1 0 1 0'
       - series: 'kube_statefulset_replicas{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
         values: '1 1 1 1 1'
       - series: 'kube_statefulset_status_replicas_available{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
@@ -180,8 +170,6 @@ tests:
           - labels: konflux_up{deployment='tekton-results-api-for-watcher', service='tekton-results-api-for-watcher', check='replicas-available', namespace='tekton-results'}
             value: 0
           - labels: konflux_up{deployment='tekton-results-watcher', service='tekton-results-watcher', check='replicas-available', namespace='tekton-results'}
-            value: 0
-          - labels: konflux_up{deployment='tekton-results-retention-policy-agent', service='tekton-results-retention-policy-agent', check='replicas-available', namespace='tekton-results'}
             value: 0
           - labels: konflux_up{statefulset='tekton-pipelines-controller', service='tekton-pipelines-controller', check='replicas-available', namespace='openshift-pipelines'}
             value: 0
@@ -235,10 +223,6 @@ tests:
         values: '1 1 1 1 1'
       - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-watcher"}'
         values: '0 0 0 0 0'
-      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
-        values: '1 1 1 1 1'
-      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
-        values: '0 0 0 0 0'
       - series: 'kube_statefulset_replicas{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
         values: '1 1 1 1 1'
       - series: 'kube_statefulset_status_replicas_available{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
@@ -272,8 +256,6 @@ tests:
           - labels: konflux_up{deployment='tekton-results-api-for-watcher', service='tekton-results-api-for-watcher', check='replicas-available', namespace='tekton-results'}
             value: 0
           - labels: konflux_up{deployment='tekton-results-watcher', service='tekton-results-watcher', check='replicas-available', namespace='tekton-results'}
-            value: 0
-          - labels: konflux_up{deployment='tekton-results-retention-policy-agent', service='tekton-results-retention-policy-agent', check='replicas-available', namespace='tekton-results'}
             value: 0
           - labels: konflux_up{statefulset='tekton-pipelines-controller', service='tekton-pipelines-controller', check='replicas-available', namespace='openshift-pipelines'}
             value: 0
@@ -327,10 +309,6 @@ tests:
         values: '0 0 0 0 0'
       - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-watcher"}'
         values: '0 0 0 0 0'
-      - series: 'kube_deployment_spec_replicas{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
-        values: '0 0 0 0 0'
-      - series: 'kube_deployment_status_replicas_available{namespace="tekton-results", deployment="tekton-results-retention-policy-agent"}'
-        values: '0 0 0 0 0'
       - series: 'kube_statefulset_replicas{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
         values: '0 0 0 0 0'
       - series: 'kube_statefulset_status_replicas_available{namespace="openshift-pipelines", statefulset="tekton-pipelines-controller"}'
@@ -364,8 +342,6 @@ tests:
           - labels: konflux_up{deployment='tekton-results-api-for-watcher', service='tekton-results-api-for-watcher', check='replicas-available', namespace='tekton-results'}
             value: 0
           - labels: konflux_up{deployment='tekton-results-watcher', service='tekton-results-watcher', check='replicas-available', namespace='tekton-results'}
-            value: 0
-          - labels: konflux_up{deployment='tekton-results-retention-policy-agent', service='tekton-results-retention-policy-agent', check='replicas-available', namespace='tekton-results'}
             value: 0
           - labels: konflux_up{statefulset='tekton-pipelines-controller', service='tekton-pipelines-controller', check='replicas-available', namespace='openshift-pipelines'}
             value: 0


### PR DESCRIPTION
### Description

Omit the Tekton Events Controller from the `konflux_up` signal recorder.

Tested in Grafana:
<img width="1222" height="1227" alt="image" src="https://github.com/user-attachments/assets/e9deb105-f653-4178-946c-8645c4b6fcaf" />


---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
