### PR TITLE
feat(SPRE-5957): add html_url annotations to all SLO alerts

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml
@@ -26,6 +26,7 @@ spec:
         slo: "true"
         component: api-server
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml#L13
         summary: >-
           API Server 5XX error count in cluster {{ $labels.source_cluster }}
         description: "API Server is experiencing 10% of 5XX failures based on the total requests for 15min in cluster {{ $labels.source_cluster }}"
@@ -95,6 +96,7 @@ spec:
         component: api-server
         team: konflux-infra
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml#L76
         summary: "API Server Latency: Critical SLO Breach ({{ $labels.source_cluster }})"
         description: "More than 5% of API requests exceeded 1s latency over the last 1h and 5m. Impact: High risk of system-wide timeouts. Action: Immediate check of Etcd health and admission webhooks."
         alert_team_handle: <!subteam^S05Q1P4Q2TG>
@@ -116,6 +118,7 @@ spec:
           slo: "true"
           component: api-server
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml#L106
           summary: API Server memory usage is above 80% in {{ $labels.source_cluster }}
           description: >-
             API Server process memory consumption is above 80% for 5 minutes in cluster {{ $labels.source_cluster }}.

--- a/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml
@@ -96,7 +96,7 @@ spec:
         component: api-server
         team: konflux-infra
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml#L76
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml#L77
         summary: "API Server Latency: Critical SLO Breach ({{ $labels.source_cluster }})"
         description: "More than 5% of API requests exceeded 1s latency over the last 1h and 5m. Impact: High risk of system-wide timeouts. Action: Immediate check of Etcd health and admission webhooks."
         alert_team_handle: <!subteam^S05Q1P4Q2TG>
@@ -118,7 +118,7 @@ spec:
           slo: "true"
           component: api-server
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml#L106
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml#L108
           summary: API Server memory usage is above 80% in {{ $labels.source_cluster }}
           description: >-
             API Server process memory consumption is above 80% for 5 minutes in cluster {{ $labels.source_cluster }}.

--- a/rhobs/alerting/data_plane/prometheus.artifact_registry_proxy_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.artifact_registry_proxy_alerts.yaml
@@ -19,6 +19,7 @@ spec:
         slo: "true"
         component: artifact-registry-proxy
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.artifact_registry_proxy_alerts.yaml#L13
         summary: >-
           Artifact Registry Nginx proxy is down
         description: >-

--- a/rhobs/alerting/data_plane/prometheus.build_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.build_service_alerts.yaml
@@ -22,6 +22,7 @@ spec:
         slo: "true"
         component: build-service
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.build_service_alerts.yaml#L12
         summary: >-
           build-service is down in cluster {{ $labels.source_cluster }}
         description: >

--- a/rhobs/alerting/data_plane/prometheus.caching_squid_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.caching_squid_alerts.yaml
@@ -19,6 +19,7 @@ spec:
         slo: "true"
         component: squid
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.caching_squid_alerts.yaml#L13
         summary: >-
           Caching Squid proxy is down
         description: >-

--- a/rhobs/alerting/data_plane/prometheus.cluster_capacity_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.cluster_capacity_alerts.yaml
@@ -51,6 +51,7 @@ spec:
           slo: "true"
           component: etcd
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.cluster_capacity_alerts.yaml#L45
           summary: >-
              Etcd cluster database is running full.
           description: >-

--- a/rhobs/alerting/data_plane/prometheus.etcd_shield.yaml
+++ b/rhobs/alerting/data_plane/prometheus.etcd_shield.yaml
@@ -19,6 +19,7 @@ spec:
           slo: "true"
           component: etcd
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.etcd_shield.yaml#L13
           summary: >-
              Etcd Shield Alert Triggered
           description: >-

--- a/rhobs/alerting/data_plane/prometheus.image_controller_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.image_controller_alerts.yaml
@@ -22,6 +22,7 @@ spec:
         slo: "true"
         component: image-controller
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.image_controller_alerts.yaml#L12
         summary: >-
           image-controller is down in cluster {{ $labels.source_cluster }}
         description: >

--- a/rhobs/alerting/data_plane/prometheus.integration_service_availability_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.integration_service_availability_alerts.yaml
@@ -22,6 +22,7 @@ spec:
             tenant: rhtap
             component: integration-service
           annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.integration_service_availability_alerts.yaml#L12
             summary: >-
               Integration Service Availability SLO Violation
             description: >-

--- a/rhobs/alerting/data_plane/prometheus.konflux_kite_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.konflux_kite_alerts.yaml
@@ -24,6 +24,7 @@ spec:
         slo: "true"
         component: konflux-kite
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_kite_alerts.yaml#L12
         summary: >-
           konflux-kite is down in cluster {{ $labels.source_cluster }}
         description: >
@@ -44,6 +45,7 @@ spec:
         slo: "true"
         component: konflux-kite
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_kite_alerts.yaml#L38
         summary: >-
           Konflux Kite endpoint is down in cluster {{ $labels.source_cluster }}
         description: >

--- a/rhobs/alerting/data_plane/prometheus.konflux_kite_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.konflux_kite_alerts.yaml
@@ -45,7 +45,7 @@ spec:
         slo: "true"
         component: konflux-kite
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_kite_alerts.yaml#L38
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_kite_alerts.yaml#L39
         summary: >-
           Konflux Kite endpoint is down in cluster {{ $labels.source_cluster }}
         description: >

--- a/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml
@@ -23,6 +23,7 @@ spec:
         slo: "true"
         component: konflux-ui
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L13
         summary: >-
           Konflux UI proxy pod is down in cluster {{ $labels.source_cluster }}
         description: >
@@ -47,6 +48,7 @@ spec:
         slo: "true"
         component: konflux-ui
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L37
         summary: >-
           Konflux UI dex pod is down in cluster {{ $labels.source_cluster }}
         description: >
@@ -67,6 +69,7 @@ spec:
         slo: "true"
         component: konflux-ui
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L61
         summary: >-
           Konflux UI endpoint is down in cluster {{ $labels.source_cluster }}
         description: >

--- a/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml
@@ -48,7 +48,7 @@ spec:
         slo: "true"
         component: konflux-ui
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L37
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L38
         summary: >-
           Konflux UI dex pod is down in cluster {{ $labels.source_cluster }}
         description: >
@@ -69,7 +69,7 @@ spec:
         slo: "true"
         component: konflux-ui
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L61
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L63
         summary: >-
           Konflux UI endpoint is down in cluster {{ $labels.source_cluster }}
         description: >
