### PR TITLE
fix(PVO11Y-5400): Fix kaexporter bootstrap loop and gap-fill improvements for high-volume tenants

### DIFF
--- a/exporters/kaexporter/DESIGN.md
+++ b/exporters/kaexporter/DESIGN.md
@@ -67,7 +67,7 @@ Steady State Settings:
 **How It Works:**
 1. During cold start, if a namespace hits the 30K limit, mark it as "truncated" and record the oldest fetched timestamp
 2. Schedule a background gap-fill attempt with a narrower time window (query older data before the truncation point)
-3. Limit gap-fill to **5 attempts per namespace** to prevent infinite retries (total coverage up to 150K items)
+3. Limit gap-fill to **5 consecutive failures/stalls per namespace** to prevent infinite retries on persistently truncated namespaces. Successful gap-fills reset the counter, allowing further attempts
 4. Track gap-fill attempts and exhaustion via Prometheus counters
 
 **Trade-offs:**
@@ -89,7 +89,7 @@ Steady State Settings:
 type BootstrapState struct {
     Bootstrapped      bool      // Has 30-day window been populated?
     TruncatedAt       string    // Oldest timestamp if truncated
-    GapFillAttempts   int       // Number of gap-fill retries (max 5)
+    GapFillAttempts   int       // Consecutive gap-fill failures/stalls (max 5, resets on progress)
 }
 
 map[namespace]*BootstrapState
@@ -220,14 +220,14 @@ Typical deployment (500 label combinations):
 **Limitation:** Extremely busy namespaces with >30,000 PLRs in 30 days will be truncated during cold start.
 
 **Mitigations:**
-- Gap-fill mechanism retries with narrower time windows (up to 5 attempts = 150K total coverage)
+- Gap-fill mechanism retries with narrower time windows until the full 30-day range is covered
 - Truncation metrics track occurrences: `kaexporter_truncations_total{resource="pipelineruns"}`
 - Per-namespace bootstrap state prevents repeated failures
 
 **When This Happens:**
 - Typical namespace: ~100-500 PLRs/day → no issue
 - Busy namespace: 500-1,000 PLRs/day → may hit 30K limit over 30 days
-- Very busy namespace: >1,000 PLRs/day → gap-fill may also truncate (uses additional 5 attempts)
+- Very busy namespace: >1,000 PLRs/day → gap-fill runs across multiple cycles until complete (stops only after 5 consecutive failures)
 
 ---
 

--- a/exporters/kaexporter/collector.go
+++ b/exporters/kaexporter/collector.go
@@ -538,11 +538,11 @@ func (e *KAExporter) fillNamespaceGap(ctx context.Context, namespace string) {
 	}
 	gapSince := time.Now().UTC().Add(-coldStartWindowHours * time.Hour).Format(time.RFC3339)
 	gapUntil := state.OldestSeenCreationTS
-	attemptNum := state.GapAttempts + 1
+	errorCount := state.GapAttempts
 	e.mu.RUnlock()
 
-	log.Printf("namespace %q: gap-fill attempt %d/%d (window: %s to %s)",
-		namespace, attemptNum, maxGapFillAttempts, gapSince, gapUntil)
+	log.Printf("namespace %q: gap-fill (errors: %d/%d, window: %s to %s)",
+		namespace, errorCount, maxGapFillAttempts, gapSince, gapUntil)
 
 	buildCnt, testCnt, wasTrunc, oldestTS, err := e.collectNamespace(
 		ctx, namespace, gapSince, gapUntil, coldStartMaxItems,
@@ -563,17 +563,15 @@ func (e *KAExporter) fillNamespaceGap(ctx context.Context, namespace string) {
 		return
 	}
 
-	if !wasTrunc {
-		// Gap filled successfully!
-		updatedState.Bootstrapped = true
-		updatedState.OldestSeenCreationTS = ""
-		updatedState.GapAttempts = 0
+	switch updateGapFillState(updatedState, wasTrunc, oldestTS) {
+	case "completed":
 		log.Printf("namespace %q: bootstrap COMPLETE (%d builds, %d tests fetched in gap-fill)",
 			namespace, buildCnt, testCnt)
-	} else {
-		updatedState.OldestSeenCreationTS = oldestTS
-		updatedState.GapAttempts++
-		log.Printf("namespace %q: gap-fill incomplete (%d builds, %d tests, still truncated, oldest now %s)",
-			namespace, buildCnt, testCnt, oldestTS)
+	case "progressing":
+		log.Printf("namespace %q: gap-fill progressing (%d builds, %d tests, oldest now %s)",
+			namespace, buildCnt, testCnt, updatedState.OldestSeenCreationTS)
+	case "stalled":
+		log.Printf("namespace %q: gap-fill stalled (%d builds, %d tests, oldest unchanged %s, errors %d/%d)",
+			namespace, buildCnt, testCnt, oldestTS, updatedState.GapAttempts, maxGapFillAttempts)
 	}
 }

--- a/exporters/kaexporter/collector.go
+++ b/exporters/kaexporter/collector.go
@@ -158,37 +158,45 @@ func (e *KAExporter) collectMetrics(ctx context.Context) (*releaseIndex, error) 
 		concurrency = coldStartMaxConcurrent
 	}
 
