### PR TITLE
feat(PVO11Y-5369): add kueue performance SLO recording rules

### DIFF
--- a/rhobs/recording/kueue_performance_slo_recording_rules.yaml
+++ b/rhobs/recording/kueue_performance_slo_recording_rules.yaml
@@ -1,0 +1,47 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-kueue-performance-slo
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: kueue_performance_slo
+      interval: 10m
+      rules:
+        - record: konflux_cluster:kueue_admission_wait_time_seconds:p95_1h
+          expr: |
+            histogram_quantile(0.95, sum by (le, priority_class, source_cluster) (
+              rate(kueue_admission_wait_time_seconds_bucket{
+                cluster_queue="cluster-pipeline-queue"
+              }[1h])
+            ))
+
+        - record: konflux_cluster:kueue_admission_wait_time_seconds:saturated
+          expr: |
+            konflux_cluster:kueue_admission_wait_time_seconds:p95_1h
+            > bool (
+              last_over_time(konflux_cluster:kueue_admission_wait_time_seconds:p95_1h_7d_avg[65m])
+              + last_over_time(konflux_cluster:kueue_admission_wait_time_seconds:p95_1h_7d_stddev[65m])
+            )
+
+        - record: konflux_cluster:kueue_admission_wait_time_seconds:saturation_7d
+          expr: |
+            avg_over_time(
+              konflux_cluster:kueue_admission_wait_time_seconds:saturated[7d:1h]
+            )
+
+    - name: kueue_performance_slo_baseline
+      interval: 30m
+      rules:
+        - record: konflux_cluster:kueue_admission_wait_time_seconds:p95_1h_7d_avg
+          expr: |
+            avg_over_time(
+              (konflux_cluster:kueue_admission_wait_time_seconds:p95_1h >= 0)[7d:1h]
+            )
+
+        - record: konflux_cluster:kueue_admission_wait_time_seconds:p95_1h_7d_stddev
+          expr: |
+            stddev_over_time(
+              (konflux_cluster:kueue_admission_wait_time_seconds:p95_1h >= 0)[7d:1h]
+            )

--- a/test/promql/tests/recording/kueue_performance_slo_recording_rules_test.yaml
+++ b/test/promql/tests/recording/kueue_performance_slo_recording_rules_test.yaml
@@ -1,0 +1,76 @@
+evaluation_interval: 5m
+
+rule_files:
+  - kueue_performance_slo_recording_rules.yaml
+
+tests:
+  - name: KueuePerformanceSloP95ComputationTest
+    interval: 5m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{le="60", priority_class="test-priority", cluster_queue="cluster-pipeline-queue", source_cluster="test-cluster"}'
+        values: "0x15"
+      - series: 'kueue_admission_wait_time_seconds_bucket{le="120", priority_class="test-priority", cluster_queue="cluster-pipeline-queue", source_cluster="test-cluster"}'
+        values: "0+1x15"
+      - series: 'kueue_admission_wait_time_seconds_bucket{le="300", priority_class="test-priority", cluster_queue="cluster-pipeline-queue", source_cluster="test-cluster"}'
+        values: "0+1x15"
+      - series: 'kueue_admission_wait_time_seconds_bucket{le="+Inf", priority_class="test-priority", cluster_queue="cluster-pipeline-queue", source_cluster="test-cluster"}'
+        values: "0+1x15"
+    promql_expr_test:
+      - expr: konflux_cluster:kueue_admission_wait_time_seconds:p95_1h
+        eval_time: 60m
+        exp_samples:
+          - labels: 'konflux_cluster:kueue_admission_wait_time_seconds:p95_1h{priority_class="test-priority", source_cluster="test-cluster"}'
+            value: 117
+
+  - name: KueuePerformanceSloNoOutputForNonMatchingQueueTest
+    interval: 5m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{le="60", priority_class="test-priority", cluster_queue="other-queue", source_cluster="test-cluster"}'
+        values: "0x15"
+      - series: 'kueue_admission_wait_time_seconds_bucket{le="120", priority_class="test-priority", cluster_queue="other-queue", source_cluster="test-cluster"}'
+        values: "0+1x15"
+      - series: 'kueue_admission_wait_time_seconds_bucket{le="+Inf", priority_class="test-priority", cluster_queue="other-queue", source_cluster="test-cluster"}'
+        values: "0+1x15"
+    promql_expr_test:
+      - expr: konflux_cluster:kueue_admission_wait_time_seconds:p95_1h
+        eval_time: 60m
+        exp_samples: []
+
+  - name: KueuePerformanceSloBaselineAndSaturationChainTest
+    interval: 5m
+    input_series:
+      - series: 'konflux_cluster:kueue_admission_wait_time_seconds:p95_1h{priority_class="test-priority", source_cluster="test-cluster"}'
+        values: "100x130"
+    promql_expr_test:
+      - expr: konflux_cluster:kueue_admission_wait_time_seconds:p95_1h_7d_avg
+        eval_time: 600m
+        exp_samples:
+          - labels: 'konflux_cluster:kueue_admission_wait_time_seconds:p95_1h_7d_avg{priority_class="test-priority", source_cluster="test-cluster"}'
+            value: 100
+      - expr: konflux_cluster:kueue_admission_wait_time_seconds:p95_1h_7d_stddev
+        eval_time: 600m
+        exp_samples:
+          - labels: 'konflux_cluster:kueue_admission_wait_time_seconds:p95_1h_7d_stddev{priority_class="test-priority", source_cluster="test-cluster"}'
+            value: 0
+      - expr: konflux_cluster:kueue_admission_wait_time_seconds:saturated
+        eval_time: 600m
+        exp_samples:
+          - labels: 'konflux_cluster:kueue_admission_wait_time_seconds:saturated{priority_class="test-priority", source_cluster="test-cluster"}'
+            value: 0
+      - expr: konflux_cluster:kueue_admission_wait_time_seconds:saturation_7d
+        eval_time: 600m
+        exp_samples:
+          - labels: 'konflux_cluster:kueue_admission_wait_time_seconds:saturation_7d{priority_class="test-priority", source_cluster="test-cluster"}'
+            value: 0
+
+  - name: KueuePerformanceSloSaturatedIndicatorFiresTest
+    interval: 5m
+    input_series:
+      - series: 'konflux_cluster:kueue_admission_wait_time_seconds:p95_1h{priority_class="test-priority", source_cluster="test-cluster"}'
+        values: "100x100 500x30"
+    promql_expr_test:
+      - expr: konflux_cluster:kueue_admission_wait_time_seconds:saturated
+        eval_time: 505m
+        exp_samples:
+          - labels: 'konflux_cluster:kueue_admission_wait_time_seconds:saturated{priority_class="test-priority", source_cluster="test-cluster"}'
+            value: 1