@@ -151,6 +151,7 @@ spec:
         slo: "true"
         component: konflux-ui
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L136
         summary: >-
           Konflux UI proxy returning 502 errors in cluster {{ $labels.source_cluster }}
         description: >

--- a/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml
@@ -22,6 +22,7 @@ spec:
             slo: "true"
             component: kubearchive
           annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml#L13
             summary: >-
               KubeArchive Operator pod is down in cluster {{ $labels.source_cluster }}
             description: >
@@ -44,7 +45,7 @@ spec:
             slo: "true"
             component: kubearchive
           annotations:
-            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml#L35
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml#L36
             summary: >-
               KubeArchive API Server pod is down in cluster {{ $labels.source_cluster }}
             description: >
@@ -67,7 +68,7 @@ spec:
             slo: "true"
             component: kubearchive
           annotations:
-            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml#L57
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml#L59
             summary: >-
               KubeArchive Sink pod is down in cluster {{ $labels.source_cluster }}
             description: >

--- a/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml
@@ -44,6 +44,7 @@ spec:
             slo: "true"
             component: kubearchive
           annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml#L35
             summary: >-
               KubeArchive API Server pod is down in cluster {{ $labels.source_cluster }}
             description: >
@@ -66,6 +67,7 @@ spec:
             slo: "true"
             component: kubearchive
           annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kubearchive_availability.yaml#L57
             summary: >-
               KubeArchive Sink pod is down in cluster {{ $labels.source_cluster }}
             description: >

--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -22,6 +22,7 @@ spec:
         component: tekton-kueue
         slo: "true"
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L12
         summary: "Tekton Kueue controller is down"
         description: "The Tekton Kueue controller has no available replicas in cluster {{ $labels.source_cluster }}. PipelineRuns will be created in Pending state but cannot be processed, resulting in stuck builds."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueControllerDown.md
@@ -41,6 +42,7 @@ spec:
         component: tekton-kueue
         slo: "true"
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L31
         summary: "Tekton Kueue webhook is down"
         description: "The Tekton Kueue webhook has no available replicas in cluster {{ $labels.source_cluster }}. PipelineRuns may not be created with Pending state and Workload resources, bypassing Kueue admission control."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueWebhookDown.md
@@ -149,6 +151,7 @@ spec:
         component: tekton-kueue
         slo: "true"
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L142
         summary: "Tekton Kueue CEL evaluation failures detected"
         description: "{{ $value }} CEL evaluation failures occurred in the last 5 minutes in cluster {{ $labels.source_cluster }}"
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-KueueCELEvaluationFailures.md?ref_type=heads
@@ -207,6 +210,7 @@ spec:
         component: kueue
         slo: "true"
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L200
         summary: "Kueue cluster queue is not active"
         description: "Cluster queue 'cluster-pipeline-queue' is not in active state in cluster {{ $labels.source_cluster }}"
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md?ref_type=heads

--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -42,7 +42,7 @@ spec:
         component: tekton-kueue
         slo: "true"
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L31
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L32
         summary: "Tekton Kueue webhook is down"
         description: "The Tekton Kueue webhook has no available replicas in cluster {{ $labels.source_cluster }}. PipelineRuns may not be created with Pending state and Workload resources, bypassing Kueue admission control."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueWebhookDown.md
@@ -151,7 +151,7 @@ spec:
         component: tekton-kueue
         slo: "true"
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L142
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L146
         summary: "Tekton Kueue CEL evaluation failures detected"
         description: "{{ $value }} CEL evaluation failures occurred in the last 5 minutes in cluster {{ $labels.source_cluster }}"
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-KueueCELEvaluationFailures.md?ref_type=heads
@@ -210,7 +210,7 @@ spec:
         component: kueue
         slo: "true"
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L200
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L205
         summary: "Kueue cluster queue is not active"
         description: "Cluster queue 'cluster-pipeline-queue' is not in active state in cluster {{ $labels.source_cluster }}"
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md?ref_type=heads
@@ -280,6 +280,7 @@ spec:
         component: kueue
         slo: "true"
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L271
         summary: "High admission wait time for Release workloads"
         description: "99th percentile admission wait time for konflux and tenant release workloads is {{ $value | humanizeDuration }}, which is above 1.33 hours in cluster {{ $labels.source_cluster }}"
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md

--- a/rhobs/alerting/data_plane/prometheus.kyverno_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kyverno_alerts.yaml
@@ -35,7 +35,7 @@ spec:
           slo: "true"
           component: kyverno
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kyverno_alerts.yaml#L28
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kyverno_alerts.yaml#L29
           summary: Kyverno internal controllers are encountering errors causing items to be re-queued.
           description: "The Kyverno controller '{{ $labels.controller_name }}' on cluster '{{ $labels.source_cluster }}' is experiencing a consistent rate of requeue errors."
           alert_team_handle: <!subteam^S05Q1P4Q2TG>

--- a/rhobs/alerting/data_plane/prometheus.kyverno_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kyverno_alerts.yaml
@@ -19,6 +19,7 @@ spec:
           slo: "true"
           component: kyverno
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kyverno_alerts.yaml#L13
           summary: Kyverno has reported that not all the deployments pods are up and running for the last 3 minutes.
           description: "The Kyverno Deployment '{{ $labels.deployment }}' in namespace '{{ $labels.namespace }}' on cluster '{{ $labels.source_cluster }}' is unhealthy."
           alert_team_handle: <!subteam^S05Q1P4Q2TG>
@@ -34,6 +35,7 @@ spec:
           slo: "true"
           component: kyverno
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kyverno_alerts.yaml#L28
           summary: Kyverno internal controllers are encountering errors causing items to be re-queued.
           description: "The Kyverno controller '{{ $labels.controller_name }}' on cluster '{{ $labels.source_cluster }}' is experiencing a consistent rate of requeue errors."
           alert_team_handle: <!subteam^S05Q1P4Q2TG>

--- a/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
@@ -23,6 +23,7 @@ spec:
         slo: "true"
         component: mintmaker
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml#L13
         summary: >-
           MintMaker controller is down in cluster {{ $labels.source_cluster }}
         description: >
@@ -47,6 +48,7 @@ spec:
         slo: "true"
         component: mintmaker
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml#L37
         summary: >-
           MintMaker cache is down in cluster {{ $labels.source_cluster }}
         description: >

