### PR TITLE
chore(STONEINTG-1568): edits to IS latency release creation SLO

### DIFF
--- a/dashboards/grafana-dashboard-konflux-integration-service-slo.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-integration-service-slo.configmap.yaml
@@ -958,7 +958,57 @@ data:
               },
               "unit": "s"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/Saturation/"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 100
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Saturation"
+                  },
+                  {
+                    "id": "custom.thresholdsStyle",
+                    "value": {
+                      "mode": "dashed"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "transparent"
+                        },
+                        {
+                          "color": "text",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 9,
@@ -986,7 +1036,7 @@ data:
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -1000,6 +1050,19 @@ data:
               "legendFormat": "{{source_cluster}}",
               "range": true,
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "editorMode": "code",
+              "expr": "(sum by (source_cluster) (rate(integration_svc_release_latency_seconds_bucket{le=\"+Inf\", source_cluster=~\"$cluster\"}[$__rate_interval])) - sum by (source_cluster) (rate(integration_svc_release_latency_seconds_bucket{le=\"1200.0\", source_cluster=~\"$cluster\"}[$__rate_interval]))) / sum by (source_cluster) (rate(integration_svc_release_latency_seconds_count{source_cluster=~\"$cluster\"}[$__rate_interval])) * 100",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Saturation {{source_cluster}}",
+              "range": true,
+              "refId": "B"
             }
           ],
           "title": "#5 Latency of Release Creation",
@@ -1100,7 +1163,7 @@ data:
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.3",
+          "pluginVersion": "11.6.11",
           "targets": [
             {
               "datasource": {
@@ -1232,5 +1295,5 @@ data:
       "timezone": "browser",
       "title": "Konflux - Integration Service SLO",
       "uid": "cerzhj80cyvi8c",
-      "version": 4
+      "version": 29
     }

--- a/rhobs/alerting/data_plane/prometheus.integration_service_latency_release_creation_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.integration_service_latency_release_creation_alerts.yaml
@@ -19,7 +19,7 @@ spec:
           ) / ignoring(le)
           increase(integration_svc_release_latency_seconds_bucket{le="+Inf"}[5m])
         ) > 0.10
-      for: 10m
+      for: 15m
       labels:
         severity: high
         slo: "false"
@@ -29,7 +29,7 @@ spec:
           Latency of release creation time exceeded
         description: >
           Time from Snapshot marked as passed to release created has been over
-          10s for more than 10% of requests during the last 10 minutes on cluster
+          10s for more than 10% of requests during the last 15 minutes on cluster
           {{ $labels.source_cluster }}
         # alert_team_handle: <!subteam^S05M4AG8CJH>
         alert_routing_key: <!subteam^S05M4AG8CJH>

--- a/test/promql/tests/data_plane/integration_service_latency_release_creation_test.yaml
+++ b/test/promql/tests/data_plane/integration_service_latency_release_creation_test.yaml
@@ -8,18 +8,18 @@ tests:
     input_series:
       # Simulating data from Cluster 1 (crosses the 10% threshold)
       - series: 'integration_svc_release_latency_seconds_bucket{le="10.0", source_cluster="cluster01"}'
-        values: '0+10x15'  # 10 requests took less than 10s
+        values: '0+10x20'  # 10 requests took less than 10s
       - series: 'integration_svc_release_latency_seconds_bucket{le="+Inf", source_cluster="cluster01"}'
-        values: '0+100x15'  # 100 total occurrences in cluster01
+        values: '0+100x20'  # 100 total occurrences in cluster01
 
       # Simulating data from Cluster 2 (does not cross the 10% threshold)
       - series: 'integration_svc_release_latency_seconds_bucket{le="10.0", source_cluster="cluster02"}'
-        values: '0+90x15'  # 90 requests took less than 10s
+        values: '0+90x20'  # 90 requests took less than 10s
       - series: 'integration_svc_release_latency_seconds_bucket{le="+Inf", source_cluster="cluster02"}'
-        values: '0+100x15'  # 100 total occurrences in cluster02
+        values: '0+100x20'  # 100 total occurrences in cluster02
 
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 20m
         alertname: IntegrationServiceLatencyReleaseCreation
         exp_alerts:
           - exp_labels:
@@ -31,7 +31,7 @@ tests:
               summary: Latency of release creation time exceeded
               description: >
                 Time from Snapshot marked as passed to release created has been over
