### PR TITLE
Tuning PipelineRunStuckWithIntegrationFinalizer-spre-5951

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pipelinerun_stuck_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipelinerun_stuck_alerts.yaml
@@ -76,21 +76,25 @@ spec:
 
     - alert: PipelineRunStuckWithIntegrationFinalizer
       expr: |
-        kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
-          finalizers=~".*test.appstudio.openshift.io/pipelinerun.*",
-        } > 0
-        and
-        (time() - kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
-          finalizers=~".*test.appstudio.openshift.io/pipelinerun.*",
-        }) > 3600
+        count by (source_cluster) (
+          kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
+            finalizers=~".*test.appstudio.openshift.io/pipelinerun.*",
+          } > 0
+          and
+          (
+            time() - kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{
+              finalizers=~".*test.appstudio.openshift.io/pipelinerun.*",
+            }
+          ) > 1800
+        ) > 10
       for: 10m
       labels:
         severity: warning
         component: integration-service
         slo: "false"
       annotations:
-        summary: "PipelineRun {{ $labels.pipelinerun }} stuck with Integration Service finalizer in namespace {{ $labels.namespace }}"
-        description: "PipelineRun {{ $labels.pipelinerun }} (pipeline: {{ $labels.pipeline }}) in namespace {{ $labels.namespace }} has had deletionTimestamp set for more than 60 minutes and still has finalizers: {{ $labels.finalizers }}."
+        summary: "{{ $value }} PipelineRun(s) on {{ $labels.source_cluster }} stuck with Integration Service finalizer"
+        description: "{{ $value }} PipelineRun(s) on {{ $labels.source_cluster }} have had deletionTimestamp set for more than 30 minutes and still have the Integration Service finalizer."
         alert_routing_key: integration
         team: integration
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/plr_stuck_with_integration_finalizer.md

--- a/rhobs/alerting/data_plane/prometheus.pipelinerun_stuck_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipelinerun_stuck_alerts.yaml
@@ -94,7 +94,7 @@ spec:
         slo: "false"
       annotations:
         summary: "{{ $value }} PipelineRun(s) on {{ $labels.source_cluster }} stuck with Integration Service finalizer"
-        description: "{{ $value }} PipelineRun(s) on {{ $labels.source_cluster }} have had deletionTimestamp set for more than 30 minutes and still have the Integration Service finalizer."
+        description: "{{ $value }} PipelineRun(s) on {{ $labels.source_cluster }} have had deletionTimestamp set for more than 40 minutes and still have the Integration Service finalizer."
         alert_routing_key: integration
         team: integration
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/plr_stuck_with_integration_finalizer.md

--- a/rhobs/alerting/data_plane/prometheus.pipelinerun_stuck_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pipelinerun_stuck_alerts.yaml
@@ -94,7 +94,7 @@ spec:
         slo: "false"
       annotations:
         summary: "{{ $value }} PipelineRun(s) on {{ $labels.source_cluster }} stuck with Integration Service finalizer"
-        description: "{{ $value }} PipelineRun(s) on {{ $labels.source_cluster }} have had deletionTimestamp set for more than 40 minutes and still have the Integration Service finalizer."
+        description: "{{ $value }} PipelineRun(s) on {{ $labels.source_cluster }} have had deletionTimestamp set for more than 30 minutes and still have the Integration Service finalizer."
         alert_routing_key: integration
         team: integration
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/plr_stuck_with_integration_finalizer.md

--- a/test/promql/tests/data_plane/pipelinerun_stuck_test.yaml
+++ b/test/promql/tests/data_plane/pipelinerun_stuck_test.yaml
@@ -121,7 +121,6 @@ tests:
         exp_alerts: []
 
   # Test 4d: PAC finalizer — rotation scenario: PipelineRuns rotate under 40m threshold, no alert
-  # pr-pac-rotate-1 disappears at 30m, pr-pac-rotate-2 appears at 25m — neither was stuck >40m
   - interval: 1m
     input_series:
       - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-pac-rotate-1", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[pipelinesascode.tekton.dev/finalizer]"}
@@ -134,27 +133,55 @@ tests:
         alertname: PipelineRunStuckWithPACFinalizer
         exp_alerts: []
 
-  # Test 5: Integration finalizer — stuck PipelineRun fires alert
+  # Test 5a: Integration finalizer — 1 stuck PipelineRun for >30m, count below threshold, no alert
   - interval: 1m
     input_series:
-      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-integration-stuck", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[test.appstudio.openshift.io/pipelinerun]"}
-        values: '1+0x90'
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-integration-stuck", namespace="tenant-ns", pipeline="build-pipeline", finalizers="[test.appstudio.openshift.io/pipelinerun]", source_cluster="c1"}
+        values: '1+0x50'
 
     alert_rule_test:
-      - eval_time: 80m
+      - eval_time: 45m
+        alertname: PipelineRunStuckWithIntegrationFinalizer
+        exp_alerts: []
+
+  # Test 5b: Integration finalizer — 11 stuck PipelineRuns for >30m, alert fires with count=11
+  - interval: 1m
+    input_series:
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-int-1", namespace="ns", pipeline="build-pipeline", finalizers="[test.appstudio.openshift.io/pipelinerun]", source_cluster="c1"}
+        values: '1+0x50'
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-int-2", namespace="ns", pipeline="build-pipeline", finalizers="[test.appstudio.openshift.io/pipelinerun]", source_cluster="c1"}
+        values: '1+0x50'
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-int-3", namespace="ns", pipeline="build-pipeline", finalizers="[test.appstudio.openshift.io/pipelinerun]", source_cluster="c1"}
+        values: '1+0x50'
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-int-4", namespace="ns", pipeline="build-pipeline", finalizers="[test.appstudio.openshift.io/pipelinerun]", source_cluster="c1"}
+        values: '1+0x50'
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-int-5", namespace="ns", pipeline="build-pipeline", finalizers="[test.appstudio.openshift.io/pipelinerun]", source_cluster="c1"}
+        values: '1+0x50'
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-int-6", namespace="ns", pipeline="build-pipeline", finalizers="[test.appstudio.openshift.io/pipelinerun]", source_cluster="c1"}
+        values: '1+0x50'
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-int-7", namespace="ns", pipeline="build-pipeline", finalizers="[test.appstudio.openshift.io/pipelinerun]", source_cluster="c1"}
+        values: '1+0x50'
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-int-8", namespace="ns", pipeline="build-pipeline", finalizers="[test.appstudio.openshift.io/pipelinerun]", source_cluster="c1"}
+        values: '1+0x50'
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-int-9", namespace="ns", pipeline="build-pipeline", finalizers="[test.appstudio.openshift.io/pipelinerun]", source_cluster="c1"}
+        values: '1+0x50'
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-int-10", namespace="ns", pipeline="build-pipeline", finalizers="[test.appstudio.openshift.io/pipelinerun]", source_cluster="c1"}
+        values: '1+0x50'
+      - series: kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds{pipelinerun="pr-int-11", namespace="ns", pipeline="build-pipeline", finalizers="[test.appstudio.openshift.io/pipelinerun]", source_cluster="c1"}
+        values: '1+0x50'
+
+    alert_rule_test:
+      - eval_time: 45m
         alertname: PipelineRunStuckWithIntegrationFinalizer
         exp_alerts:
           - exp_labels:
               severity: warning
               component: integration-service
               slo: "false"
-              pipelinerun: pr-integration-stuck
-              namespace: tenant-ns
-              pipeline: build-pipeline
-              finalizers: "[test.appstudio.openshift.io/pipelinerun]"
+              source_cluster: c1
             exp_annotations:
-              summary: "PipelineRun pr-integration-stuck stuck with Integration Service finalizer in namespace tenant-ns"
-              description: "PipelineRun pr-integration-stuck (pipeline: build-pipeline) in namespace tenant-ns has had deletionTimestamp set for more than 60 minutes and still has finalizers: [test.appstudio.openshift.io/pipelinerun]."
+              summary: "11 PipelineRun(s) on c1 stuck with Integration Service finalizer"
+              description: "11 PipelineRun(s) on c1 have had deletionTimestamp set for more than 30 minutes and still have the Integration Service finalizer."
               alert_routing_key: integration
               team: integration
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/plr_stuck_with_integration_finalizer.md

--- a/test/promql/tests/data_plane/pipelinerun_stuck_test.yaml
+++ b/test/promql/tests/data_plane/pipelinerun_stuck_test.yaml
@@ -181,7 +181,7 @@ tests:
               source_cluster: c1
             exp_annotations:
               summary: "11 PipelineRun(s) on c1 stuck with Integration Service finalizer"
-              description: "11 PipelineRun(s) on c1 have had deletionTimestamp set for more than 30 minutes and still have the Integration Service finalizer."
+              description: "11 PipelineRun(s) on c1 have had deletionTimestamp set for more than 40 minutes and still have the Integration Service finalizer."
               alert_routing_key: integration
               team: integration
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/plr_stuck_with_integration_finalizer.md

--- a/test/promql/tests/data_plane/pipelinerun_stuck_test.yaml
+++ b/test/promql/tests/data_plane/pipelinerun_stuck_test.yaml
@@ -181,7 +181,7 @@ tests:
               source_cluster: c1
             exp_annotations:
               summary: "11 PipelineRun(s) on c1 stuck with Integration Service finalizer"
-              description: "11 PipelineRun(s) on c1 have had deletionTimestamp set for more than 40 minutes and still have the Integration Service finalizer."
+              description: "11 PipelineRun(s) on c1 have had deletionTimestamp set for more than 30 minutes and still have the Integration Service finalizer."
               alert_routing_key: integration
               team: integration
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/integration-service/plr_stuck_with_integration_finalizer.md


### PR DESCRIPTION
Tuning PipelineRunStuckWithIntegrationFinalizer-spre-5951

https://redhat.atlassian.net/browse/SPRE-5951

## Summary
This PR updates the `PipelineRunStuckWithIntegrationFinalizer` alert to use an aggregated `count by (source_cluster)` model instead of firing on individual `PipelineRun`s.

## Background & Problem
- Previously, the alert fired per individual `PipelineRun`, causing alert fatigue due to isolated edge cases.
- Increasing the timeout from 30m to 60m did not resolve the noise issue.

## Key Changes
- **Count-Based Threshold:** The alert now triggers only when **> 10** `PipelineRun`s are stuck simultaneously in a given cluster (`source_cluster`).
- **Timeout Reversion:** Reverted the stuck duration threshold back to **1800s (30m)** to catch systemic cluster-wide issues faster.
- **Annotations Updated:** Refactored alert annotations to reflect cluster-level aggregated counts (`{{ $value }}` and `{{ $labels.source_cluster }}`).
- **Tests Updated:** Updated `pipelinerun_stuck_test.yaml` to validate the new aggregation threshold logic.

## Verification
- [x] Verified logic and historical trend in Grafana dashboard (`Time series` view).
- [x] Successfully ran unit tests via `promtool test rules pipelinerun_stuck_test.yaml`.
- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