--- a/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
@@ -48,7 +48,7 @@ spec:
         slo: "true"
         component: mintmaker
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml#L37
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml#L38
         summary: >-
           MintMaker cache is down in cluster {{ $labels.source_cluster }}
         description: >

--- a/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml
@@ -23,6 +23,7 @@ spec:
         slo: "true"
         component: multi-platform-controller
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml#L13
         summary: >-
           Multiplatform controller is down in cluster {{ $labels.source_cluster }}
         description: >
@@ -47,6 +48,7 @@ spec:
         slo: "true"
         component: multi-platform-controller
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml#L37
         summary: >-
           Multiplatform OTP is down in cluster {{ $labels.source_cluster }}
         description: >

--- a/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml
@@ -48,7 +48,7 @@ spec:
         slo: "true"
         component: multi-platform-controller
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml#L37
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml#L38
         summary: >-
           Multiplatform OTP is down in cluster {{ $labels.source_cluster }}
         description: >

--- a/rhobs/alerting/data_plane/prometheus.namespace_lister_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.namespace_lister_alerts.yaml
@@ -53,6 +53,7 @@ spec:
         slo: "true"
         component: namespace-lister
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.namespace_lister_alerts.yaml#L43
         summary: >-
           namespace-lister is down in cluster {{ $labels.source_cluster }}
         description: >

--- a/rhobs/alerting/data_plane/prometheus.node_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.node_alerts.yaml
@@ -35,6 +35,7 @@ spec:
             severity: critical
             slo: "true"
           annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.node_alerts.yaml#L29
             summary: >-
               Master Node High Memory Usage.
             description: >-

--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -44,6 +44,7 @@ spec:
           slo: "true"
           component: pipelines-as-code
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L34
           summary: >-
             Pipelines as Code controller is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -67,6 +68,7 @@ spec:
           slo: "true"
           component: pipelines-as-code
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L57
           summary: >-
             Pipelines as Code watcher is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -113,6 +115,7 @@ spec:
           slo: "true"
           component: tekton-chains
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L103
           summary: >-
             Tekton Chians controller is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -136,6 +139,7 @@ spec:
           slo: "true"
           component: tekton-operator
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L148
           summary: >-
             Tekton Operator Proxy Webhook is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -159,6 +163,7 @@ spec:
           slo: "true"
           component: tekton-pipelines
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L171
           summary: >-
             TektonPipelinesWebhook is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -205,6 +210,7 @@ spec:
           slo: "true"
           component: tekton-results
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L217
           summary: >-
             Tekton Results API reader is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -228,6 +234,7 @@ spec:
           slo: "true"
           component: tekton-results
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L240
           summary: >-
             Tekton Results API writer is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -251,6 +258,7 @@ spec:
           slo: "true"
           component: tekton-results
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L263
           summary: >-
             Tekton Results watcher is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -274,6 +282,7 @@ spec:
           slo: "true"
           component: tekton-pipelines
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L309
           summary: >-
             Tekton Pipelines Controller is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -297,6 +306,7 @@ spec:
           slo: "true"
           component: tekton-pipelines
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L332
           summary: >-
             Tekton Pipelines Remote Resolvers is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -332,6 +342,7 @@ spec:
             slo: "true"
             component: tekton-pipelines
           annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L371
             summary: >-
               Tekton controller is in a crashloop
             description: >-
@@ -349,6 +360,7 @@ spec:
             slo: "true"
             component: tekton-pipelines
           annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L388
             summary: >-
               Tekton pipeline controller appears to have stopped processing active pipelineruns which have not been started yet.
             description: >-
@@ -365,6 +377,7 @@ spec:
             slo: "true"
             component: tekton-pipelines
           annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L404
             summary: >-
               Tekton taskrun controller appears to have stopped processing active taskruns whose underlying Pod have not failed Kubernetes screening.
             description: >-
@@ -381,6 +394,7 @@ spec:
             slo: "true"
             component: tekton-pipelines
           annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L420
             summary: >-
               Tekton resolver controller appears to have stopped processing active resolutionrequests which have not been started yet.
             description: >-
@@ -397,6 +411,7 @@ spec:
             slo: "true"
             component: tekton-chains
           annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L436
             summary: >-
               Tekton chains controller is experiencing high overhead in processing pipelineruns.
             description: >-
@@ -415,6 +430,7 @@ spec:
             slo: "true"
             component: tekton-results
           annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L452
             summary: >-
               Tekton results appears to have stopped processing active pipelineruns.
             description: >-
@@ -436,6 +452,7 @@ spec:
             slo: "true"
             component: tekton-results
           annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L470
             summary: >-
               Tekton results is experiencing too many API errors.
             description: >-
@@ -452,6 +469,7 @@ spec:
             slo: "true"
             component: pipelines-as-code
           annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L491
             summary: >-
               Tekton PAC controller appears to have stopped processing active pipelineruns.
             description: >-

--- a/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml
@@ -68,7 +68,7 @@ spec:
           slo: "true"
           component: pipelines-as-code
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L57
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L58
           summary: >-
             Pipelines as Code watcher is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -115,7 +115,7 @@ spec:
           slo: "true"
           component: tekton-chains
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L103
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L105
           summary: >-
             Tekton Chians controller is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -139,7 +139,7 @@ spec:
           slo: "true"
           component: tekton-operator
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L148
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L129
           summary: >-
             Tekton Operator Proxy Webhook is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -163,7 +163,7 @@ spec:
           slo: "true"
           component: tekton-pipelines
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L171
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L153
           summary: >-
             TektonPipelinesWebhook is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -210,7 +210,7 @@ spec:
           slo: "true"
           component: tekton-results
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L217
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L200
           summary: >-
             Tekton Results API reader is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -234,7 +234,7 @@ spec:
           slo: "true"
           component: tekton-results
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L240
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L224
           summary: >-
             Tekton Results API writer is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -258,7 +258,7 @@ spec:
           slo: "true"
           component: tekton-results
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L263
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L248
           summary: >-
             Tekton Results watcher is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -282,7 +282,7 @@ spec:
           slo: "true"
           component: tekton-pipelines
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L309
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L272
           summary: >-
             Tekton Pipelines Controller is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -306,7 +306,7 @@ spec:
           slo: "true"
           component: tekton-pipelines
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L332
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L296
           summary: >-
             Tekton Pipelines Remote Resolvers is down in cluster {{ $labels.source_cluster }}
           description: >
