### PR TITLE
chore(STONINTG-1636): rename alert to BuildPlrToSnapshotInProgress

### DIFF
--- a/dashboards/grafana-dashboard-konflux-integration-service-slo.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-integration-service-slo.configmap.yaml
@@ -121,7 +121,7 @@ data:
             "sizing": "auto",
             "text": {}
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -192,7 +192,7 @@ data:
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -303,7 +303,7 @@ data:
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -462,7 +462,7 @@ data:
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -493,7 +493,7 @@ data:
               "refId": "B"
             }
           ],
-          "title": "#1 Latency - Percentile Service Response (in-progress change)",
+          "title": "#1 Latency - Build PLR to Snapshot In Progress",
           "type": "timeseries"
         },
         {
@@ -591,7 +591,7 @@ data:
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -607,7 +607,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "[Violations] #1 Latency - Percentile Service Response (in-progress change)",
+          "title": "[Violations] #1 Latency - Build PLR to Snapshot In Progress",
           "type": "timeseries"
         },
         {
@@ -750,7 +750,7 @@ data:
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -877,7 +877,7 @@ data:
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -1232,5 +1232,5 @@ data:
       "timezone": "browser",
       "title": "Konflux - Integration Service SLO",
       "uid": "cerzhj80cyvi8c",
-      "version": 2
+      "version": 4
     }

--- a/rhobs/alerting/data_plane/prometheus.integration_service_build_pipeline_to_snapshot_in_progress_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.integration_service_build_pipeline_to_snapshot_in_progress_alerts.yaml
@@ -6,10 +6,10 @@ metadata:
     tenant: rhtap
 spec:
   groups:
-  - name: pipeline-to-snapshot-exceeded
+  - name: build-plr-to-snapshot-in-progress
     interval: 1m
     rules:
-    - alert: PipelineRunToSnapshotExceeded
+    - alert: BuildPlrToSnapshotInProgress
       expr: |
         (
           (
@@ -26,10 +26,10 @@ spec:
         component: integration-service
       annotations:
         summary: >-
-          PipelineRunFinish to SnapshotInProgress time exceeded
+          Build PLR to Snapshot In Progress time exceeded
         description: >
           Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 25% of requests during the last 30 minutes on cluster {{ $labels.source_cluster }}
         # alert_team_handle: <!subteam^S05M4AG8CJH>
         alert_routing_key: <!subteam^S05M4AG8CJH>
         team: integration
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/build_plr_to_snapshot_in_progress.md

--- a/test/promql/tests/data_plane/integration_service_build_pipeline_to_snapshot_in_progress_test.yaml
+++ b/test/promql/tests/data_plane/integration_service_build_pipeline_to_snapshot_in_progress_test.yaml
@@ -20,7 +20,7 @@ tests:
       values: '0+100x40'
   alert_rule_test:
     - eval_time: 35m
-      alertname: PipelineRunToSnapshotExceeded
+      alertname: BuildPlrToSnapshotInProgress
       exp_alerts:
         - exp_labels:
             severity: high
@@ -29,13 +29,13 @@ tests:
             namespace: integration-service
             source_cluster: cluster01
           exp_annotations:
-            summary: PipelineRunFinish to SnapshotInProgress time exceeded
+            summary: Build PLR to Snapshot In Progress time exceeded
             description: >
               Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 25% of requests during the last 30 minutes on cluster cluster01
             # alert_team_handle: <!subteam^S05M4AG8CJH>
             alert_routing_key: <!subteam^S05M4AG8CJH>
             team: integration
-            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/build_plr_to_snapshot_in_progress.md
 
 # Scenario where both clusters cross the 25% threshold
 - interval: 1m
@@ -52,7 +52,7 @@ tests:
       values: '0+100x40'
   alert_rule_test:
     - eval_time: 35m
-      alertname: PipelineRunToSnapshotExceeded
+      alertname: BuildPlrToSnapshotInProgress
       exp_alerts:
         - exp_labels:
             severity: high
@@ -61,13 +61,13 @@ tests:
             namespace: integration-service
             source_cluster: cluster01
           exp_annotations:
-            summary: PipelineRunFinish to SnapshotInProgress time exceeded
+            summary: Build PLR to Snapshot In Progress time exceeded
             description: >
               Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 25% of requests during the last 30 minutes on cluster cluster01
             # alert_team_handle: <!subteam^S05M4AG8CJH>
             alert_routing_key: <!subteam^S05M4AG8CJH>
             team: integration
-            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/build_plr_to_snapshot_in_progress.md
         - exp_labels:
             severity: high
             slo: "false"
@@ -75,13 +75,13 @@ tests:
             namespace: integration-service
             source_cluster: cluster02
           exp_annotations:
-            summary: PipelineRunFinish to SnapshotInProgress time exceeded
+            summary: Build PLR to Snapshot In Progress time exceeded
             description: >
               Time from build pipeline run finished to snapshot marked in progress has been over 30s for more than 25% of requests during the last 30 minutes on cluster cluster02
             # alert_team_handle: <!subteam^S05M4AG8CJH>
             alert_routing_key: <!subteam^S05M4AG8CJH>
             team: integration
-            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/latency_service_response.md
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/sre/build_plr_to_snapshot_in_progress.md
 
 # Scenario where no alert is triggered as both clusters stay below the 25% threshold
 - interval: 1m
@@ -99,5 +99,5 @@ tests:
       values: '0+100x40'  # 100 total occurrences in cluster2
   alert_rule_test:
     - eval_time: 35m
-      alertname: PipelineRunToSnapshotExceeded
+      alertname: BuildPlrToSnapshotInProgress
       exp_alerts: []  # No alerts are expected in this scenario


### PR DESCRIPTION
 - rename alert `PipelineRunToSnapshotExceeded` to `BuildPlrToSnapshotInProgress`
 - point runbook URL at `build_plr_to_snapshot_in_progress.md`
 - rename matching Grafana latency / violations panel titles

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [ ] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