-                10s for more than 10% of requests during the last 10 minutes on cluster
+                10s for more than 10% of requests during the last 15 minutes on cluster
                 cluster01
               # alert_team_handle: <!subteam^S05M4AG8CJH>
               alert_routing_key: <!subteam^S05M4AG8CJH>
@@ -44,18 +44,18 @@ tests:
     input_series:
       # Simulating data from Cluster 1 (crosses the 10% threshold)
       - series: 'integration_svc_release_latency_seconds_bucket{le="10.0", source_cluster="cluster01"}'
-        values: '0+5x15'  # 5 requests took less than 10s
+        values: '0+5x20'  # 5 requests took less than 10s
       - series: 'integration_svc_release_latency_seconds_bucket{le="+Inf", source_cluster="cluster01"}'
-        values: '0+100x15'  # 100 total occurrences in cluster01
+        values: '0+100x20'  # 100 total occurrences in cluster01
 
       # Simulating data from Cluster 2 (also crosses the 10% threshold)
       - series: 'integration_svc_release_latency_seconds_bucket{le="10.0", source_cluster="cluster02"}'
-        values: '0+5x15'  # 5 requests took less than 10s
+        values: '0+5x20'  # 5 requests took less than 10s
       - series: 'integration_svc_release_latency_seconds_bucket{le="+Inf", source_cluster="cluster02"}'
-        values: '0+100x15'  # 100 total occurrences in cluster02
+        values: '0+100x20'  # 100 total occurrences in cluster02
 
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 20m
         alertname: IntegrationServiceLatencyReleaseCreation
         exp_alerts:
           - exp_labels:
@@ -67,7 +67,7 @@ tests:
               summary: Latency of release creation time exceeded
               description: >
                 Time from Snapshot marked as passed to release created has been over
-                10s for more than 10% of requests during the last 10 minutes on cluster
+                10s for more than 10% of requests during the last 15 minutes on cluster
                 cluster01
               # alert_team_handle: <!subteam^S05M4AG8CJH>
               alert_routing_key: <!subteam^S05M4AG8CJH>
@@ -82,7 +82,7 @@ tests:
               summary: Latency of release creation time exceeded
               description: >
                 Time from Snapshot marked as passed to release created has been over
-                10s for more than 10% of requests during the last 10 minutes on cluster
+                10s for more than 10% of requests during the last 15 minutes on cluster
                 cluster02
               # alert_team_handle: <!subteam^S05M4AG8CJH>
               alert_routing_key: <!subteam^S05M4AG8CJH>
@@ -95,17 +95,17 @@ tests:
     input_series:
       # Simulating data from Cluster 1 (does not cross the 10% threshold)
       - series: 'integration_svc_release_latency_seconds_bucket{le="10.0", source_cluster="cluster01"}'
-        values: '0+95x15'  # 95 requests took less than 10s
+        values: '0+95x20'  # 95 requests took less than 10s
       - series: 'integration_svc_release_latency_seconds_bucket{le="+Inf", source_cluster="cluster01"}'
-        values: '0+100x15'  # 100 total occurrences in cluster01
+        values: '0+100x20'  # 100 total occurrences in cluster01
 
       # Simulating data from Cluster 2 (does not cross the 10% threshold)
       - series: 'integration_svc_release_latency_seconds_bucket{le="10.0", source_cluster="cluster02"}'
-        values: '0+95x15'  # 95 requests took less than 10s
+        values: '0+95x20'  # 95 requests took less than 10s
       - series: 'integration_svc_release_latency_seconds_bucket{le="+Inf", source_cluster="cluster02"}'
-        values: '0+100x15'  # 100 total occurrences in cluster02
+        values: '0+100x20'  # 100 total occurrences in cluster02
 
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 20m
         alertname: IntegrationServiceLatencyReleaseCreation
         exp_alerts: []  # No alerts are expected in this scenario


### PR DESCRIPTION
### Description

- amending alerts & tests to measure over 15 mins
- adding saturation measurement to grafana panel

https://redhat.atlassian.net/browse/STONEINTG-1568
https://grafana.app-sre.devshift.net/d/cerzhj80cyvi8c/konflux-integration-service-slo?orgId=1&from=now-7d&to=now&timezone=browser&var-Datasource=P22466E8E7855F1E0&var-service=integration-service-controller-manager&var-check=replicas-available&var-cluster=$__all&refresh=30s

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [y] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [y] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [y] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [y] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [y] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [y] **Pipeline Finished Successfully**

---

### Deployment Notice

- [y] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