@@ -342,7 +342,7 @@ spec:
             slo: "true"
             component: tekton-pipelines
           annotations:
-            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L371
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L336
             summary: >-
               Tekton controller is in a crashloop
             description: >-
@@ -360,7 +360,7 @@ spec:
             slo: "true"
             component: tekton-pipelines
           annotations:
-            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L388
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L354
             summary: >-
               Tekton pipeline controller appears to have stopped processing active pipelineruns which have not been started yet.
             description: >-
@@ -377,7 +377,7 @@ spec:
             slo: "true"
             component: tekton-pipelines
           annotations:
-            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L404
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L371
             summary: >-
               Tekton taskrun controller appears to have stopped processing active taskruns whose underlying Pod have not failed Kubernetes screening.
             description: >-
@@ -394,7 +394,7 @@ spec:
             slo: "true"
             component: tekton-pipelines
           annotations:
-            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L420
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L388
             summary: >-
               Tekton resolver controller appears to have stopped processing active resolutionrequests which have not been started yet.
             description: >-
@@ -411,7 +411,7 @@ spec:
             slo: "true"
             component: tekton-chains
           annotations:
-            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L436
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L405
             summary: >-
               Tekton chains controller is experiencing high overhead in processing pipelineruns.
             description: >-
@@ -430,7 +430,7 @@ spec:
             slo: "true"
             component: tekton-results
           annotations:
-            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L452
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L422
             summary: >-
               Tekton results appears to have stopped processing active pipelineruns.
             description: >-
@@ -452,7 +452,7 @@ spec:
             slo: "true"
             component: tekton-results
           annotations:
-            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L470
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L441
             summary: >-
               Tekton results is experiencing too many API errors.
             description: >-
@@ -469,7 +469,7 @@ spec:
             slo: "true"
             component: pipelines-as-code
           annotations:
-            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L491
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L463
             summary: >-
               Tekton PAC controller appears to have stopped processing active pipelineruns.
             description: >-

--- a/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
@@ -109,6 +109,7 @@ spec:
         reason: "OOMKilled"
         slo: "true"
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml#L103
         summary: "Pod {{ $labels.pod }} ran out of memory - OOMKilled."
         description: "Pod {{ $labels.pod }} in Namespace {{ $labels.namespace }} was killed due to OOM."
         alert_team_handle: >- # testing

--- a/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
@@ -20,6 +20,7 @@ spec:
           severity: critical
           slo: "true"
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L13
           summary: >-
              Probe alert {{ $labels.job }}.
           description: >-
@@ -55,6 +56,7 @@ spec:
           severity: critical
           slo: "true"
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L30
           summary: >-
              Probe alert {{ $labels.job }} ({{ $labels.instance }}) in multiple clusters.
           description: >-
@@ -73,6 +75,7 @@ spec:
           severity: critical
           slo: "true"
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L48
           summary: >-
              Quay Probe alert {{ $labels.instance }} in multiple clusters.
           description: >-
@@ -91,6 +94,7 @@ spec:
           severity: critical
           slo: "true"
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L66
           summary: >-
              Infra S390x Static Host Probe alert {{ $labels.job }}.
           description: >-
@@ -110,6 +114,7 @@ spec:
           severity: critical
           slo: "true"
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L85
           summary: >-
              Infra PPC Static Host Probe alert {{ $labels.job }}.
           description: >-
@@ -129,6 +134,7 @@ spec:
           severity: critical
           slo: "true"
         annotations:
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L104
           summary: >-
              PWVS Probe alert {{ $labels.job }}.
           description: >-

--- a/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
@@ -56,7 +56,7 @@ spec:
           severity: critical
           slo: "true"
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L30
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L48
           summary: >-
              Probe alert {{ $labels.job }} ({{ $labels.instance }}) in multiple clusters.
           description: >-
@@ -75,7 +75,7 @@ spec:
           severity: critical
           slo: "true"
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L48
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L67
           summary: >-
              Quay Probe alert {{ $labels.instance }} in multiple clusters.
           description: >-
@@ -94,7 +94,7 @@ spec:
           severity: critical
           slo: "true"
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L66
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L86
           summary: >-
              Infra S390x Static Host Probe alert {{ $labels.job }}.
           description: >-
@@ -114,7 +114,7 @@ spec:
           severity: critical
           slo: "true"
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L85
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L106
           summary: >-
              Infra PPC Static Host Probe alert {{ $labels.job }}.
           description: >-
@@ -134,7 +134,7 @@ spec:
           severity: critical
           slo: "true"
         annotations:
-          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L104
+          html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L126
           summary: >-
              PWVS Probe alert {{ $labels.job }}.
           description: >-

--- a/rhobs/alerting/data_plane/prometheus.project_controller_up_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.project_controller_up_alerts.yaml
@@ -22,6 +22,7 @@ spec:
         slo: "true"
         component: project-controller
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.project_controller_up_alerts.yaml#L12
         summary: >-
           Project controller is down on cluster {{ $labels.source_cluster }}
         description: >

--- a/rhobs/alerting/data_plane/prometheus.prometheus_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.prometheus_alerts.yaml
@@ -36,7 +36,7 @@ spec:
         slo: "true"
         component: prometheus
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.prometheus_alerts.yaml#L30
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.prometheus_alerts.yaml#L31
         summary: Prometheus Instance in Openshift Monitoring is down in cluster {{ $labels.source_cluster }}
         description: >-
           Prometheus Openshift Monitoring instance on cluster {{ $labels.source_cluster }} has declared 'prometheus_ready' = 0. Namespace 'openshift-monitoring'.
@@ -54,7 +54,7 @@ spec:
         slo: "true"
         component: prometheus
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.prometheus_alerts.yaml#L47
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.prometheus_alerts.yaml#L49
         summary: Prometheus User Workload Instance is down in cluster {{ $labels.source_cluster }}
         description: >-
           Prometheus User Workload instance on cluster {{ $labels.source_cluster }} has declared 'prometheus_ready' = 0. Namespace 'openshift-user-workload-monitoring'.

--- a/rhobs/alerting/data_plane/prometheus.prometheus_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.prometheus_alerts.yaml
@@ -17,6 +17,7 @@ spec:
         slo: "true"
         component: prometheus
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.prometheus_alerts.yaml#L12
         summary: Prometheus Federate Instance is down in cluster {{ $labels.source_cluster }}
         description: >-
           Prometheus Federate instance on cluster {{ $labels.source_cluster }} has declared 'prometheus_ready' = 0. Namespace 'appstudio-monitoring'.
