### PR TITLE
fix(SPRE-6253): align BuildServiceDown service label and runbook URL

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.build_service_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.build_service_alerts.yaml
@@ -14,7 +14,7 @@ spec:
         konflux_up{
           namespace="build-service",
           check="replicas-available",
-          service="build-service"
+          service="build-service-controller-manager"
         } != 1
       for: 5m
       labels:
@@ -28,4 +28,4 @@ spec:
           The build-service pod has been down for 5min in cluster {{ $labels.source_cluster }}
         team: build
         alert_team_handle: <!subteam^S03DM1RL0TF>
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/build-service/build-service-availability.md
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/build-service/sre/build-service-availability.md

--- a/test/promql/tests/data_plane/build_service_up_test.yaml
+++ b/test/promql/tests/data_plane/build_service_up_test.yaml
@@ -8,9 +8,9 @@ tests:
 # replica count = 0
 - interval: 1m
   input_series:
-    - series: 'konflux_up{namespace="build-service", check="replicas-available", service="build-service", source_cluster="c1"}'
+    - series: 'konflux_up{namespace="build-service", check="replicas-available", service="build-service-controller-manager", source_cluster="c1"}'
       values: '0 0 0 0 0'
-    - series: 'konflux_up{namespace="build-service", check="replicas-available", service="build-service", source_cluster="c2"}'
+    - series: 'konflux_up{namespace="build-service", check="replicas-available", service="build-service-controller-manager", source_cluster="c2"}'
       values: '1 1 1 1 1'
 
   alert_rule_test:
@@ -22,7 +22,7 @@ tests:
             component: build-service
             check: replicas-available
             namespace: build-service
-            service: build-service
+            service: build-service-controller-manager
             slo: "true"
             source_cluster: c1
           exp_annotations:
@@ -32,4 +32,4 @@ tests:
               The build-service pod has been down for 5min in cluster c1
             team: build
             alert_team_handle: <!subteam^S03DM1RL0TF>
-            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/build-service/build-service-availability.md
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/build-service/sre/build-service-availability.md


### PR DESCRIPTION
## Summary
- Fix `BuildServiceDown` to select `service="build-service-controller-manager"` so it matches the deployment-derived `konflux_up` label from the recording rule
- Update `runbook_url` to the restructured SOP path `build-service/sre/build-service-availability.md`
- Update PromQL unit tests to match

## Test plan
- [x] `make selective-check-and-test RULE_FILES="rhobs/alerting/data_plane/prometheus.build_service_alerts.yaml" TEST_CASE_FILES="test/promql/tests/data_plane/build_service_up_test.yaml"`
- [ ] Confirm alert can fire against live `konflux_up{service="build-service-controller-manager"}` in RHOBS after deploy

Jira: https://redhat.atlassian.net/browse/SPRE-6253