### PR TITLE
Fixup JIRA ticket guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,5 +38,5 @@ See docs/CICD.md for details.
 
 ## Conventions
 
-- Commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) — include Jira ticket ID (e.g. `STONEO11Y-123`) when applicable
+- Commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) — include Jira ticket ID {JIRA_PROJECT}-{JIRA_ID} (e.g. `PVO11Y-123`) when applicable
 - Review channel: `#forum-konflux-o11y` on Slack, tag `@konflux-o11y-ic`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ of the code within the PR lifecycle (e.g. no `addressing comments` commit messag
 the commit message standard.
 
 If the commit message (also applicable to PR names and branch names) includes a Jira
-ticket identifier (e.g. STONEO11Y-123), then it will automatically be referenced within
+ticket identifier {JIRA_PROJECT}-{JIRA_ID} (e.g. `PVO11Y-123`), then it will automatically be referenced within
 the Jira ticket.
 
 Commit messages should be descriptive:
@@ -98,7 +98,7 @@ Commit messages should be descriptive:
 
 Example:
 ```
-chore(STONEO11Y-21): add network egress metric and tests
+chore(PVO11Y-123): add network egress metric and tests
 
 - Create a new rule for getting the network transmit in bytes
 and add the label_pipelines_appstudio_openshift_io_type to it.


### PR DESCRIPTION
Agents use the STONEO11Y jira project sometimes when developer does not explicitly specify it. Use the correct O11Y project in the example, but also include the template to contstruct it.

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