@@ -35,6 +36,7 @@ spec:
         slo: "true"
         component: prometheus
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.prometheus_alerts.yaml#L30
         summary: Prometheus Instance in Openshift Monitoring is down in cluster {{ $labels.source_cluster }}
         description: >-
           Prometheus Openshift Monitoring instance on cluster {{ $labels.source_cluster }} has declared 'prometheus_ready' = 0. Namespace 'openshift-monitoring'.
@@ -52,6 +54,7 @@ spec:
         slo: "true"
         component: prometheus
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.prometheus_alerts.yaml#L47
         summary: Prometheus User Workload Instance is down in cluster {{ $labels.source_cluster }}
         description: >-
           Prometheus User Workload instance on cluster {{ $labels.source_cluster }} has declared 'prometheus_ready' = 0. Namespace 'openshift-user-workload-monitoring'.

--- a/rhobs/alerting/data_plane/prometheus.pulp_access_controller_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pulp_access_controller_alerts.yaml
@@ -22,6 +22,7 @@ spec:
         slo: "true"
         component: pulp-access-controller
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pulp_access_controller_alerts.yaml#L12
         summary: >-
           pulp-access-controller is down in cluster {{ $labels.source_cluster }}
         description: >

--- a/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
@@ -18,6 +18,7 @@ spec:
         slo: "true"
         component: registry-exporter
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L12
         summary: >-
           Registry exporter check failed for registry {{ $labels.check }} in cluster {{ $labels.source_cluster }}
         description: >-

--- a/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml
@@ -94,6 +94,7 @@ spec:
         slo: "true"
         component: release-service
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml#L85
         summary: >-
           Release Service Controller Manager pod is down in cluster {{ $labels.source_cluster }}
         description: >

--- a/rhobs/alerting/data_plane/prometheus.smee_up_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.smee_up_alerts.yaml
@@ -21,6 +21,7 @@ spec:
         slo: "true"
         component: smee
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.smee_up_alerts.yaml#L12
         summary: >-
           {{ $labels.service }} is down on cluster {{ $labels.source_cluster }}
         description: >

--- a/rhobs/alerting/data_plane/prometheus.support_ops_availability_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.support_ops_availability_alerts.yaml
@@ -22,6 +22,7 @@ spec:
         slo: "true"
         component: support-ops
       annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.support_ops_availability_alerts.yaml#L12
         summary: >-
           User support automation is down on cluster {{ $labels.source_cluster }}
         description: >

--- a/test/promql/tests/data_plane/api_server_availability_test.yaml
+++ b/test/promql/tests/data_plane/api_server_availability_test.yaml
@@ -27,6 +27,7 @@ tests:
               component: api-server
               source_cluster: "kflux-prd-es01"
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml#L13
               summary: "API Server 5XX error count in cluster kflux-prd-es01"
               description: "API Server is experiencing 10% of 5XX failures based on the total requests for 15min in cluster kflux-prd-es01"
               alert_team_handle: "<!subteam^S05Q1P4Q2TG>"
@@ -93,6 +94,7 @@ tests:
               component: api-server
               source_cluster: "cluster01"
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml#L108
               summary: API Server memory usage is above 80% in cluster01
               description: >-
                 API Server process memory consumption is above 80% for 5 minutes in cluster cluster01.
@@ -168,6 +170,7 @@ tests:
               team: konflux-infra
               source_cluster: "cluster01"
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.api_server_alerts.yaml#L77
               summary: "API Server Latency: Critical SLO Breach (cluster01)"
               description: "More than 5% of API requests exceeded 1s latency over the last 1h and 5m. Impact: High risk of system-wide timeouts. Action: Immediate check of Etcd health and admission webhooks."
               alert_team_handle: "<!subteam^S05Q1P4Q2TG>"

--- a/test/promql/tests/data_plane/artifact_registry_proxy_alerts_test.yaml
+++ b/test/promql/tests/data_plane/artifact_registry_proxy_alerts_test.yaml
@@ -25,6 +25,7 @@ tests:
               service: artifact-registry-proxy
               source_cluster: cluster01
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.artifact_registry_proxy_alerts.yaml#L13
               summary: "Artifact Registry Nginx proxy is down"
               description: "Access log exporter cannot scrape the artifact registry proxy successfully in namespace caching. The proxy has been down for 5 minutes in cluster cluster01."
               alert_team_handle: "<!subteam^S07NDQV6A4D>"

--- a/test/promql/tests/data_plane/build_service_up_test.yaml
+++ b/test/promql/tests/data_plane/build_service_up_test.yaml
@@ -26,6 +26,7 @@ tests:
             slo: "true"
             source_cluster: c1
           exp_annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.build_service_alerts.yaml#L12
             summary: >-
               build-service is down in cluster c1
             description: >

--- a/test/promql/tests/data_plane/caching_squid_alerts_test.yaml
+++ b/test/promql/tests/data_plane/caching_squid_alerts_test.yaml
@@ -20,6 +20,7 @@ tests:
               namespace: "caching"
               service: "squid"
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.caching_squid_alerts.yaml#L13
               summary: "Caching Squid proxy is down"
               description: "Squid exporter cannot scrape the Squid proxy successfully in namespace caching. The proxy has been down for 5 minutes."
               alert_team_handle: "<!subteam^S07NDQV6A4D>"

--- a/test/promql/tests/data_plane/cluster_capacity_test.yaml
+++ b/test/promql/tests/data_plane/cluster_capacity_test.yaml
@@ -88,6 +88,7 @@ tests:
               source_cluster: cluster01
               slo: 'true'
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.cluster_capacity_alerts.yaml#L45
               description: 'Database size exceeds critical usage threshold on etcd instances in cluster cluster01.'
               summary: Etcd cluster database is running full.
               alert_team_handle: '<!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>'

--- a/test/promql/tests/data_plane/etcd_shield_test.yaml
+++ b/test/promql/tests/data_plane/etcd_shield_test.yaml
@@ -20,6 +20,7 @@ tests:
               source_cluster: cluster01
               slo: 'true'
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.etcd_shield.yaml#L13
               description: 'Etcd Shield Alert Triggered in cluster cluster01.'
               summary: Etcd Shield Alert Triggered
               alert_team_handle: >-

--- a/test/promql/tests/data_plane/image_controller_up_test.yaml
+++ b/test/promql/tests/data_plane/image_controller_up_test.yaml
@@ -26,6 +26,7 @@ tests:
             slo: "true"
             source_cluster: c1
           exp_annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.image_controller_alerts.yaml#L12
             summary: >-
               image-controller is down in cluster c1
             description: >

