### PR TITLE
feat(KFLUXVNGD-1118): add normalized_uri repository filter to artifact registry proxy dashboards

### DIFF
--- a/dashboards/grafana-dashboard-artifact-registry-proxy-cache-performance.configmap.yaml
+++ b/dashboards/grafana-dashboard-artifact-registry-proxy-cache-performance.configmap.yaml
@@ -119,7 +119,7 @@ data:
                 "uid": "${nginx_datasource}"
               },
               "editorMode": "code",
-              "expr": "(sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", cache_status=\"HIT\"}[$interval])) / sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$interval]))) * 100",
+              "expr": "(sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", cache_status=\"HIT\"}[$interval])) / sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$interval]))) * 100",
               "legendFormat": "Cache Hit Ratio",
               "range": true,
               "refId": "A"
@@ -184,7 +184,7 @@ data:
                 "uid": "${nginx_datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", cache_status=\"HIT\"}[$interval]))",
+              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", cache_status=\"HIT\"}[$interval]))",
               "legendFormat": "Cache Hits/sec",
               "range": true,
               "refId": "A"
@@ -249,7 +249,7 @@ data:
                 "uid": "${nginx_datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", cache_status=\"MISS\"}[$interval]))",
+              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", cache_status=\"MISS\"}[$interval]))",
               "legendFormat": "Cache Misses/sec",
               "range": true,
               "refId": "A"
@@ -325,7 +325,7 @@ data:
                 "uid": "${nginx_datasource}"
               },
               "editorMode": "code",
-              "expr": "(sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", cache_status=\"HIT\"}[$interval])) / sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$interval]))) * 100",
+              "expr": "(sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", cache_status=\"HIT\"}[$interval])) / sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$interval]))) * 100",
               "legendFormat": "Upstream Load Reduction",
               "range": true,
               "refId": "A"
@@ -483,7 +483,7 @@ data:
                 "uid": "${nginx_datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$interval])) by (cache_status)",
+              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$interval])) by (cache_status)",
               "legendFormat": "{{cache_status}}",
               "range": true,
               "refId": "A"
@@ -614,7 +614,7 @@ data:
                 "uid": "${nginx_datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$__range])) by (cache_status)",
+              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$__range])) by (cache_status)",
               "instant": true,
               "legendFormat": "{{cache_status}}",
               "refId": "A"
@@ -710,7 +710,7 @@ data:
                 "uid": "${nginx_datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", cache_status=\"BYPASS\"}[$interval]))",
+              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", cache_status=\"BYPASS\"}[$interval]))",
               "legendFormat": "Bypass Requests",
               "range": true,
               "refId": "A"
@@ -806,7 +806,7 @@ data:
                 "uid": "${nginx_datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", cache_status=\"EXPIRED\"}[$interval]))",
+              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", cache_status=\"EXPIRED\"}[$interval]))",
               "legendFormat": "Expired Cache Entries",
               "range": true,
               "refId": "A"
@@ -902,7 +902,7 @@ data:
                 "uid": "${nginx_datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", cache_status=~\"STALE|UPDATING|REVALIDATED\"}[$interval])) by (cache_status)",
+              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", cache_status=~\"STALE|UPDATING|REVALIDATED\"}[$interval])) by (cache_status)",
               "legendFormat": "{{cache_status}}",
               "range": true,
               "refId": "A"
@@ -1001,7 +1001,7 @@ data:
                 "uid": "${nginx_datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", cache_status=\"MISS\"}[$interval]))",
+              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", cache_status=\"MISS\"}[$interval]))",
               "legendFormat": "Upstream Requests (MISS only)",
               "range": true,
               "refId": "A"
