### PR TITLE
feat(KONFLUX-14971, kaexporter): use cfg file for tenant exclusions

### DIFF
--- a/config/exporters/monitoring/kaexporter/base/kaexporter-service.yaml
+++ b/config/exporters/monitoring/kaexporter/base/kaexporter-service.yaml
@@ -83,20 +83,6 @@ spec:
   selector:
     app: kaexporter
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kaexporter-config
-  namespace: konflux-o11y-exporters
-data:
-  config.yaml: |
-    excludeNamespaces:
-      - rhtap-releng-tenant
-      - "managed-*"
-      - dev-release-team-tenant
-      - "konflux-perfscale-*-tenant"
-      - build-templates-e2e
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -113,10 +99,6 @@ spec:
         app: kaexporter
     spec:
       serviceAccountName: kaexporter-sa
-      volumes:
-        - name: kaexporter-config
-          configMap:
-            name: kaexporter-config
       containers:
         - name: kube-rbac-proxy
           image: quay.io/brancz/kube-rbac-proxy:v0.14.0
@@ -161,12 +143,6 @@ spec:
               value: "9101"
             - name: KA_COLLECTION_TIMEOUT_SECONDS
               value: "160"
-            - name: KA_CONFIG_FILE
-              value: "/etc/kaexporter/config.yaml"
-          volumeMounts:
-            - name: kaexporter-config
-              mountPath: /etc/kaexporter
-              readOnly: true
           startupProbe:
             httpGet:
               path: /healthz

--- a/config/exporters/monitoring/kaexporter/base/kaexporter-service.yaml
+++ b/config/exporters/monitoring/kaexporter/base/kaexporter-service.yaml
@@ -83,6 +83,20 @@ spec:
   selector:
     app: kaexporter
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kaexporter-config
+  namespace: konflux-o11y-exporters
+data:
+  config.yaml: |
+    excludeNamespaces:
+      - rhtap-releng-tenant
+      - "managed-*"
+      - dev-release-team-tenant
+      - "konflux-perfscale-*-tenant"
+      - build-templates-e2e
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -99,6 +113,10 @@ spec:
         app: kaexporter
     spec:
       serviceAccountName: kaexporter-sa
+      volumes:
+        - name: kaexporter-config
+          configMap:
+            name: kaexporter-config
       containers:
         - name: kube-rbac-proxy
           image: quay.io/brancz/kube-rbac-proxy:v0.14.0
@@ -143,6 +161,12 @@ spec:
               value: "9101"
             - name: KA_COLLECTION_TIMEOUT_SECONDS
               value: "160"
+            - name: KA_CONFIG_FILE
+              value: "/etc/kaexporter/config.yaml"
+          volumeMounts:
+            - name: kaexporter-config
+              mountPath: /etc/kaexporter
+              readOnly: true
           startupProbe:
             httpGet:
               path: /healthz

--- a/exporters/kaexporter/README.md
+++ b/exporters/kaexporter/README.md
@@ -24,7 +24,21 @@ Exposes mean duration and success rate metrics over a rolling 30-day window usin
 | `KA_MAX_RETRIES` | No | `3` | Max retries per failed KubeArchive request (exponential backoff). |
 | `KA_INITIAL_RETRY_DELAY_MS` | No | `100` | Initial retry delay in milliseconds. |
 | `KA_MAX_RETRY_DELAY_MS` | No | `5000` | Maximum retry delay cap in milliseconds. |
+| `KA_CONFIG_FILE` | No | *(empty)* | Path to YAML config file. When set, the file controls which namespaces are excluded from collection. When unset, no namespaces are excluded. |
 | `EXPORTER_PORT` | No | `9101` | HTTP listen port. |