-	// Count how many namespaces need bootstrap (for logging)
+	// Count namespaces by bootstrap phase:
+	// - needsFirstFetch: no state yet, requires full 30-day initial fetch
+	// - gapFilling: already truncated, gap-fill handles history, main collection uses steady-state
 	e.mu.RLock()
-	var needsBootstrap int
+	var needsFirstFetch, gapFilling int
 	for _, ns := range namespaces {
 		state := e.bootstrapStates[ns]
 		if state == nil || !state.Bootstrapped {
-			needsBootstrap++
+			if state != nil && state.OldestSeenCreationTS != "" {
+				gapFilling++
+			} else {
+				needsFirstFetch++
+			}
 		}
 	}
 	e.mu.RUnlock()
+	needsBootstrap := needsFirstFetch + gapFilling
 
 	if e.coldStart {
 		log.Printf("COLD START: bootstrapping 30-day rolling store (%d tenant namespace(s), %d need bootstrap, concurrency=%d, releases=30d)...",
 			len(namespaces), needsBootstrap, concurrency)
-	} else if needsBootstrap > 0 {
-		log.Printf("Collecting metrics from KubeArchive (%d tenant namespace(s), %d need 30d bootstrap, concurrency=%d, releases=30d)...",
-			len(namespaces), needsBootstrap, concurrency)
+	} else if needsFirstFetch > 0 {
+		log.Printf("Collecting metrics from KubeArchive (%d tenant namespace(s), %d need 30d bootstrap, %d gap-filling, concurrency=%d, releases=30d)...",
+			len(namespaces), needsFirstFetch, gapFilling, concurrency)
+	} else if gapFilling > 0 {
+		log.Printf("Collecting metrics from KubeArchive (%d tenant namespace(s), %d gap-filling, concurrency=%d, releases=%dh)...",
+			len(namespaces), gapFilling, concurrency, e.queryWindowHours)
 	} else {
 		log.Printf("Collecting metrics from KubeArchive (%d tenant namespace(s), query_window=%dh, concurrency=%d, releases=%dh)...",
 			len(namespaces), e.queryWindowHours, concurrency, e.queryWindowHours)
 	}
 
-	// Per-namespace window selection will happen inside goroutines based on bootstrappedNamespaces map
-
-	// For release fetching, use 30d window if ANY namespace still needs bootstrap.
-	// Releases may live in different namespaces (managed release namespaces), and the
-	// release catalog is global for metric collection and retry analysis across all namespaces.
-	// Continue querying 30 days of releases until ALL namespaces are fully bootstrapped.
+	// For release fetching, use 30d window only when namespaces still need their
+	// initial 30-day fetch. Namespaces that are already truncated (gap-filling)
+	// collect fresh data in steady-state; their historical releases were captured
+	// on the first fetch and gap-fill handles the rest.
 	releaseWindowHours := e.queryWindowHours
 	releaseMaxItems := kaMaxItems
