### PR TITLE
CI: Enable linting and static security analysis for O11Y repository

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,48 @@
+name: Validate PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: './go.mod'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          args: --timeout=5m
+          only-new-issues: true
+
+  security_scan:
+    name: Security scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: './go.mod'
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@v2.28.0
+        with:
+          args: '-exclude-generated -no-fail -fmt sarif -out results.sarif ./...'
+        env:
+          GOROOT: ""
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -1,0 +1,31 @@
+name: Lint manifests with yamllint
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          pip install pipenv
+          pipenv sync --dev
+      - name: Lint yaml manifests
+        run: |
+          pipenv run yamllint -f github --no-warnings .
+      - name: Check for yaml lint warnings
+        if: success() || failure()
+        continue-on-error: true
+        run: |
+          pipenv run yamllint -f github -s .

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+version: "2"
+linters:
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: (.+)\.go$
+        text: composites
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->
[PVO11Y-5373](https://redhat.atlassian.net/browse/PVO11Y-5373)

  Konflux repositories currently lack a standardized approach to linting. Some security vulnerabilities and low-quality code to slip through. With the rise of AI-generated code, un-linted repositories create critical blind spots.

  This PR adds GitHub Actions workflows and linting configuration to enforce correctness, programming standards and static security analysis on every pull request to the o11y repository:

  request to the o11y repository:

  - **`.golangci.yml`** - golangci-lint v2 configuration. `only-new-issues` is enabled so existing code is not flagged, only new or changed code is linted going forward. Exclusions cover generated code, common false positives, and third-party paths.
  - **`.github/workflows/pr.yaml`** - Runs golangci-lint and gosec security scanner on pull requests to main.
  - **`.github/workflows/yamllint.yaml`** - Runs yamllint on pull requests and pushes to main, using the existing `.yamllint` configuration already present in the repository.


- [x] **Jira Ticket:** [PVO11Y-5373](https://redhat.atlassian.net/browse/PVO11Y-5373)

[PVO11Y-5373]: https://redhat.atlassian.net/browse/PVO11Y-5373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PVO11Y-5373]: https://redhat.atlassian.net/browse/PVO11Y-5373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