--- a/test/promql/tests/data_plane/integration_service_availability_test.yaml
+++ b/test/promql/tests/data_plane/integration_service_availability_test.yaml
@@ -26,6 +26,7 @@ tests:
               source_cluster: cluster01
               check: replicas-available
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.integration_service_availability_alerts.yaml#L12
               summary: Integration Service Availability SLO Violation
               description: Integration service 'integration-service-controller-manager' in namespace 'integration-service' on cluster01 has been down for 5min.
               alert_team_handle: <!subteam^S05M4AG8CJH>
@@ -67,6 +68,7 @@ tests:
               source_cluster: cluster01
               check: replicas-available
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.integration_service_availability_alerts.yaml#L12
               summary: Integration Service Availability SLO Violation
               description: Integration service 'integration-service-controller-manager' in namespace 'integration-service' on cluster01 has been down for 5min.
 

--- a/test/promql/tests/data_plane/konflux_kite_up_test.yaml
+++ b/test/promql/tests/data_plane/konflux_kite_up_test.yaml
@@ -26,6 +26,7 @@ tests:
             slo: "true"
             source_cluster: c1
           exp_annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_kite_alerts.yaml#L12
             summary: >-
               konflux-kite is down in cluster c1
             description: >
@@ -67,6 +68,7 @@ tests:
             slo: "true"
             source_cluster: c1
           exp_annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_kite_alerts.yaml#L39
             summary: >-
               Konflux Kite endpoint is down in cluster c1
             description: >

--- a/test/promql/tests/data_plane/konflux_ui_alerts_test.yaml
+++ b/test/promql/tests/data_plane/konflux_ui_alerts_test.yaml
@@ -24,6 +24,7 @@ tests:
               slo: "true"
               source_cluster: c1
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L13
               summary: Konflux UI proxy pod is down in cluster c1
               description: >
                 The Konflux UI proxy pod has been down for 5min in cluster c1
@@ -51,6 +52,7 @@ tests:
               slo: "true"
               source_cluster: c3
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L38
               summary: Konflux UI dex pod is down in cluster c3
               description: >
                 The Konflux UI dex pod has been down for 5min in cluster c3
@@ -77,6 +79,7 @@ tests:
               slo: "true"
               source_cluster: c5
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L63
               summary: Konflux UI endpoint is down in cluster c5
               description: >
                 There were no Konflux UI proxy pods behind the endopint for 5min in cluster c5
@@ -278,6 +281,7 @@ tests:
               slo: "true"
               source_cluster: c_upstream_502
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L136
               summary: Konflux UI proxy returning 502 errors in cluster c_upstream_502
               description: >
                 The Konflux UI nginx proxy has been returning 502 errors for 2min in cluster
@@ -296,6 +300,7 @@ tests:
               slo: "true"
               source_cluster: c_upstream_502
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L136
               summary: Konflux UI proxy returning 502 errors in cluster c_upstream_502
               description: >
                 The Konflux UI nginx proxy has been returning 502 errors for 2min in cluster

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -332,6 +332,7 @@ tests:
               slo: "true"
               source_cluster: c1
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L271
               summary: "High admission wait time for Release workloads"
               description: "99th percentile admission wait time for konflux and tenant release workloads is 1h 23m 20s, which is above 1.33 hours in cluster c1"
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md

--- a/test/promql/tests/data_plane/kyverno_test.yaml
+++ b/test/promql/tests/data_plane/kyverno_test.yaml
@@ -32,6 +32,7 @@ tests:
               namespace: konflux-kyverno
               source_cluster: stone-stg-rh01
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kyverno_alerts.yaml#L13
               summary: Kyverno has reported that not all the deployments pods are up and running for the last 3 minutes.
               description: "The Kyverno Deployment 'kyverno-admission-controller' in namespace 'konflux-kyverno' on cluster 'stone-stg-rh01' is unhealthy."
               team: konflux-infra
@@ -74,6 +75,7 @@ tests:
               controller_name: certmanager-controller
               source_cluster: stone-stg-rh01
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kyverno_alerts.yaml#L29
               summary: Kyverno internal controllers are encountering errors causing items to be re-queued.
               description: "The Kyverno controller 'certmanager-controller' on cluster 'stone-stg-rh01' is experiencing a consistent rate of requeue errors."
               team: konflux-infra

--- a/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
+++ b/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
@@ -24,6 +24,7 @@ tests:
               slo: "true"
               source_cluster: c1
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml#L13
               summary: MintMaker controller is down in cluster c1
               description: >
                 The MintMaker controller pod has been down for 5min in cluster c1
@@ -51,6 +52,7 @@ tests:
               slo: "true"
               source_cluster: c5
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml#L38
               summary: MintMaker cache is down in cluster c5
               description: >
                 The MintMaker cache pod has been down for 5min in cluster c5

--- a/test/promql/tests/data_plane/multi_platform_alerts_test.yaml
+++ b/test/promql/tests/data_plane/multi_platform_alerts_test.yaml
@@ -24,6 +24,7 @@ tests:
               slo: "true"
               source_cluster: c1
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml#L13
               summary: Multiplatform controller is down in cluster c1
               description: >
                 The multi-platform-controller pod has been down for 5min in cluster c1
@@ -51,6 +52,7 @@ tests:
               slo: "true"
               source_cluster: c3
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.multi_platform_alerts.yaml#L38
               summary: Multiplatform OTP is down in cluster c3
               description: >
                 The multi-platform otp pod has been down for 5min in cluster c3

--- a/test/promql/tests/data_plane/namespace_lister_test.yaml
+++ b/test/promql/tests/data_plane/namespace_lister_test.yaml
@@ -144,6 +144,7 @@ tests:
             slo: "true"
             source_cluster: c1
           exp_annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.namespace_lister_alerts.yaml#L43
             summary: namespace-lister is down in cluster c1
             description: >
               The namespace-lister pod has been down for 5min in cluster c1

--- a/test/promql/tests/data_plane/node_alerts_test.yaml
+++ b/test/promql/tests/data_plane/node_alerts_test.yaml
@@ -61,6 +61,7 @@ tests:
               source_cluster: cluster01
               slo: "true"
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.node_alerts.yaml#L29
               summary: "Master Node High Memory Usage."
               description: "Memory Usage is 98% on master node instance1 in cluster cluster01."
               alert_team_handle: '<!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>'