-	if e.coldStart || needsBootstrap > 0 {
+	if e.coldStart || needsFirstFetch > 0 {
 		releaseWindowHours = coldStartWindowHours
 		releaseMaxItems = coldStartMaxItems
 	}
@@ -219,10 +227,14 @@ func (e *KAExporter) collectMetrics(ctx context.Context) (*releaseIndex, error) 
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			// Per-namespace bootstrap check: use 30-day window if not yet bootstrapped
+			// Per-namespace bootstrap check: use 30-day window only on the
+			// very first attempt (no state yet). Once truncated, switch to
+			// steady-state window for fresh data and let gap-fill handle
+			// the historical backfill independently.
 			e.mu.RLock()
 			state := e.bootstrapStates[ns]
 			bootstrapped := state != nil && state.Bootstrapped
+			alreadyTruncated := state != nil && state.OldestSeenCreationTS != ""
 			e.mu.RUnlock()
 
 			var windowHours int
@@ -230,7 +242,8 @@ func (e *KAExporter) collectMetrics(ctx context.Context) (*releaseIndex, error) 
 			var nsCtx context.Context
 			var nsCancel context.CancelFunc
 
-			if !bootstrapped {
+			if !bootstrapped && !alreadyTruncated {
+				// First attempt: full 30-day bootstrap
 				windowHours = coldStartWindowHours // 720h (30 days)
 				maxItems = coldStartMaxItems       // 30,000
 				// Give each non-bootstrapped namespace its own independent 30-minute timeout.
@@ -241,34 +254,31 @@ func (e *KAExporter) collectMetrics(ctx context.Context) (*releaseIndex, error) 
 				stop := context.AfterFunc(ctx, nsCancel) // Cancel nsCtx when ctx is cancelled
 				defer stop()
 			} else {
+				// Bootstrapped or already truncated: use steady-state window.
+				// Truncated namespaces get fresh data here; gap-fill handles the
+				// historical range [30d ago ... OldestSeenCreationTS] separately.
 				windowHours = e.queryWindowHours // 36h (steady state with safety margin)
 				maxItems = kaMaxItems
-				// Bootstrapped namespaces share the parent context (global timeout)
+				// Share the parent context (global timeout)
 				nsCtx = ctx
 			}
 
 			since := time.Now().UTC().Add(-time.Duration(windowHours) * time.Hour).Format(time.RFC3339)
 			b, t, wasTrunc, oldestTS, err := e.collectNamespace(nsCtx, ns, since, "", maxItems)
 
-			// Track bootstrap state
-			if err == nil {
+			// Track bootstrap state - only on the first-fetch path.
+			// Steady-state cycles (alreadyTruncated=true) just collect fresh
+			// data; gap-fill handles the historical backfill and state transitions.
+			if err == nil && !bootstrapped && !alreadyTruncated {
 				e.mu.Lock()
 				if e.bootstrapStates[ns] == nil {
 					e.bootstrapStates[ns] = &nsBootstrapState{}
 				}
-				if !bootstrapped {
-					if !wasTrunc {
-						// Bootstrap complete: full 30-day fetch succeeded
-						e.bootstrapStates[ns].Bootstrapped = true
-						e.bootstrapStates[ns].OldestSeenCreationTS = ""
-						e.bootstrapStates[ns].GapAttempts = 0
-						log.Printf("namespace %q: 30-day bootstrap complete (%d builds, %d tests)", ns, b, t)
-					} else {
-						// Bootstrap truncated: track gap for later filling
-						e.bootstrapStates[ns].OldestSeenCreationTS = oldestTS
-						log.Printf("namespace %q: 30-day bootstrap TRUNCATED (%d builds, %d tests, oldest=%s)",
-							ns, b, t, oldestTS)
-					}
+				if completed := updateBootstrapState(e.bootstrapStates[ns], wasTrunc, oldestTS); completed {
+					log.Printf("namespace %q: 30-day bootstrap complete (%d builds, %d tests)", ns, b, t)
+				} else if e.bootstrapStates[ns].OldestSeenCreationTS != "" {
+					log.Printf("namespace %q: 30-day bootstrap TRUNCATED (%d builds, %d tests, oldest=%s)",
+						ns, b, t, e.bootstrapStates[ns].OldestSeenCreationTS)
 				}
 				e.mu.Unlock()
 			}

--- a/exporters/kaexporter/exporter.go
+++ b/exporters/kaexporter/exporter.go
@@ -110,6 +110,24 @@ type nsBootstrapState struct {
 	GapAttempts          int    // number of gap-fill attempts (prevent infinite retry)
 }
 
+// updateBootstrapState applies the state transition after a collection cycle.
+// Returns true if the namespace just completed bootstrap.
+func updateBootstrapState(state *nsBootstrapState, wasTrunc bool, oldestTS string) bool {
+	if state.Bootstrapped {
+		return false
+	}
+	if !wasTrunc {
+		state.Bootstrapped = true
+		state.OldestSeenCreationTS = ""
+		state.GapAttempts = 0
+		return true
+	}
+	if state.OldestSeenCreationTS == "" {
+		state.OldestSeenCreationTS = oldestTS
+	}
+	return false
+}
+
 // ── Retry configuration ───────────────────────────────────────────────────────
 
 // retryConfig holds exponential backoff parameters for KubeArchive API retries

--- a/exporters/kaexporter/exporter.go
+++ b/exporters/kaexporter/exporter.go
@@ -96,8 +96,8 @@ const (
 	defaultMaxRetryDelay     = 5000 // milliseconds
 	retryBackoffMultiplier   = 2.0
 
-	// maxGapFillAttempts limits gap-fill retries for truncated namespaces.
-	// With coldStartMaxItems=30,000, this allows up to 150,000 PLRs to be covered across 5 attempts.
+	// maxGapFillAttempts limits consecutive gap-fill failures or stalls.
+	// Resets to 0 when gap-fill makes progress (oldest timestamp moves backward).
 	maxGapFillAttempts = 5
 )
 
@@ -107,7 +107,7 @@ const (
 type nsBootstrapState struct {
 	Bootstrapped         bool   // true when namespace has complete 30-day data
 	OldestSeenCreationTS string // RFC3339 timestamp of oldest item seen (empty = no gap)
-	GapAttempts          int    // number of gap-fill attempts (prevent infinite retry)
+	GapAttempts          int    // consecutive gap-fill errors or stalls (resets on progress)
 }
 
 // updateBootstrapState applies the state transition after a collection cycle.
@@ -126,6 +126,32 @@ func updateBootstrapState(state *nsBootstrapState, wasTrunc bool, oldestTS strin
 		state.OldestSeenCreationTS = oldestTS
 	}
 	return false
+}
+
+// updateGapFillState applies state transitions after a gap-fill fetch.
+// Returns "completed" if bootstrap finished, "progressing" if the cursor
+// moved backward, or "stalled" if no progress was made.
+func updateGapFillState(state *nsBootstrapState, wasTrunc bool, oldestTS string) string {
+	if !wasTrunc {
+		state.Bootstrapped = true
+		state.OldestSeenCreationTS = ""
+		state.GapAttempts = 0
+		return "completed"
+	}
+	if isTimeBefore(oldestTS, state.OldestSeenCreationTS) {
+		state.OldestSeenCreationTS = oldestTS
+		state.GapAttempts = 0
+		return "progressing"
+	}
+	state.GapAttempts++
+	return "stalled"
+}
+
+// isTimeBefore parses two RFC3339 timestamps and returns true if a is before b.
+func isTimeBefore(a, b string) bool {
+	tA, _ := time.Parse(time.RFC3339, a)
+	tB, _ := time.Parse(time.RFC3339, b)
+	return tA.Before(tB)
 }
 
 // ── Retry configuration ───────────────────────────────────────────────────────

--- a/exporters/kaexporter/metrics_test.go
+++ b/exporters/kaexporter/metrics_test.go
@@ -548,6 +548,80 @@ func TestStoreCleanup(t *testing.T) {
 	})
 }
 
+// ── Bootstrap State Transition Tests ─────────────────────────────────────────
+
+func TestUpdateBootstrapState(t *testing.T) {
+	t.Run("successful non-truncated fetch marks bootstrapped", func(t *testing.T) {
+		state := &nsBootstrapState{}
+		completed := updateBootstrapState(state, false, "")
+		if !completed {
+			t.Error("expected completed=true")
+		}
+		if !state.Bootstrapped {
+			t.Error("expected Bootstrapped=true")
+		}
+		if state.OldestSeenCreationTS != "" {
+			t.Errorf("expected empty OldestSeenCreationTS, got %q", state.OldestSeenCreationTS)
+		}
+	})
+
+	t.Run("first truncation records oldest timestamp", func(t *testing.T) {
+		state := &nsBootstrapState{}
+		completed := updateBootstrapState(state, true, "2026-07-29T00:44:46Z")
+		if completed {
+			t.Error("expected completed=false")
+		}
+		if state.Bootstrapped {
+			t.Error("expected Bootstrapped=false")
+		}
+		if state.OldestSeenCreationTS != "2026-07-29T00:44:46Z" {
+			t.Errorf("expected OldestSeenCreationTS=2026-07-29T00:44:46Z, got %q", state.OldestSeenCreationTS)
+		}
+	})
+
+	t.Run("subsequent truncation does not overwrite oldest timestamp", func(t *testing.T) {
+		state := &nsBootstrapState{OldestSeenCreationTS: "2026-07-25T10:00:00Z"}
+		completed := updateBootstrapState(state, true, "2026-07-29T00:50:25Z")
+		if completed {
+			t.Error("expected completed=false")
+		}
+		if state.OldestSeenCreationTS != "2026-07-25T10:00:00Z" {
+			t.Errorf("expected original OldestSeenCreationTS preserved, got %q", state.OldestSeenCreationTS)
+		}
+	})
+
+	t.Run("already bootstrapped is a no-op", func(t *testing.T) {
+		state := &nsBootstrapState{Bootstrapped: true}
+		completed := updateBootstrapState(state, false, "")
+		if completed {
+			t.Error("expected completed=false for already-bootstrapped")
+		}
+		if !state.Bootstrapped {
+			t.Error("Bootstrapped should remain true")
+		}
+	})
+
+	t.Run("successful fetch after truncation marks bootstrapped and clears oldest", func(t *testing.T) {
+		state := &nsBootstrapState{
+			OldestSeenCreationTS: "2026-07-25T10:00:00Z",
+			GapAttempts:          3,
+		}
+		completed := updateBootstrapState(state, false, "")
+		if !completed {
+			t.Error("expected completed=true")
+		}
+		if !state.Bootstrapped {
+			t.Error("expected Bootstrapped=true")
+		}
+		if state.OldestSeenCreationTS != "" {
+			t.Errorf("expected OldestSeenCreationTS cleared, got %q", state.OldestSeenCreationTS)
+		}
+		if state.GapAttempts != 0 {
+			t.Errorf("expected GapAttempts reset to 0, got %d", state.GapAttempts)
+		}
+	})
+}
+
 // ── Test Helpers ──────────────────────────────────────────────────────────────
 
 func assertEqual[T comparable](t *testing.T, name string, got, want T) {

--- a/exporters/kaexporter/metrics_test.go
+++ b/exporters/kaexporter/metrics_test.go
@@ -601,6 +601,17 @@ func TestUpdateBootstrapState(t *testing.T) {
 		}
 	})
 
+	t.Run("already bootstrapped ignores truncation", func(t *testing.T) {
+		state := &nsBootstrapState{Bootstrapped: true}
+		completed := updateBootstrapState(state, true, "2026-07-29T00:00:00Z")
+		if completed {
+			t.Error("expected completed=false")
+		}
+		if state.OldestSeenCreationTS != "" {
+			t.Errorf("should not set OldestSeenCreationTS, got %q", state.OldestSeenCreationTS)
+		}
+	})
+
 	t.Run("successful fetch after truncation marks bootstrapped and clears oldest", func(t *testing.T) {
 		state := &nsBootstrapState{
 			OldestSeenCreationTS: "2026-07-25T10:00:00Z",
@@ -618,6 +629,92 @@ func TestUpdateBootstrapState(t *testing.T) {
 		}
 		if state.GapAttempts != 0 {
 			t.Errorf("expected GapAttempts reset to 0, got %d", state.GapAttempts)
+		}
+	})
+}
+
+// ── Gap-Fill State Transition Tests ──────────────────────────────────────────
+
+func TestUpdateGapFillState(t *testing.T) {
+	t.Run("non-truncated completes bootstrap", func(t *testing.T) {
+		state := &nsBootstrapState{
+			OldestSeenCreationTS: "2026-07-20T00:00:00Z",
+			GapAttempts:          2,
+		}
+		result := updateGapFillState(state, false, "")
+		if result != "completed" {
+			t.Errorf("expected completed, got %s", result)
+		}
+		if !state.Bootstrapped {
+			t.Error("expected Bootstrapped=true")
+		}
+		if state.OldestSeenCreationTS != "" {
+			t.Errorf("expected OldestSeenCreationTS cleared, got %q", state.OldestSeenCreationTS)
+		}
+		if state.GapAttempts != 0 {
+			t.Errorf("expected GapAttempts=0, got %d", state.GapAttempts)
+		}
+	})
+
+	t.Run("truncated with progress resets error counter", func(t *testing.T) {
+		state := &nsBootstrapState{
+			OldestSeenCreationTS: "2026-07-20T00:00:00Z",
+			GapAttempts:          3,
+		}
+		result := updateGapFillState(state, true, "2026-07-15T00:00:00Z")
+		if result != "progressing" {
+			t.Errorf("expected progressing, got %s", result)
+		}
+		if state.OldestSeenCreationTS != "2026-07-15T00:00:00Z" {
+			t.Errorf("expected oldest moved to Jul 15, got %q", state.OldestSeenCreationTS)
+		}
+		if state.GapAttempts != 0 {
+			t.Errorf("expected GapAttempts reset to 0, got %d", state.GapAttempts)
+		}
+	})
+
+	t.Run("truncated without progress increments error counter", func(t *testing.T) {
+		state := &nsBootstrapState{
+			OldestSeenCreationTS: "2026-07-20T00:00:00Z",
+			GapAttempts:          2,
+		}
+		result := updateGapFillState(state, true, "2026-07-20T00:00:00Z")
+		if result != "stalled" {
+			t.Errorf("expected stalled, got %s", result)
+		}
+		if state.OldestSeenCreationTS != "2026-07-20T00:00:00Z" {
+			t.Errorf("expected oldest unchanged, got %q", state.OldestSeenCreationTS)
+		}
+		if state.GapAttempts != 3 {
+			t.Errorf("expected GapAttempts=3, got %d", state.GapAttempts)
+		}
+	})
+
+	t.Run("newer oldest timestamp counts as stall", func(t *testing.T) {
+		state := &nsBootstrapState{
+			OldestSeenCreationTS: "2026-07-15T00:00:00Z",
+			GapAttempts:          0,
+		}
+		result := updateGapFillState(state, true, "2026-07-20T00:00:00Z")
+		if result != "stalled" {
+			t.Errorf("expected stalled, got %s", result)
+		}
+		if state.GapAttempts != 1 {
+			t.Errorf("expected GapAttempts=1, got %d", state.GapAttempts)
+		}
+	})
+
+	t.Run("progress after errors resets counter", func(t *testing.T) {
+		state := &nsBootstrapState{
+			OldestSeenCreationTS: "2026-07-20T00:00:00Z",
+			GapAttempts:          4,
+		}
+		result := updateGapFillState(state, true, "2026-07-10T00:00:00Z")
+		if result != "progressing" {
+			t.Errorf("expected progressing, got %s", result)
+		}
+		if state.GapAttempts != 0 {
+			t.Errorf("expected GapAttempts reset to 0 after progress, got %d", state.GapAttempts)
 		}
 	})
 }


### PR DESCRIPTION
### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

Jira: [PVO11Y-5400](https://redhat.atlassian.net/browse/PVO11Y-5400)

High-volume tenants tend to get stuck in permanent truncated state resulting in repetetive coldstart behavior for them, unable to bootstrap correctly; meaning no 30d are being fetched at all

#### 1. Main collection overwrites OldestSeenCreationTS every cycle
After the initial cold-start fetch hits the 30k item cap, every subsequent cycle re-fetches 30k PLRs with the 30-day window (covering only ~5 days for high-volume tenants) and overwrites OldestSeenCreationTS - preventing gap-fill from ever shrinking the gap.
**Fix:** After first truncation, main collection switches to steady-state window (36h/1500 items). OldestSeenCreationTS is set once; only gap-fill adjusts it backward.

#### 2. Releases fetched with 30d window while any namespace needs bootstrap
Release fetching uses the 30-day/30k window as long as any namespace is not fully bootstrapped, wasting ~11s per cycle re-fetching already-captured releases.
**Fix:** Only use the 30-day release window when namespaces still need their initial cold-start fetch (needsFirstFetch > 0). Gap-filling namespaces no longer force cluster-wide 30d release fetches.

#### 3. Gap-fill retry counter incremented on successful-but-truncated fetches
GapAttempts was incremented on every gap-fill cycle, including ones making steady progress (oldest timestamp moving backward). After 5 attempts, gap-fill stopped permanently.
**Fix:** Only count errors and stalls (no progress) toward the limit. Progress resets the counter. The 5-attempt cap now gates consecutive failures, not total cycles. 


**Verification**
Running locally against ansible-tenant, rh-acs-tenant and our tenant to check usual behavior is not disrupted

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [X] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [X] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [X] **Pipeline Finished Successfully**

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.


[PVO11Y-5400]: https://redhat.atlassian.net/browse/PVO11Y-5400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