+
+### Configuration file
+
+When `KA_CONFIG_FILE` is set, the exporter reads a YAML file that specifies namespaces to exclude from metric collection. Entries containing `*` are treated as glob patterns (using Go's `path.Match`); all others are exact matches. The `*` wildcard matches any sequence of characters and can appear anywhere in the pattern — leading (`*-managed`), trailing (`managed-*`), or mid-string (`konflux-perfscale-*-tenant`).
+
+```yaml
+excludeNamespaces:
+  - rhtap-releng-tenant
+  - "managed-*"
+  - "konflux-perfscale-*-tenant"
+```
+
+If the file is specified but cannot be read or parsed, the exporter fails to start. When `KA_CONFIG_FILE` is not set, no namespaces are excluded.
 
 ### Cold start behavior
 

--- a/exporters/kaexporter/collector.go
+++ b/exporters/kaexporter/collector.go
@@ -398,35 +398,13 @@ func (e *KAExporter) tenantNamespaces(ctx context.Context) ([]string, error) {
 
 	sort.Strings(names)
 
-	// Filter out managed tenants that should not be scraped.
-	// rhtap-releng-tenant is a special managed tenant with different SLO expectations.
-	filtered := filterManagedTenants(names)
+	filtered := e.nsFilter.apply(names)
 	if len(filtered) < len(names) {
 		excluded := len(names) - len(filtered)
-		log.Printf("Filtered out %d managed tenant namespace(s) from scraping", excluded)
+		log.Printf("Filtered out %d namespace(s) from scraping (filter: %s)", excluded, e.nsFilter.source)
 	}
 
 	return filtered, nil
-}
-
-// filterManagedTenants removes namespaces that should not be scraped.
-// Excludes:
-//   - rhtap-releng-tenant: special managed tenant with separate monitoring
-//   - managed-*: other managed tenant namespaces
-func filterManagedTenants(namespaces []string) []string {
-	var result []string
-	for _, ns := range namespaces {
-		// Exact match: rhtap-releng-tenant
-		if ns == "rhtap-releng-tenant" {
-			continue
-		}
-		// Prefix match: managed-*
-		if strings.HasPrefix(ns, "managed-") {
-			continue
-		}
-		result = append(result, ns)
-	}
-	return result
 }
 
 // gatherAllReleasesParallel fetches Release CRs from every tenant namespace in parallel

--- a/exporters/kaexporter/config.go
+++ b/exporters/kaexporter/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"strings"
@@ -35,12 +36,12 @@ func loadConfig(path string) (*KAConfig, error) {
 	return &cfg, nil
 }
 
-func newNamespaceFilter(cfg *KAConfig) *namespaceFilter {
+func newNamespaceFilter(cfg *KAConfig) (*namespaceFilter, error) {
 	if cfg == nil {
 		return &namespaceFilter{
 			exactMatches: make(map[string]bool),
 			source:       "none",
-		}
+		}, nil
 	}
 
 	f := &namespaceFilter{
@@ -53,12 +54,15 @@ func newNamespaceFilter(cfg *KAConfig) *namespaceFilter {
 			continue
 		}
 		if strings.Contains(entry, "*") {
+			if _, err := path.Match(entry, "validate"); err != nil {
+				return nil, fmt.Errorf("invalid glob pattern %q: %w", entry, err)
+			}
 			f.patterns = append(f.patterns, entry)
 		} else {
 			f.exactMatches[entry] = true
 		}
 	}
-	return f
+	return f, nil
 }
 
 func (f *namespaceFilter) apply(namespaces []string) []string {
@@ -69,7 +73,12 @@ func (f *namespaceFilter) apply(namespaces []string) []string {
 		}
 		excluded := false
 		for _, pattern := range f.patterns {
-			if matched, _ := path.Match(pattern, ns); matched {
+			matched, err := path.Match(pattern, ns)
+			if err != nil {
+				log.Printf("WARNING: invalid glob pattern %q (skipping): %v", pattern, err)
+				continue
+			}
+			if matched {
 				excluded = true
 				break
 			}

--- a/exporters/kaexporter/config.go
+++ b/exporters/kaexporter/config.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// KAConfig represents the YAML configuration file for the exporter.
+type KAConfig struct {
+	ExcludeNamespaces []string `yaml:"excludeNamespaces"`
+}
+
+// namespaceFilter holds parsed exclusion rules for namespace filtering.
+type namespaceFilter struct {
+	exactMatches map[string]bool
+	patterns     []string
+	source       string // "config" or "none"
+}
+
+func loadConfig(path string) (*KAConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config file %s: %w", path, err)
+	}
+
+	var cfg KAConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse config file %s: %w", path, err)
+	}
+
+	return &cfg, nil
+}
+
+func newNamespaceFilter(cfg *KAConfig) *namespaceFilter {
+	if cfg == nil {
+		return &namespaceFilter{
+			exactMatches: make(map[string]bool),
+			source:       "none",
+		}
+	}
+
+	f := &namespaceFilter{
+		exactMatches: make(map[string]bool),
+		source:       "config",
+	}
+	for _, entry := range cfg.ExcludeNamespaces {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if strings.Contains(entry, "*") {
+			f.patterns = append(f.patterns, entry)
+		} else {
+			f.exactMatches[entry] = true
+		}
+	}
+	return f
+}
+
+func (f *namespaceFilter) apply(namespaces []string) []string {
+	var result []string
+	for _, ns := range namespaces {
+		if f.exactMatches[ns] {
+			continue
+		}
+		excluded := false
+		for _, pattern := range f.patterns {
+			if matched, _ := path.Match(pattern, ns); matched {
+				excluded = true
+				break
+			}
+		}
+		if !excluded {
+			result = append(result, ns)
+		}
+	}
+	return result
+}

--- a/exporters/kaexporter/config_test.go
+++ b/exporters/kaexporter/config_test.go
@@ -68,6 +68,26 @@ func TestLoadConfig(t *testing.T) {
 		},
 	}
 
+	invalidGlobTests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "invalid glob pattern",
+			content: `excludeNamespaces:
+  - "bad[*"
+`,
+		},
+		{
+			name: "invalid glob among valid entries",
+			content: `excludeNamespaces:
+  - exact-ns
+  - "valid-*"
+  - "[-*"
+`,
+		},
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "config.yaml")
@@ -86,7 +106,10 @@ func TestLoadConfig(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			f := newNamespaceFilter(cfg)
+			f, filterErr := newNamespaceFilter(cfg)
+			if filterErr != nil {
+				t.Fatalf("unexpected newNamespaceFilter error: %v", filterErr)
+			}
 
 			if len(tt.wantExact) == 0 && len(f.exactMatches) != 0 {
 				t.Errorf("exactMatches: want empty, got %v", f.exactMatches)
@@ -109,6 +132,23 @@ func TestLoadConfig(t *testing.T) {
 			}
 		})
 	}
