### PR TITLE
SPRE-5842 - Update Mintmaker runbook

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.mintmaker_controller_up_alerts.yaml
@@ -29,7 +29,7 @@ spec:
           The MintMaker controller pod has been down for 5min in cluster {{ $labels.source_cluster }}
         alert_team_handle: <!subteam^S078T8TMQP5>
         team: mintmaker
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/SRE/controller_pod_down.md
 
   - name: mintmaker-cache-availability
     interval: 1m
@@ -53,7 +53,7 @@ spec:
           The MintMaker cache pod has been down for 5min in cluster {{ $labels.source_cluster }}
         alert_team_handle: <!subteam^S078T8TMQP5>
         team: mintmaker
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/SRE/cache_pod_down.md
 
   - name: mintmaker-dependency-update-check-availability
     interval: 1m
@@ -75,4 +75,4 @@ spec:
           The last DUC was created more than 4.5 hours ago.
         alert_routing_key: <!subteam^S078T8TMQP5>
         team: mintmaker
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/SRE/duc_not_created.md

--- a/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
+++ b/test/promql/tests/data_plane/mintmaker_controller_up_test.yaml
@@ -29,7 +29,7 @@ tests:
                 The MintMaker controller pod has been down for 5min in cluster c1
               alert_team_handle: <!subteam^S078T8TMQP5>
               team: mintmaker
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/SRE/controller_pod_down.md
 
   - interval: 1m
     input_series:
@@ -56,7 +56,7 @@ tests:
                 The MintMaker cache pod has been down for 5min in cluster c5
               alert_team_handle: <!subteam^S078T8TMQP5>
               team: mintmaker
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/SRE/cache_pod_down.md
 
   - interval: 1m
     input_series:
@@ -86,4 +86,4 @@ tests:
                 The last DUC was created more than 4.5 hours ago.
               alert_routing_key: <!subteam^S078T8TMQP5>
               team: mintmaker
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/faq.md
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/mintmaker/SRE/duc_not_created.md


### PR DESCRIPTION
### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

Updating runbook URLS for Mintmaker 

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [x] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