--- a/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_deadlock_crashloop_test.yaml
@@ -79,6 +79,7 @@ tests:
               component: tekton-pipelines
               source_cluster: cluster01
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L354
               summary: >-
                 Tekton pipeline controller appears to have stopped processing active pipelineruns which have not been started yet.
               description: >-
@@ -137,6 +138,7 @@ tests:
               component: tekton-pipelines
               source_cluster: cluster01
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L371
               summary: >-
                 Tekton taskrun controller appears to have stopped processing active taskruns whose underlying Pod have not failed Kubernetes screening.
               description: >-
@@ -169,6 +171,7 @@ tests:
               component: tekton-pipelines
               source_cluster: cluster01
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L371
               summary: >-
                 Tekton taskrun controller appears to have stopped processing active taskruns whose underlying Pod have not failed Kubernetes screening.
               description: >-
@@ -243,6 +246,7 @@ tests:
               component: tekton-pipelines
               source_cluster: cluster01
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L388
               summary: >-
                 Tekton resolver controller appears to have stopped processing active resolutionrequests which have not been started yet.
               description: >-
@@ -286,6 +290,7 @@ tests:
               component: tekton-results
               source_cluster: cluster01
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L422
               summary: >-
                 Tekton results appears to have stopped processing active pipelineruns.
               description: >-
@@ -357,6 +362,7 @@ tests:
               component: pipelines-as-code
               source_cluster: cluster01
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L463
               summary: >-
                 Tekton PAC controller appears to have stopped processing active pipelineruns.
               description: >-

--- a/test/promql/tests/data_plane/pipeline_overhead_test.yaml
+++ b/test/promql/tests/data_plane/pipeline_overhead_test.yaml
@@ -28,6 +28,7 @@ tests:
               component: tekton-results
               source_cluster: cluster01
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L441
               summary: >-
                 Tekton results is experiencing too many API errors.
               description: >-
@@ -58,6 +59,7 @@ tests:
               component: tekton-results
               source_cluster: cluster01
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L441
               summary: >-
                 Tekton results is experiencing too many API errors.
               description: >-
@@ -138,6 +140,7 @@ tests:
               component: tekton-chains
               source_cluster: cluster01
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L405
               summary: >-
                 Tekton chains controller is experiencing high overhead in processing pipelineruns.
               description: >-

--- a/test/promql/tests/data_plane/pipelines_up_test.yaml
+++ b/test/promql/tests/data_plane/pipelines_up_test.yaml
@@ -178,6 +178,7 @@ tests:
               source_cluster: c_down
               component: pipelines-as-code
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L34
               summary: Pipelines as Code controller is down in cluster c_down
               description: >
                 The Pipelines as Code controller pod has been down for 5min in cluster c_down
@@ -196,6 +197,7 @@ tests:
               source_cluster: c_down
               component: pipelines-as-code
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L58
               summary: Pipelines as Code watcher is down in cluster c_down
               description: >
                 The Pipelines as Code watcher pod has been down for 5min in cluster c_down
@@ -231,6 +233,7 @@ tests:
               source_cluster: c_down
               component: tekton-chains
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L105
               summary: Tekton Chians controller is down in cluster c_down
               description: >
                 The Tekton Chains controller pod has been down for 5min in cluster c_down
@@ -249,6 +252,7 @@ tests:
               source_cluster: c_down
               component: tekton-operator
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L129
               summary: Tekton Operator Proxy Webhook is down in cluster c_down
               description: >
                 The Tekton Operator Proxy webhook pod has been down for 5min in cluster c_down
@@ -267,6 +271,7 @@ tests:
               source_cluster: c_down
               component: tekton-pipelines
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L153
               summary: TektonPipelinesWebhook is down in cluster c_down
               description: >
                 The Tekton Pipelines webhook pod has been down for 5min in cluster c_down
@@ -302,6 +307,7 @@ tests:
               source_cluster: c_down
               component: tekton-results
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L200
               summary: Tekton Results API reader is down in cluster c_down
               description: >
                 The Tekton Results API pod (reader instance) has been down for 5min in cluster c_down
@@ -320,6 +326,7 @@ tests:
               source_cluster: c_down
               component: tekton-results
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L224
               summary: Tekton Results API writer is down in cluster c_down
               description: >
                 The Tekton Results API pod (writer instance) has been down for 5min in cluster c_down
@@ -338,6 +345,7 @@ tests:
               source_cluster: c_down
               component: tekton-results
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L248
               summary: Tekton Results watcher is down in cluster c_down
               description: >
                 The Tekton Results watcher pod has been down for 5min in cluster c_down
@@ -356,6 +364,7 @@ tests:
               source_cluster: c_down
               component: tekton-results
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L248
               summary: Tekton Results watcher is down in cluster c_down
               description: >
                 The Tekton Results watcher pod has been down for 5min in cluster c_down
@@ -374,6 +383,7 @@ tests:
               source_cluster: c_down
               component: tekton-pipelines
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L272
               summary: Tekton Pipelines Controller is down in cluster c_down
               description: >
                 Tekton Pipelines Controller pod has been down for 5min in cluster c_down
@@ -392,6 +402,7 @@ tests:
               source_cluster: c_down
               component: tekton-pipelines
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pipeline_alerts.yaml#L296
               summary: Tekton Pipelines Remote Resolvers is down in cluster c_down
               description: >
                 Tekton Pipelines Remote Resolvers pod has been down for 5min in cluster c_down

--- a/test/promql/tests/data_plane/pod_oom_test.yaml
+++ b/test/promql/tests/data_plane/pod_oom_test.yaml
@@ -44,6 +44,7 @@ tests:
               reason: "OOMKilled"
               slo: "true"
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml#L103
               summary: "Pod .*controller.*|.*manager.* ran out of memory - OOMKilled."
               description: "Pod .*controller.*|.*manager.* in Namespace namespace was killed due to OOM."
               alert_team_handle: >- # testing