### PR DESCRIPTION
## Summary

- Adds 5 chained recording rules for the cluster-level Performance UX SLO (KONFLUX-12573 / PVO11Y-5369)
- Rules compute a **saturation ratio**: the fraction of the past 7 days where the hourly P95 kueue admission wait time exceeded the cluster's statistical baseline (7-day avg + 1σ)
- The final SLO verdict (breach threshold) is **not** a recording rule — it is configured per cluster in the dashboard

### Recording Rule Chain

| Rule | Metric | Eval Interval | Purpose |
|------|--------|---------------|---------|
| 1 | `konflux_cluster:kueue_admission_wait_time_seconds:p95_1h` | 10m | P95 wait time over 1h window |
| 2 | `konflux_cluster:kueue_admission_wait_time_seconds:p95_1h_7d_avg` | 30m | 7-day rolling average of P95 |
| 3 | `konflux_cluster:kueue_admission_wait_time_seconds:p95_1h_7d_stddev` | 30m | 7-day rolling standard deviation |
| 4 | `konflux_cluster:kueue_admission_wait_time_seconds:saturated` | 10m | 1 if P95 > avg+1σ, 0 otherwise |
| 5 | `konflux_cluster:kueue_admission_wait_time_seconds:saturation_7d` | 10m | Fraction of past 7 days saturated |

### Design Decisions

- **Optimized evaluation intervals**: Signal rules (P95, saturated, saturation) run at 10m — the P95 uses a 1h rate window so its output barely changes within 5 minutes; baseline rules (avg/stddev) run at 30m since the `[7d:1h]` subquery only shifts hourly
- **`last_over_time(...[65m])` bridge**: The saturated rule (10m interval) consumes baselines from the 30m group. A 65m lookback covers two baseline evaluation periods, ensuring resilience against a missed or delayed 30m cycle (e.g. during a Prometheus restart). The staleness is negligible since the baseline is a 7-day aggregate that barely moves.
- **1σ threshold**: validated against production — at 2σ, no priority class triggered a breach even during genuine degradation
- **1h rate window**: provides 168 samples/week (vs 7 for 1d), making percentage-based thresholds meaningful
- **NaN handling**: `>= 0` filter in baseline rules excludes hours with zero admissions (affects intermittent priority classes)
- **Subquery `[7d:1h]` step**: matches hourly semantics and reduces sample count from ~2016 to 168

### Production Validation

The full rule chain was validated against stone-prd-rh01, stone-prod-p02, and kflux-prd-rh02 using nested subqueries that replicate the exact computation. See [PVO11Y-5341 comment](https://issues.redhat.com/browse/PVO11Y-5341) for details.

## Test plan

- [x] `make selective-check-and-test` passes (rule syntax, pint linter, unit tests)
- [x] `yamllint` passes
- [ ] Verify recording rules produce expected metrics after deployment to stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)