### PR TITLE
fix(SPRE-5323): Split ProbeAlert by severity to support high-severity services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-kustomize
+.vscode/

--- a/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
@@ -12,13 +12,30 @@ spec:
 
       - alert: ProbeAlert
         expr: |
-          konflux_up{check="probe", service!~".*-vpn|.*static-host|.*pwvs"} != 1
+          konflux_up{check="probe", service!~".*-vpn|.*static-host|.*pwvs", severity!="high"} != 1
           and on(instance, job)
           (multicluster_probe_up == 1)
         for: 25m
         labels:
           severity: critical
           slo: "true"
+        annotations:
+          summary: >-
+             Probe alert {{ $labels.job }}.
+          description: >-
+             Probe on {{ $labels.source_cluster }} is unable to connect to {{ $labels.instance }} ({{ $labels.job }}) for the last 25 minutes. At least 80% of Konflux clusters successfully connect to {{ $labels.instance }}.
+          alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md
+
+      - alert: ProbeAlert
+        expr: |
+          konflux_up{check="probe", service!~".*-vpn|.*static-host|.*pwvs", severity="high"} != 1
+          and on(instance, job)
+          (multicluster_probe_up == 1)
+        for: 25m
+        labels:
+          severity: high
+          slo: "false"
         annotations:
           summary: >-
              Probe alert {{ $labels.job }}.

--- a/test/promql/tests/data_plane/probe_test.yaml
+++ b/test/promql/tests/data_plane/probe_test.yaml
@@ -5,6 +5,7 @@ rule_files:
 
 tests:
 
+  # ProbeAlert critical: service without severity="high" label fires at critical severity
   - interval: 1m
     input_series:
       - series: konflux_up{job="web-server",instance="instance01",target="target01",source_cluster="cluster01",check="probe",service="web-server"}
@@ -33,6 +34,34 @@ tests:
             exp_annotations:
               description: 'Probe on cluster01 is unable to connect to instance01 (web-server) for the last 25 minutes. At least 80% of Konflux clusters successfully connect to instance01.'
               summary: Probe alert web-server.
+              alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md
+
+  # ProbeAlert high: service with severity="high" label fires at high severity (not critical)
+  - interval: 1m
+    input_series:
+      - series: konflux_up{job="critical-service",instance="instance02",target="target02",source_cluster="cluster01",check="probe",service="critical-service",severity="high"}
+        values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+      - series: konflux_up{job="critical-service",instance="instance02",target="target02",source_cluster="cluster02",check="probe",service="critical-service",severity="high"}
+        values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+      - series: multicluster_probe_up{instance="instance02",job="critical-service",check="probe-multicluster",service="critical-service"}
+        values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+    alert_rule_test:
+      - eval_time: 39m
+        alertname: ProbeAlert
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              instance: instance02
+              job: critical-service
+              target: target02
+              source_cluster: cluster01
+              check: probe
+              service: critical-service
+              slo: "false"
+            exp_annotations:
+              description: 'Probe on cluster01 is unable to connect to instance02 (critical-service) for the last 25 minutes. At least 80% of Konflux clusters successfully connect to instance02.'
+              summary: Probe alert critical-service.
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md
 


### PR DESCRIPTION
### Description

The ProbeAlert rule previously fired at critical severity for all probe targets, regardless of the service's inherent criticality. Services labelled severity="high" in their konflux_up metric needed to page at high (not critical) so that on-call routing and SLO tracking could distinguish between tiers of service importance

---

Jira- 

- [ ] **Jira Ticket:** SPRE-5323
- [ ] **Alert Tests:** 
make selective-check-and-test   RULE_FILES="rhobs/alerting/data_plane/prometheus.probe_alerts.yaml"   TEST_CASE_FILES="test/promql/tests/data_plane/probe_test.yaml"
  promtool test rules passes with the new test case
 Confirmed the critical-path test still passes (no regression on the existing alert)
 Verified the severity!="high" selector excludes high-severity services from the critical rule
 Verified the severity="high" selector fires the new rule for high-severity services only


