### PR TITLE
fix(SPRE-5890): Scope ProbeAlert by job and clarify MultiCluster text

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
@@ -13,7 +13,7 @@ spec:
       - alert: ProbeAlert
         expr: |
           konflux_up{check="probe", service!~".*-vpn|.*static-host|.*pwvs"} != 1
-          and on(instance)
+          and on(instance, job)
           (multicluster_probe_up == 1)
         for: 25m
         labels:
@@ -39,9 +39,9 @@ spec:
           slo: "true"
         annotations:
           summary: >-
-             Probe alert {{ $labels.instance }} in multiple clusters.
+             Probe alert {{ $labels.job }} ({{ $labels.instance }}) in multiple clusters.
           description: >-
-             More than 20% of Konflux cluster probes are failing to connect to {{ $labels.instance }} for the last 25 minutes.
+             More than 20% of Konflux cluster probes are failing to connect to {{ $labels.instance }} ({{ $labels.job }}) for the last 25 minutes.
           alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
           runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md
 

--- a/test/promql/tests/data_plane/probe_test.yaml
+++ b/test/promql/tests/data_plane/probe_test.yaml
@@ -15,7 +15,7 @@ tests:
         values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
       - series: konflux_up{job="web-server",instance="instance01",target="target01",source_cluster="cluster04",check="probe",service="web-server"}
         values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
-      - series: multicluster_probe_up{instance="instance01",check="probe-multicluster",service="web-server"}
+      - series: multicluster_probe_up{instance="instance01",job="web-server",check="probe-multicluster",service="web-server"}
         values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
     alert_rule_test:
       - eval_time: 39m
@@ -36,9 +36,24 @@ tests:
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md
 
+  # Shared instance across jobs (e.g. github-actions vs github-webhooks on githubstatus.com):
+  # when one job is down multicluster-wide, ProbeAlert must not fire via another job's healthy multicluster_probe_up.
   - interval: 1m
     input_series:
-      - series: multicluster_probe_up{instance="instance01",check="probe-multicluster",service="web-server"}
+      - series: konflux_up{job="github-actions",instance="https://www.githubstatus.com/api/v2/components.json",target="github-actions",source_cluster="cluster01",check="probe",service="github-actions"}
+        values: 0x44
+      - series: multicluster_probe_up{instance="https://www.githubstatus.com/api/v2/components.json",job="github-actions",check="probe-multicluster",service="github-actions"}
+        values: 0x55
+      - series: multicluster_probe_up{instance="https://www.githubstatus.com/api/v2/components.json",job="github-webhooks",check="probe-multicluster",service="github-webhooks"}
+        values: 1x55
+    alert_rule_test:
+      - eval_time: 39m
+        alertname: ProbeAlert
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: multicluster_probe_up{instance="instance01",job="web-server",check="probe-multicluster",service="web-server"}
         values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
     alert_rule_test:
       - eval_time: 39m
@@ -47,12 +62,13 @@ tests:
           - exp_labels:
               severity: critical
               instance: instance01
+              job: web-server
               slo: "true"
               check: probe-multicluster
               service: web-server
             exp_annotations:
-              description: 'More than 20% of Konflux cluster probes are failing to connect to instance01 for the last 25 minutes.'
-              summary: Probe alert instance01 in multiple clusters.
+              description: 'More than 20% of Konflux cluster probes are failing to connect to instance01 (web-server) for the last 25 minutes.'
+              summary: Probe alert web-server (instance01) in multiple clusters.
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md
 


### PR DESCRIPTION
## Summary
- Join `ProbeAlert` on `(instance, job)` so per-cluster alerts are suppressed when that job is already down multicluster-wide (e.g. GitHub Actions sharing `githubstatus.com` with healthy sibling probes).
- Include `job` in `MultiClusterProbeAlert` summary/description while keeping `instance`.
- Add a promtool regression test for the shared-instance GitHub Actions case; update existing MultiCluster expectations.

## Test plan
- [x] `make selective-check-and-test RULE_FILES="rhobs/alerting/data_plane/prometheus.probe_alerts.yaml" TEST_CASE_FILES="test/promql/tests/data_plane/probe_test.yaml"`
- [ ] Confirm after merge that a GitHub Actions-only outage fires `MultiClusterProbeAlert` without a flood of `ProbeAlert`s for the same job

Fixes: SPRE-5890