### PR TITLE
new metrics in Grafana KubeArchive Status SPRE-5945

### DIFF
--- a/dashboards/grafana-dashboard-konflux-kubearchive-status.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-kubearchive-status.configmap.yaml
@@ -190,7 +190,7 @@ data:
                     "uid": "${Datasource}"
                   },
                   "editorMode": "code",
-                  "expr": "clamp_max((sum by (source_cluster) (rate(db_sql_latency_bucket{source_cluster=~\"$cluster\", exported_job=\"kubearchive.api\", le=\"10.0\"}[5m])) / sum by (source_cluster) (rate(db_sql_latency_bucket{source_cluster=~\"$cluster\", exported_job=\"kubearchive.api\", le=\"+Inf\"}[5m]))) * 100, 100)",
+                  "expr": "clamp_max((sum by (source_cluster) (rate(db_sql_latency_milliseconds_bucket{source_cluster=~\"$cluster\", exported_job=\"kubearchive.api\", le=\"10.0\"}[5m])) / sum by (source_cluster) (rate(db_sql_latency_milliseconds_bucket{source_cluster=~\"$cluster\", exported_job=\"kubearchive.api\", le=\"+Inf\"}[5m]))) * 100, 100)",
                   "hide": false,
                   "legendFormat": "__auto",
                   "range": true,
@@ -267,7 +267,7 @@ data:
                     "uid": "${Datasource}"
                   },
                   "editorMode": "code",
-                  "expr": "clamp_max((sum by (source_cluster) (rate(db_sql_latency_bucket{source_cluster=~\"$cluster\", exported_job=\"kubearchive.sink\", le=\"10.0\"}[5m])) / sum by (source_cluster) (rate(db_sql_latency_bucket{source_cluster=~\"$cluster\", exported_job=\"kubearchive.sink\", le=\"+Inf\"}[5m]))) * 100, 100)",
+                  "expr": "clamp_max((sum by (source_cluster) (rate(db_sql_latency_milliseconds_bucket{source_cluster=~\"$cluster\", exported_job=\"kubearchive.sink\", le=\"10.0\"}[5m])) / sum by (source_cluster) (rate(db_sql_latency_milliseconds_bucket{source_cluster=~\"$cluster\", exported_job=\"kubearchive.sink\", le=\"+Inf\"}[5m]))) * 100, 100)",
                   "legendFormat": "__auto",
                   "range": true,
                   "refId": "A"
@@ -1513,7 +1513,7 @@ data:
                     "uid": "${Datasource}"
                   },
                   "editorMode": "code",
-                  "expr": "sum by (source_cluster) (rate(db_sql_latency_sum{source_cluster=~\"$cluster\", exported_job=\"kubearchive.api\", method!~\".*(ping|reset_session)\"}[$__rate_interval])) / sum by (source_cluster) (rate(db_sql_latency_count{source_cluster=~\"$cluster\", exported_job=\"kubearchive.api\", method!~\".*(ping|reset_session)\"}[$__rate_interval]))",
+                  "expr": "sum by (source_cluster) (rate(db_sql_latency_milliseconds_sum{source_cluster=~\"$cluster\", exported_job=\"kubearchive.api\", method!~\".*(ping|reset_session)\"}[$__rate_interval])) / sum by (source_cluster) (rate(db_sql_latency_milliseconds_count{source_cluster=~\"$cluster\", exported_job=\"kubearchive.api\", method!~\".*(ping|reset_session)\"}[$__rate_interval]))",
                   "legendFormat": "{{ source_cluster }}",
                   "range": true,
                   "refId": "A"
@@ -1612,7 +1612,7 @@ data:
                     "uid": "${Datasource}"
                   },
                   "editorMode": "code",
-                  "expr": "sum by (source_cluster) (rate(db_sql_latency_sum{source_cluster=~\"$cluster\", exported_job=\"kubearchive.sink\", method!~\".*(ping|reset_session)\"}[$__rate_interval])) / sum by (source_cluster) (rate(db_sql_latency_count{source_cluster=~\"$cluster\", exported_job=\"kubearchive.sink\", method!~\".*(ping|reset_session)\"}[$__rate_interval]))",
+                  "expr": "sum by (source_cluster) (rate(db_sql_latency_milliseconds_sum{source_cluster=~\"$cluster\", exported_job=\"kubearchive.sink\", method!~\".*(ping|reset_session)\"}[$__rate_interval])) / sum by (source_cluster) (rate(db_sql_latency_milliseconds_count{source_cluster=~\"$cluster\", exported_job=\"kubearchive.sink\", method!~\".*(ping|reset_session)\"}[$__rate_interval]))",
                   "legendFormat": "{{ source_cluster }}",
                   "range": true,
                   "refId": "A"
@@ -1736,7 +1736,7 @@ data:
                     "uid": "${Datasource}"
                   },
                   "editorMode": "code",
-                  "expr": "avg_over_time(\n  histogram_quantile(0.99, \n    sum by (le, source_cluster) (rate(db_sql_latency_bucket{source_cluster=~\"$cluster\", exported_job=\"kubearchive.api\"}[5m]))\n  )[1h:5m]\n)",
+                  "expr": "avg_over_time(\n  histogram_quantile(0.99, \n    sum by (le, source_cluster) (rate(db_sql_latency_milliseconds_bucket{source_cluster=~\"$cluster\", exported_job=\"kubearchive.api\"}[5m]))\n  )[1h:5m]\n)",
                   "legendFormat": "{{ source_cluster }} - {{ status }} - {{ exported_job }}",
                   "range": true,
                   "refId": "A"
@@ -1860,7 +1860,7 @@ data:
                     "uid": "${Datasource}"
                   },
                   "editorMode": "code",
-                  "expr": "clamp_max(\n  (sum by (source_cluster) (rate(db_sql_latency_bucket{source_cluster=~\"$cluster\", le=\"10.0\"}[5m]))\n  / \n  sum by (source_cluster) (rate(db_sql_latency_bucket{source_cluster=~\"$cluster\", le=\"+Inf\"}[5m]))) * 100,\n  100\n)",
+                  "expr": "clamp_max(\n  (sum by (source_cluster) (rate(db_sql_latency_milliseconds_bucket{source_cluster=~\"$cluster\", le=\"10.0\"}[5m]))\n  / \n  sum by (source_cluster) (rate(db_sql_latency_milliseconds_bucket{source_cluster=~\"$cluster\", le=\"+Inf\"}[5m]))) * 100,\n  100\n)",
                   "legendFormat": "{{ source_cluster }} - {{ status }} - {{ exported_job }}",
                   "range": true,
                   "refId": "A"


### PR DESCRIPTION

Updated the opentelemetry-collector image used in KubeArchive to 0.155.0 version and seems like the some metric name changed:
 metric name changed:
• Old (v0.123.0):db_sql_latency_bucket.
• New (v0.155.0):db_sql_latency_milliseconds_bucket.
-
Tested on stage:
https://grafana.stage.devshift.net/d/beqtfn88x35kwf-fix/kubearchive-status-fix?orgId=1&from=now-2d&to=now&timezone=UTC&var-Datasource=P22466E8E7855F1E0&var-cluster=$__all&var-namespace=$__all&var-service=$__all&refresh=15m


- [X ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
https://redhat.atlassian.net/browse/SPRE-5945