@@ -1121,6 +1121,32 @@ data:
             "options": [],
             "query": {
               "query": "label_values(nginx_up{namespace=\"caching\"}, source_cluster)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {
+              "text": "All",
+              "value": [
+                "$__all"
+              ]
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${nginx_datasource}"
+            },
+            "definition": "label_values(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}, normalized_uri)",
+            "includeAll": true,
+            "label": "Repository",
+            "multi": true,
+            "name": "normalized_uri",
+            "options": [],
+            "query": {
+              "query": "label_values(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}, normalized_uri)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 2,

--- a/dashboards/grafana-dashboard-artifact-registry-proxy.configmap.yaml
+++ b/dashboards/grafana-dashboard-artifact-registry-proxy.configmap.yaml
@@ -246,7 +246,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$interval]))",
+              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$interval]))",
               "refId": "A"
             }
           ],
@@ -377,7 +377,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "(sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", status=~\"[45]..\"}[$interval])) or vector(0)) / (sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$interval])) or vector(1)) * 100",
+              "expr": "(sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", status=~\"[45]..\"}[$interval])) or vector(0)) / (sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$interval])) or vector(1)) * 100",
               "refId": "A"
             }
           ],
@@ -467,7 +467,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$interval])) by (source_cluster, pod)",
+              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$interval])) by (source_cluster, pod)",
               "legendFormat": "{{source_cluster}} - {{pod}}",
               "refId": "A"
             }
@@ -577,7 +577,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$interval])) by (source_cluster)",
+              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$interval])) by (source_cluster)",
               "legendFormat": "{{source_cluster}} (total)",
               "refId": "A"
             },
@@ -586,7 +586,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$interval])) by (source_cluster, pod)",
+              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$interval])) by (source_cluster, pod)",
               "legendFormat": "{{source_cluster}} - {{pod}}",
               "refId": "B"
             }
@@ -734,7 +734,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", status=~\"2..\"}[1h])) or vector(0)",
+              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", status=~\"2..\"}[1h])) or vector(0)",
               "legendFormat": "2xx Success",
               "refId": "A",
               "interval": "1h"
@@ -744,7 +744,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", status=~\"3..\"}[1h])) or vector(0)",
+              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", status=~\"3..\"}[1h])) or vector(0)",
               "legendFormat": "3xx Redirect",
               "refId": "B",
               "interval": "1h"
@@ -754,7 +754,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", status=~\"4..\"}[1h])) or vector(0)",
+              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", status=~\"4..\"}[1h])) or vector(0)",
               "legendFormat": "4xx Client Error",
               "refId": "C",
               "interval": "1h"
@@ -764,7 +764,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", status=~\"5..\"}[1h])) or vector(0)",
+              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", status=~\"5..\"}[1h])) or vector(0)",
               "legendFormat": "5xx Server Error",
               "refId": "D",
               "interval": "1h"
@@ -893,7 +893,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", status=~\"2..\"}[$__range])) or vector(0)",
+              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", status=~\"2..\"}[$__range])) or vector(0)",
               "instant": true,
               "legendFormat": "2xx Success",
               "refId": "A"
@@ -903,7 +903,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", status=~\"3..\"}[$__range])) or vector(0)",
+              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", status=~\"3..\"}[$__range])) or vector(0)",
               "instant": true,
               "legendFormat": "3xx Redirect",
               "refId": "B"
@@ -913,7 +913,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", status=~\"4..\"}[$__range])) or vector(0)",
+              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", status=~\"4..\"}[$__range])) or vector(0)",
               "instant": true,
               "legendFormat": "4xx Client Error",
               "refId": "C"
@@ -923,7 +923,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", status=~\"5..\"}[$__range])) or vector(0)",
+              "expr": "sum(increase(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", status=~\"5..\"}[$__range])) or vector(0)",
               "instant": true,
               "legendFormat": "5xx Server Error",
               "refId": "D"
@@ -1015,7 +1015,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", status=~\"2..\"}[$interval])) by (source_cluster, pod)",
+              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", status=~\"2..\"}[$interval])) by (source_cluster, pod)",
               "legendFormat": "{{source_cluster}} - {{pod}}",
               "refId": "A"
             }
@@ -1137,7 +1137,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", status=~\"4..\"}[$interval])) by (source_cluster, pod)",
+              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", status=~\"4..\"}[$interval])) by (source_cluster, pod)",
               "legendFormat": "{{source_cluster}} - {{pod}} 4xx",
               "refId": "A"
             },