--- a/test/promql/tests/data_plane/probe_test.yaml
+++ b/test/promql/tests/data_plane/probe_test.yaml
@@ -31,6 +31,7 @@ tests:
               service: web-server
               slo: "true"
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L13
               description: 'Probe on cluster01 is unable to connect to instance01 (web-server) for the last 25 minutes. At least 80% of Konflux clusters successfully connect to instance01.'
               summary: Probe alert web-server.
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
@@ -107,6 +108,7 @@ tests:
               check: probe-multicluster
               service: web-server
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L48
               description: 'More than 20% of Konflux cluster probes are failing to connect to instance01 (web-server) for the last 25 minutes.'
               summary: Probe alert web-server (instance01) in multiple clusters.
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
@@ -127,6 +129,7 @@ tests:
               check: probe-multicluster
               service: quay
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L67
               description: 'Quay probes from more than 20% of Konflux clusters are unable to connect to instance01 for the last 20 minutes.'
               summary: Quay Probe alert instance01 in multiple clusters.
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG> <!subteam^S01B3J0AEEL>'
@@ -149,6 +152,7 @@ tests:
               service: s390x-static-host
               slo: 'true'
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L86
               description: 'Probe alert for job s390x-static-host on cluster cluster01.'
               summary: Infra S390x Static Host Probe alert s390x-static-host.
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
@@ -172,6 +176,7 @@ tests:
               service: ppc-static-host
               slo: 'true'
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L106
               description: 'Probe alert for job ppc-static-host on cluster cluster01.'
               summary: Infra PPC Static Host Probe alert ppc-static-host.
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
@@ -195,6 +200,7 @@ tests:
               service: pwvs
               slo: 'true'
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml#L126
               description: 'Probe alert for job pwvs and target net01 on cluster cluster01.'
               summary: PWVS Probe alert pwvs.
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'

--- a/test/promql/tests/data_plane/project_controller_up_test.yaml
+++ b/test/promql/tests/data_plane/project_controller_up_test.yaml
@@ -24,6 +24,7 @@ tests:
               source_cluster: c1
               component: project-controller
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.project_controller_up_alerts.yaml#L12
               summary: Project controller is down on cluster c1
               description: >
                 Some of the replicas of project-controller-controller-manager are down

--- a/test/promql/tests/data_plane/prometheus_alerts_test.yaml
+++ b/test/promql/tests/data_plane/prometheus_alerts_test.yaml
@@ -24,6 +24,7 @@ tests:
               source_cluster: c1
               component: prometheus
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.prometheus_alerts.yaml#L12
               summary: Prometheus Federate Instance is down in cluster c1
               description: >-
                 Prometheus Federate instance on cluster c1 has declared 'prometheus_ready' = 0. Namespace 'appstudio-monitoring'.
@@ -52,6 +53,7 @@ tests:
               source_cluster: c1
               component: prometheus
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.prometheus_alerts.yaml#L31
               summary: Prometheus Instance in Openshift Monitoring is down in cluster c1
               description: >-
                 Prometheus Openshift Monitoring instance on cluster c1 has declared 'prometheus_ready' = 0. Namespace 'openshift-monitoring'.
@@ -79,6 +81,7 @@ tests:
               source_cluster: c1
               component: prometheus
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.prometheus_alerts.yaml#L49
               summary: Prometheus User Workload Instance is down in cluster c1
               description: >-
                   Prometheus User Workload instance on cluster c1 has declared 'prometheus_ready' = 0. Namespace 'openshift-user-workload-monitoring'.

--- a/test/promql/tests/data_plane/pulp_controller_up_test.yaml
+++ b/test/promql/tests/data_plane/pulp_controller_up_test.yaml
@@ -26,6 +26,7 @@ tests:
             component: pulp-access-controller
             source_cluster: c1
           exp_annotations:
+            html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.pulp_access_controller_alerts.yaml#L12
             summary: >-
               pulp-access-controller is down in cluster c1
             description: >

--- a/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
+++ b/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
@@ -24,6 +24,7 @@ tests:
               source_cluster: c1
               component: registry-exporter
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L12
               summary: >-
                 Registry exporter check failed for registry quay.io in cluster c1
               description: >-
@@ -55,6 +56,7 @@ tests:
               source_cluster: c1
               component: registry-exporter
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L12
               summary: >-
                 Registry exporter check failed for registry quay.io in cluster c1
               description: >-
@@ -71,6 +73,7 @@ tests:
               source_cluster: c1
               component: registry-exporter
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L12
               summary: >-
                 Registry exporter check failed for registry registry.example.com in cluster c1
               description: >-
@@ -115,6 +118,7 @@ tests:
               source_cluster: c1
               component: registry-exporter
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L12
               summary: >-
                 Registry exporter check failed for registry quay.io in cluster c1
               description: >-
@@ -131,6 +135,7 @@ tests:
               source_cluster: c2
               component: registry-exporter
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L12
               summary: >-
                 Registry exporter check failed for registry registry.example.com in cluster c2
               description: >-

--- a/test/promql/tests/data_plane/release_service_test.yaml
+++ b/test/promql/tests/data_plane/release_service_test.yaml
@@ -143,6 +143,7 @@ tests:
               source_cluster: c1
               component: release-service
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.release_service_alerts.yaml#L85
               summary: Release Service Controller Manager pod is down in cluster c1
               description: >
                 Release Service Controller Manager pod has been down for 10 minutes in cluster c1

--- a/test/promql/tests/data_plane/smee_up_test.yaml
+++ b/test/promql/tests/data_plane/smee_up_test.yaml
@@ -26,6 +26,7 @@ tests:
               source_cluster: c1
               component: smee
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.smee_up_alerts.yaml#L12
               summary: smee is down on cluster c1
               description: >
                 Some of the replicas of smee are down on namespace smee in cluster c1
@@ -41,6 +42,7 @@ tests:
               source_cluster: c2
               component: smee
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.smee_up_alerts.yaml#L12
               summary: smee-client is down on cluster c2
               description: >
                 Some of the replicas of smee-client are down on namespace smee-client

--- a/test/promql/tests/data_plane/support_ops_availability_alerts_test.yaml
+++ b/test/promql/tests/data_plane/support_ops_availability_alerts_test.yaml
@@ -24,6 +24,7 @@ tests:
               source_cluster: c1
               component: support-ops
             exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.support_ops_availability_alerts.yaml#L12
               summary: User support automation is down on cluster c1
               description: >
                 Some of the replicas of user support automation are down in namespace konflux-support-ops on cluster c1


### PR DESCRIPTION
## Summary

Add `html_url` annotations to all 66 Konflux SLO alerts, linking directly to the specific alert definition in GitHub instead of just the parent folder. This enables the PagerDuty Slack integration to surface a direct link to the alert definition in each incident.

Related: SPRE-5957

## Test plan

- [ ] Verify all SLO alerts (`slo: "true"`) have an `html_url` annotation
- [ ] Verify each `html_url` `#L<N>` fragment points to the correct `- alert:` line in the file