+
+	for _, tt := range invalidGlobTests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("write temp file: %v", err)
+			}
+			cfg, err := loadConfig(path)
+			if err != nil {
+				t.Fatalf("unexpected loadConfig error: %v", err)
+			}
+			_, err = newNamespaceFilter(cfg)
+			if err == nil {
+				t.Fatal("expected error for invalid glob pattern, got nil")
+			}
+		})
+	}
 }
 
 func TestLoadConfig_FileNotFound(t *testing.T) {
@@ -120,76 +160,76 @@ func TestLoadConfig_FileNotFound(t *testing.T) {
 
 func TestNamespaceFilter_Apply(t *testing.T) {
 	tests := []struct {
-		name       string
-		filter     *namespaceFilter
-		input      []string
-		want       []string
+		name   string
+		cfg    *KAConfig
+		input  []string
+		want   []string
 	}{
 		{
-			name:   "nil config excludes nothing",
-			filter: newNamespaceFilter(nil),
-			input:  []string{"my-tenant", "rhtap-releng-tenant", "managed-foo", "managed-bar", "other-ns"},
-			want:   []string{"my-tenant", "rhtap-releng-tenant", "managed-foo", "managed-bar", "other-ns"},
+			name:  "nil config excludes nothing",
+			cfg:   nil,
+			input: []string{"my-tenant", "rhtap-releng-tenant", "managed-foo", "managed-bar", "other-ns"},
+			want:  []string{"my-tenant", "rhtap-releng-tenant", "managed-foo", "managed-bar", "other-ns"},
 		},
 		{
 			name: "exact match only",
-			filter: newNamespaceFilter(&KAConfig{
+			cfg: &KAConfig{
 				ExcludeNamespaces: []string{"special-ns"},
-			}),
+			},
 			input: []string{"special-ns", "special-ns-2", "other"},
 			want:  []string{"special-ns-2", "other"},
 		},
 		{
 			name: "prefix match only",
-			filter: newNamespaceFilter(&KAConfig{
+			cfg: &KAConfig{
 				ExcludeNamespaces: []string{"test-*"},
-			}),
+			},
 			input: []string{"test-foo", "test-bar", "my-test", "production"},
 			want:  []string{"my-test", "production"},
 		},
 		{
 			name: "mixed exact and prefix",
-			filter: newNamespaceFilter(&KAConfig{
+			cfg: &KAConfig{
 				ExcludeNamespaces: []string{"exact-ns", "prefix-*"},
-			}),
+			},
 			input: []string{"exact-ns", "prefix-one", "prefix-two", "keep-me"},
 			want:  []string{"keep-me"},
 		},
 		{
 			name: "empty config excludes nothing",
-			filter: newNamespaceFilter(&KAConfig{
+			cfg: &KAConfig{
 				ExcludeNamespaces: []string{},
-			}),
+			},
 			input: []string{"rhtap-releng-tenant", "managed-foo", "anything"},
 			want:  []string{"rhtap-releng-tenant", "managed-foo", "anything"},
 		},
 		{
-			name:   "empty input",
-			filter: newNamespaceFilter(nil),
-			input:  nil,
-			want:   nil,
+			name:  "empty input",
+			cfg:   nil,
+			input: nil,
+			want:  nil,
 		},
 		{
 			name: "leading wildcard",
-			filter: newNamespaceFilter(&KAConfig{
+			cfg: &KAConfig{
 				ExcludeNamespaces: []string{"*-managed"},
-			}),
+			},
 			input: []string{"foo-managed", "bar-managed", "managed-foo", "other"},
 			want:  []string{"managed-foo", "other"},
 		},
 		{
 			name: "mid-string wildcard",
-			filter: newNamespaceFilter(&KAConfig{
+			cfg: &KAConfig{
 				ExcludeNamespaces: []string{"konflux-perfscale-*-tenant"},
-			}),
+			},
 			input: []string{"konflux-perfscale-large-tenant", "konflux-perfscale-small-tenant", "konflux-perfscale", "other-ns"},
 			want:  []string{"konflux-perfscale", "other-ns"},
 		},
 		{
 			name: "all excluded",
-			filter: newNamespaceFilter(&KAConfig{
+			cfg: &KAConfig{
 				ExcludeNamespaces: []string{"ns-a", "ns-b"},
-			}),
+			},
 			input: []string{"ns-a", "ns-b"},
 			want:  nil,
 		},
@@ -197,7 +237,11 @@ func TestNamespaceFilter_Apply(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.filter.apply(tt.input)
+			filter, err := newNamespaceFilter(tt.cfg)
+			if err != nil {
+				t.Fatalf("unexpected newNamespaceFilter error: %v", err)
+			}
+			got := filter.apply(tt.input)
 
 			if len(got) != len(tt.want) {
 				t.Fatalf("apply() = %v, want %v", got, tt.want)

--- a/exporters/kaexporter/config_test.go
+++ b/exporters/kaexporter/config_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantExact   []string
+		wantPattern  []string
+		wantErr     bool
+	}{
+		{
+			name: "exact and prefix patterns",
+			content: `excludeNamespaces:
+  - rhtap-releng-tenant
+  - "managed-*"
+`,
+			wantExact:  []string{"rhtap-releng-tenant"},
+			wantPattern: []string{"managed-*"},
+		},
+		{
+			name: "only exact matches",
+			content: `excludeNamespaces:
+  - ns-a
+  - ns-b
+`,
+			wantExact:  []string{"ns-a", "ns-b"},
+			wantPattern: nil,
+		},
+		{
+			name: "only prefix matches",
+			content: `excludeNamespaces:
+  - "test-*"
+  - "staging-*"
+`,
+			wantExact:  nil,
+			wantPattern: []string{"test-*", "staging-*"},
+		},
+		{
+			name: "mid-string wildcard pattern",
+			content: `excludeNamespaces:
+  - "konflux-perfscale-*-tenant"
+`,
+			wantExact:  nil,
+			wantPattern: []string{"konflux-perfscale-*-tenant"},
+		},
+		{
+			name:       "empty exclusion list",
+			content:    "excludeNamespaces: []\n",
+			wantExact:  nil,
+			wantPattern: nil,
+		},
+		{
+			name:       "no excludeNamespaces key",
+			content:    "someOtherKey: true\n",
+			wantExact:  nil,
+			wantPattern: nil,
+		},
+		{
+			name:    "malformed YAML",
+			content: "excludeNamespaces:\n  - [invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("write temp file: %v", err)
+			}
+
+			cfg, err := loadConfig(path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			f := newNamespaceFilter(cfg)
+
+			if len(tt.wantExact) == 0 && len(f.exactMatches) != 0 {
+				t.Errorf("exactMatches: want empty, got %v", f.exactMatches)
+			}
+			for _, e := range tt.wantExact {
+				if !f.exactMatches[e] {
+					t.Errorf("exactMatches missing %q", e)
+				}
+			}
+
+			if len(tt.wantPattern) == 0 && len(f.patterns) != 0 {
+				t.Errorf("prefixes: want empty, got %v", f.patterns)
+			}
+			for i, p := range tt.wantPattern {
+				if i >= len(f.patterns) {
+					t.Errorf("prefixes[%d]: want %q, got nothing", i, p)
+				} else if f.patterns[i] != p {
+					t.Errorf("prefixes[%d]: want %q, got %q", i, p, f.patterns[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLoadConfig_FileNotFound(t *testing.T) {
+	_, err := loadConfig("/nonexistent/path/config.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestNamespaceFilter_Apply(t *testing.T) {
+	tests := []struct {
+		name       string
+		filter     *namespaceFilter
+		input      []string
+		want       []string
+	}{
+		{
+			name:   "nil config excludes nothing",
+			filter: newNamespaceFilter(nil),
+			input:  []string{"my-tenant", "rhtap-releng-tenant", "managed-foo", "managed-bar", "other-ns"},
+			want:   []string{"my-tenant", "rhtap-releng-tenant", "managed-foo", "managed-bar", "other-ns"},
+		},
+		{
+			name: "exact match only",
+			filter: newNamespaceFilter(&KAConfig{
+				ExcludeNamespaces: []string{"special-ns"},
+			}),
+			input: []string{"special-ns", "special-ns-2", "other"},
+			want:  []string{"special-ns-2", "other"},
+		},
+		{
+			name: "prefix match only",
+			filter: newNamespaceFilter(&KAConfig{
+				ExcludeNamespaces: []string{"test-*"},
+			}),
+			input: []string{"test-foo", "test-bar", "my-test", "production"},
+			want:  []string{"my-test", "production"},
+		},
+		{
+			name: "mixed exact and prefix",
+			filter: newNamespaceFilter(&KAConfig{
+				ExcludeNamespaces: []string{"exact-ns", "prefix-*"},
+			}),
+			input: []string{"exact-ns", "prefix-one", "prefix-two", "keep-me"},
+			want:  []string{"keep-me"},
+		},
+		{
+			name: "empty config excludes nothing",
+			filter: newNamespaceFilter(&KAConfig{
+				ExcludeNamespaces: []string{},
+			}),
+			input: []string{"rhtap-releng-tenant", "managed-foo", "anything"},
+			want:  []string{"rhtap-releng-tenant", "managed-foo", "anything"},
+		},
+		{
+			name:   "empty input",
+			filter: newNamespaceFilter(nil),
+			input:  nil,
+			want:   nil,
+		},
+		{
+			name: "leading wildcard",
+			filter: newNamespaceFilter(&KAConfig{
+				ExcludeNamespaces: []string{"*-managed"},
+			}),
+			input: []string{"foo-managed", "bar-managed", "managed-foo", "other"},
+			want:  []string{"managed-foo", "other"},
+		},
+		{
+			name: "mid-string wildcard",
+			filter: newNamespaceFilter(&KAConfig{
+				ExcludeNamespaces: []string{"konflux-perfscale-*-tenant"},
+			}),
+			input: []string{"konflux-perfscale-large-tenant", "konflux-perfscale-small-tenant", "konflux-perfscale", "other-ns"},
+			want:  []string{"konflux-perfscale", "other-ns"},
+		},
+		{
+			name: "all excluded",
+			filter: newNamespaceFilter(&KAConfig{
+				ExcludeNamespaces: []string{"ns-a", "ns-b"},
+			}),
+			input: []string{"ns-a", "ns-b"},
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.filter.apply(tt.input)
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("apply() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("apply()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/exporters/kaexporter/exporter.go
+++ b/exporters/kaexporter/exporter.go
@@ -309,11 +309,14 @@ func NewKAExporter() (*KAExporter, error) {
 		if err != nil {
 			return nil, fmt.Errorf("load config: %w", err)
 		}
-		nsFilter = newNamespaceFilter(cfg)
-		log.Printf("Namespace filter: loaded from %s (%d exact, %d prefix rules)",
+		nsFilter, err = newNamespaceFilter(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("load config: %w", err)
+		}
+		log.Printf("Namespace filter: loaded from %s (%d exact, %d pattern rules)",
 			configFile, len(nsFilter.exactMatches), len(nsFilter.patterns))
 	} else {
-		nsFilter = newNamespaceFilter(nil)
+		nsFilter, _ = newNamespaceFilter(nil)
 		log.Printf("Namespace filter: no config file specified, no namespaces excluded")
 	}
 

--- a/exporters/kaexporter/exporter.go
+++ b/exporters/kaexporter/exporter.go
@@ -27,6 +27,7 @@ const (
 	namespaceEnvVar = "TENANT_NAMESPACE"
 	portEnvVar      = "EXPORTER_PORT"
 	defaultPort     = "9101"
+	kaConfigFileEnv = "KA_CONFIG_FILE"
 
 	// 30-day SLO rolling window configuration
 	// NOTE: seenPLRRetentionHours is now calculated dynamically in NewKAExporter()
@@ -185,6 +186,9 @@ type KAExporter struct {
 	// Namespaces that were truncated during cold start will be gap-filled progressively.
 	bootstrapStates map[string]*nsBootstrapState
 
+	// nsFilter controls which namespaces are excluded from metric collection.
+	nsFilter *namespaceFilter
+
 	// 30-day SLO rolling aggregates (in-memory only, no persistence).
 	rollingStore   *Store
 	buildSLO       *BuildSLO30d
@@ -299,6 +303,20 @@ func NewKAExporter() (*KAExporter, error) {
 
 	fixedNS := strings.TrimSpace(os.Getenv(namespaceEnvVar))
 
+	var nsFilter *namespaceFilter
+	if configFile := strings.TrimSpace(os.Getenv(kaConfigFileEnv)); configFile != "" {
+		cfg, err := loadConfig(configFile)
+		if err != nil {
+			return nil, fmt.Errorf("load config: %w", err)
+		}
+		nsFilter = newNamespaceFilter(cfg)
+		log.Printf("Namespace filter: loaded from %s (%d exact, %d prefix rules)",
+			configFile, len(nsFilter.exactMatches), len(nsFilter.patterns))
+	} else {
+		nsFilter = newNamespaceFilter(nil)
+		log.Printf("Namespace filter: no config file specified, no namespaces excluded")
+	}
+
 	var k8sClient kubernetes.Interface
 	if fixedNS == "" {
 		cfg, err := kubeRESTConfig()
@@ -338,6 +356,7 @@ func NewKAExporter() (*KAExporter, error) {
 		fixedTenantNamespace: fixedNS,
 		k8sClient:            k8sClient,
 		httpClient:           httpClient,
+		nsFilter:             nsFilter,
 
 		// Retry configuration
 		retry: retryConfig{


### PR DESCRIPTION
### Description

Replace hardcoded tenant/namespace exclusion in filterManagedTenants() with a configurable YAML file controlled by the KA_CONFIG_FILE env var. Patterns support glob wildcards via path.Match. When no config file is specified, no namespaces are excluded.

Also includes additional namespaces for exclusion in effort to reduce cardinality and exporter's memory usage. These excluded namespaces are for testing and development purposes and do not need to be accorded for in these metric.

Co-Authored-By: Claude Opus 4.7

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [x] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
