### PR TITLE
fix(SPRE-5323): rename ProbeAlertHigh, add severity docs and tests

### DIFF
--- a/docs/ALERTS.md
+++ b/docs/ALERTS.md
@@ -91,6 +91,9 @@ Required labels:
 - `check` — what's being verified (e.g. `replicas-available`, `probe`, `github`)
 - `source_cluster` — added automatically by RHOBS forwarding
 
+Optional labels:
+- `severity` — set on the metric itself (not the alert rule) to override the default alert tier for a specific service. Valid value: `high`. When present, the probe alert for that service fires as `ProbeAlertHigh` (severity: high, slo: "false") instead of `ProbeAlert` (severity: critical, slo: "true"). This lets individual services opt out of SLO-grade paging while still receiving alerting. The label must be emitted by the upstream exporter or recording rule — see [SPRE-5323](https://issues.redhat.com/browse/SPRE-5323) for the probe exporter change that introduced it.
+
 How `konflux_up` signals are created:
 - **Recording rules** (most common): transform an existing metric into `konflux_up` via `label_replace` and clamp to 0/1. Example: `kube_deployment_status_replicas_available / kube_deployment_spec_replicas`. See `rhobs/recording/` for examples.
 - **Custom Go exporters**: expose `konflux_up` directly via the Prometheus client library when availability checks require custom logic (HTTP probes, API calls). See `exporters/dsexporter/` for the reference implementation.

--- a/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
@@ -12,7 +12,7 @@ spec:
 
       - alert: ProbeAlert
         expr: |
-          konflux_up{check="probe", service!~".*-vpn|.*static-host|.*pwvs"} != 1
+          konflux_up{check="probe", service!~".*-vpn|.*static-host|.*pwvs", severity!="high"} != 1
           and on(instance, job)
           (multicluster_probe_up == 1)
         for: 25m
@@ -25,6 +25,23 @@ spec:
           description: >-
              Probe on {{ $labels.source_cluster }} is unable to connect to {{ $labels.instance }} ({{ $labels.job }}) for the last 25 minutes. At least 80% of Konflux clusters successfully connect to {{ $labels.instance }}.
           alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
+          runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md
+
+      - alert: ProbeAlertHigh
+        expr: |
+          konflux_up{check="probe", service!~".*-vpn|.*static-host|.*pwvs", severity="high"} != 1
+          and on(instance, job)
+          (multicluster_probe_up == 1)
+        for: 25m
+        labels:
+          severity: high
+          slo: "false"
+        annotations:
+          summary: >-
+             Probe alert {{ $labels.job }}.
+          description: >-
+             Probe on {{ $labels.source_cluster }} is unable to connect to {{ $labels.instance }} ({{ $labels.job }}) for the last 25 minutes. At least 80% of Konflux clusters successfully connect to {{ $labels.instance }}.
+          alert_routing_key: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
           runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md
 
       - alert: MultiClusterProbeAlert

--- a/test/promql/tests/data_plane/probe_test.yaml
+++ b/test/promql/tests/data_plane/probe_test.yaml
@@ -36,6 +36,46 @@ tests:
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md
 
+  # Partition boundary: severity="high" series must NOT fire the critical ProbeAlert
+  - interval: 1m
+    input_series:
+      - series: konflux_up{job="critical-service",instance="instance02",target="target02",source_cluster="cluster01",check="probe",service="critical-service",severity="high"}
+        values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+      - series: multicluster_probe_up{instance="instance02",job="critical-service",check="probe-multicluster",service="critical-service"}
+        values: 1x55
+    alert_rule_test:
+      - eval_time: 39m
+        alertname: ProbeAlert
+        exp_alerts: []
+
+  # ProbeAlertHigh: service with severity="high" metric label fires at high severity (not SLO)
+  - interval: 1m
+    input_series:
+      - series: konflux_up{job="critical-service",instance="instance02",target="target02",source_cluster="cluster01",check="probe",service="critical-service",severity="high"}
+        values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+      - series: konflux_up{job="critical-service",instance="instance02",target="target02",source_cluster="cluster02",check="probe",service="critical-service",severity="high"}
+        values: 1x44
+      - series: multicluster_probe_up{instance="instance02",job="critical-service",check="probe-multicluster",service="critical-service"}
+        values: 1x55
+    alert_rule_test:
+      - eval_time: 39m
+        alertname: ProbeAlertHigh
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              instance: instance02
+              job: critical-service
+              target: target02
+              source_cluster: cluster01
+              check: probe
+              service: critical-service
+              slo: "false"
+            exp_annotations:
+              description: 'Probe on cluster01 is unable to connect to instance02 (critical-service) for the last 25 minutes. At least 80% of Konflux clusters successfully connect to instance02.'
+              summary: Probe alert critical-service.
+              alert_routing_key: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md
+
   # Shared instance across jobs (e.g. github-actions vs github-webhooks on githubstatus.com):
   # when one job is down multicluster-wide, ProbeAlert must not fire via another job's healthy multicluster_probe_up.
   - interval: 1m


### PR DESCRIPTION
### Description

Addresses review comments on the probe alert severity tiering change (SPRE-5323):

Rename duplicate ProbeAlert (severity=high) to ProbeAlertHigh to avoid ambiguity — both rules matched the same alert name but with mutually exclusive selectors. Other alert files use distinct names per severity tier.
Add explicit partition test: verifies that konflux_up series with severity="high" metric label do not fire the critical ProbeAlert (negative case).
Add ProbeAlertHigh happy-path unit test asserting severity: high and slo: "false" labels fire correctly.
Document the optional severity metric label on konflux_up in docs/ALERTS.md — covers valid values, SLO routing impact (opt-out of SLO paging), and pointer to the upstream exporter change (SPRE-5323).

### Pre-Submission Checklist

 Jira Ticket: SPRE-5323 linked in description and original commit message.
 Alert Tests: ProbeAlertHigh fires when it should; a negative partition test confirms the critical ProbeAlert does not fire for severity="high" series.