@@ -1146,7 +1146,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", status=~\"5..\"}[$interval])) by (source_cluster, pod)",
+              "expr": "sum(rate(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\", status=~\"5..\"}[$interval])) by (source_cluster, pod)",
               "legendFormat": "{{source_cluster}} - {{pod}} 5xx",
               "refId": "B"
             }
@@ -1237,7 +1237,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$interval])) by (status, source_cluster, pod, le))",
+              "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$interval])) by (status, source_cluster, pod, le))",
               "legendFormat": "{{status}} - {{source_cluster}} - {{pod}} (p95)",
               "refId": "A"
             }
@@ -1328,7 +1328,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$interval])) by (source_cluster, pod, le))",
+              "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$interval])) by (source_cluster, pod, le))",
               "legendFormat": "{{source_cluster}} - {{pod}} p50",
               "refId": "A"
             },
@@ -1337,7 +1337,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$interval])) by (source_cluster, pod, le))",
+              "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$interval])) by (source_cluster, pod, le))",
               "legendFormat": "{{source_cluster}} - {{pod}} p95",
               "refId": "B"
             },
@@ -1346,7 +1346,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$interval])) by (source_cluster, pod, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$interval])) by (source_cluster, pod, le))",
               "legendFormat": "{{source_cluster}} - {{pod}} p99",
               "refId": "C"
             }
@@ -1437,7 +1437,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "histogram_quantile(0.50, sum(rate(http_upstream_response_time_seconds_bucket{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$interval])) by (source_cluster, pod, le))",
+              "expr": "histogram_quantile(0.50, sum(rate(http_upstream_response_time_seconds_bucket{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$interval])) by (source_cluster, pod, le))",
               "legendFormat": "{{source_cluster}} - {{pod}} Upstream p50",
               "refId": "A"
             },
@@ -1446,7 +1446,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "histogram_quantile(0.95, sum(rate(http_upstream_response_time_seconds_bucket{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$interval])) by (source_cluster, pod, le))",
+              "expr": "histogram_quantile(0.95, sum(rate(http_upstream_response_time_seconds_bucket{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$interval])) by (source_cluster, pod, le))",
               "legendFormat": "{{source_cluster}} - {{pod}} Upstream p95",
               "refId": "B"
             },
@@ -1455,7 +1455,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "histogram_quantile(0.99, sum(rate(http_upstream_response_time_seconds_bucket{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}[$interval])) by (source_cluster, pod, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(http_upstream_response_time_seconds_bucket{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\", normalized_uri=~\"$normalized_uri\"}[$interval])) by (source_cluster, pod, le))",
               "legendFormat": "{{source_cluster}} - {{pod}} Upstream p99",
               "refId": "C"
             }
@@ -1545,6 +1545,32 @@ data:
             "options": [],
             "query": {
               "query": "label_values(nginx_up{namespace=\"caching\", service=\"artifact-registry-proxy\"}, source_cluster)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {
+              "text": "All",
+              "value": [
+                "$__all"
+              ]
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}, normalized_uri)",
+            "includeAll": true,
+            "label": "Repository",
+            "multi": true,
+            "name": "normalized_uri",
+            "options": [],
+            "query": {
+              "query": "label_values(http_requests_total{namespace=\"caching\", service=\"artifact-registry-proxy\", source_cluster=~\"$source_cluster\"}, normalized_uri)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 2,


### PR DESCRIPTION
### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

Both dashboards now include a "Repository" dropdown (backed by the normalized_uri label) so users can scope all panels to a specific package-manager repository type. The three panels that use metrics without this label (Service Availability, Restart Count, Active Pods) are intentionally excluded.

Assisted-by: Claude claude-opus-4-6

Preview these changes here:
https://grafana.stage.devshift.net/d/artifact-registry-proxy-amisstea/artifact-registry-proxy
https://grafana.stage.devshift.net/d/amisstea-cache-perf/artifact-registry-proxy-cache-performance

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] ~**Alert Tests:** New or modified alerts include tests to ensure they function correctly.~
- [ ] ~**SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively.~
- [x] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [x] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [x] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
