### PR TITLE
PVO11Y-5367: Implement the tenant level slo breaching definition metrics

### DIFF
--- a/exporters/kaexporter/DESIGN.md
+++ b/exporters/kaexporter/DESIGN.md
@@ -99,6 +99,7 @@ map[namespace]*BootstrapState
 - New namespace → Bootstrap with 720h query
 - Bootstrapped namespace → Steady-state 36h query
 - Truncated namespace → Schedule gap-fill with narrower window
+- Exhausted retries → Stop gap-fill, emit SLO breach metrics with available data
 - Decommissioned namespace → Remove from map to avoid wasted gap-fill attempts
 
 **Why This Matters:**
@@ -126,9 +127,10 @@ func (e *KAExporter) runCollection() {
     e.mu.Lock()
     defer e.mu.Unlock()
 
-    e.buildSLO.updateGauges(e.rollingStore)
-    e.integrationSLO.updateGauges(e.rollingStore)
-    e.releaseSLO.updateGauges(e.rollingStore)
+    skipBreach := skipBreachNamespacesFromStates(e.bootstrapStates)
+    e.buildSLO.updateGauges(e.rollingStore, skipBreach)
+    e.integrationSLO.updateGauges(e.rollingStore, skipBreach)
+    e.releaseSLO.updateGauges(e.rollingStore, skipBreach)
 }
 ```
 
@@ -165,12 +167,13 @@ func (e *KAExporter) Collect(ch chan<- prometheus.Metric) {
 **Data Structure:**
 ```go
 type DailyBucket struct {
-    Day               string           // "2026-06-23"
-    Count             int64            // Total completed (success + fail)
-    SuccessCount      int64            // Only successful
-    SuccessSumSeconds float64          // Duration sum (successful only)
-    WaitSumSeconds    float64          // Queue time sum (all completed)
-    FailureReasons    map[string]int64 // Failure count by reason
+    Day                      string           // "2026-06-23"
+    Count                    int64            // Total completed (success + fail)
+    SuccessCount             int64            // Only successful
+    SuccessSumSeconds        float64          // Duration sum (successful only)
+    SuccessSumSquaredSeconds float64          // Sum of squared durations (for stddev)
+    WaitSumSeconds           float64          // Queue time sum (successful only)
+    FailureReasons           map[string]int64 // Failure count by reason
 }
 
 type MetricWindow struct {
@@ -225,9 +228,10 @@ Typical deployment (500 label combinations):
 - Per-namespace bootstrap state prevents repeated failures
 
 **When This Happens:**
-- Typical namespace: ~100-500 PLRs/day → no issue
-- Busy namespace: 500-1,000 PLRs/day → may hit 30K limit over 30 days
-- Very busy namespace: >1,000 PLRs/day → gap-fill runs across multiple cycles until complete (stops only after 5 consecutive failures)
+- Typical namespace: ~100-500 PLRs/day -> no issue
+- Busy namespace: 500-1,000 PLRs/day -> may hit 30K cold-start cap over 30 days; gap-fill resolves this transparently
+- Very busy namespace: >1,000 PLRs/day -> truncates on cold start, gap-fill completes across multiple cycles
+- In steady state (36h window, 1,500 cap), truncation may occur for the busiest tenants but does not affect 30-day accuracy since data is already in the rolling store from bootstrap
 
 ---
 
@@ -292,9 +296,9 @@ err := e.collectMetrics(ctx) // Queries all namespaces in parallel
 ## Testing Strategy
 
 **Unit Tests:**
-- `metrics_test.go`: Observation recording, aggregation, deduplication
+- `metrics_test.go`: Observation recording, aggregation, deduplication, SLO breach evaluation, config override end-to-end, gap-fill breach suppression
+- `config_test.go`: YAML parsing, ThresholdValue unmarshaling, SLO config resolution cascade, sanitization
 - `ka_client_test.go`: HTTP retry logic, pagination handling
-- `rolling_store_test.go`: Bucket pruning, stale data eviction (NEW)
 
 **Integration Tests:**
 - End-to-end cold start simulation with mock KubeArchive API

--- a/exporters/kaexporter/README.md
+++ b/exporters/kaexporter/README.md
@@ -24,7 +24,7 @@ Exposes mean duration and success rate metrics over a rolling 30-day window usin
 | `KA_MAX_RETRIES` | No | `3` | Max retries per failed KubeArchive request (exponential backoff). |
 | `KA_INITIAL_RETRY_DELAY_MS` | No | `100` | Initial retry delay in milliseconds. |
 | `KA_MAX_RETRY_DELAY_MS` | No | `5000` | Maximum retry delay cap in milliseconds. |
-| `KA_CONFIG_FILE` | No | *(empty)* | Path to YAML config file. When set, the file controls which namespaces are excluded from collection. When unset, no namespaces are excluded. |
+| `KA_CONFIG_FILE` | No | *(empty)* | Path to YAML config file. Controls namespace exclusions and per-tenant SLO threshold overrides. When unset, no namespaces are excluded and default SLO thresholds are used. |
 | `EXPORTER_PORT` | No | `9101` | HTTP listen port. |
 
 ### Configuration file
@@ -38,7 +38,75 @@ excludeNamespaces:
   - "konflux-perfscale-*-tenant"
 ```
 
-If the file is specified but cannot be read or parsed, the exporter fails to start. When `KA_CONFIG_FILE` is not set, no namespaces are excluded.
+If the file is specified but cannot be read or parsed, the exporter fails to start. When `KA_CONFIG_FILE` is not set, no namespaces are excluded and default SLO thresholds are used.
+
+#### Custom SLO thresholds
+
+The same config file supports a `customSLO` section for per-tenant, per-application, or per-component SLO threshold overrides. Values cascade from the most specific level upward: component overrides application, application overrides tenant, tenant overrides built-in defaults (k=1 stddev, 5% breach percentage).
+
+At each level, domain-specific keys can be set:
+
+| Key | Description |
+|-----|-------------|
+| `build_duration_threshold_seconds` | Fixed build duration threshold in seconds. Replaces the computed mean + stddev. |
+| `build_duration_breach_percentage` | Fraction of daily means that must exceed the threshold to trigger breach (default: 0.05). |
+| `integration_duration_threshold_seconds` | Fixed integration test duration threshold. |
+| `integration_duration_breach_percentage` | Integration breach percentage override. |
+| `release_duration_threshold_seconds` | Fixed release duration threshold. |
+| `release_duration_breach_percentage` | Release breach percentage override. |
+
+Each key accepts either a simple numeric value or an object with `default` and `matches` for label-specific precision:
+
+```yaml
+# Simple form (backward compatible):
+build_duration_threshold_seconds: 7200
+
+# Match-based form:
+integration_duration_threshold_seconds:
+  default: 1800
+  matches:
+    - scenario: ec-scan
+      value: 300
+    - event_type: pull_request
+      value: 900
+```
+
+Match fields (`scenario`, `event_type`, `build_type`, `automated`) are compared against the metric's label set. Empty fields act as wildcards. Matches are evaluated in YAML order; the first match wins. When no match hits, `default` is used. When `default` is also absent, the value falls through to the parent hierarchy level or the built-in defaults.
+
+When `duration_threshold_seconds` is set, the breach evaluation uses that fixed value directly instead of computing `mean + stddev`. When omitted, the statistical baseline is used. Breach percentages must be in the range (0, 1]. Thresholds must be > 0. Invalid values are logged as warnings at startup and ignored -- the exporter starts normally and the affected overrides fall back to built-in defaults.
+
+```yaml
+excludeNamespaces:
+  - rhtap-releng-tenant
+  - "managed-*"
+
+customSLO:
+  tenants:
+    a-team-tenant:
+      integration_duration_threshold_seconds: 3600
+      applications:
+        heavy-app:
+          integration_duration_breach_percentage: 0.10
+          components:
+            slow-builder:
+              build_duration_threshold_seconds: 7200
+            tested-component:
+              integration_duration_threshold_seconds:
+                default: 1800
+                matches:
+                  - scenario: enterprise-contract
+                    value: 300
+                  - scenario: long-running-integration
+                    event_type: push
+                    value: 5400
+```
+
+In this example:
+- `slow-builder` uses a fixed 7200s build threshold and inherits the 10% integration breach percentage from `heavy-app`
+- `tested-component` uses different integration thresholds depending on the scenario: 300s for EC checks, 5400s for a specific long-running scenario on push events, and 1800s for everything else
+- All other components in `heavy-app` use the default stddev-based build threshold but the relaxed 10% integration breach percentage
+- All components in `a-team-tenant` use a fixed 3600s integration threshold unless overridden at a lower level
+- Tenants not listed use the built-in defaults
 
 ### Cold start behavior
 
@@ -49,7 +117,7 @@ On first boot, the exporter queries **720 hours (30 days)** of historical data t
 | Query window | 720h (30 days) | `KA_WINDOW_HOURS` + 50% |
 | Collection timeout | 600s | `KA_COLLECTION_TIMEOUT_SECONDS` |
 | Concurrency | 5 | `KA_MAX_CONCURRENT` |
-| Per-namespace item cap | 10,000 | 1,500 |
+| Per-namespace item cap | 30,000 | 1,500 |
 
 **Note:** `/metrics` endpoint is not served until cold start completes (~90-120 seconds). For architectural details on why this is necessary, see [DESIGN.md](DESIGN.md#1-cold-start-bootstrapping).
 
@@ -68,16 +136,19 @@ All metrics are **Gauges** over a rolling 30-day window of daily aggregated buck
 | `konflux_build_total_count_30d` | build | `cluster, namespace, application, component, build_type, event_type` |
 | `konflux_build_success_count_30d` | build | `cluster, namespace, application, component, build_type, event_type` |
 | `konflux_build_failure_count_30d` | build | `cluster, namespace, application, component, build_type, event_type, reason` |
+| `konflux_build_duration_slo_breach` | build | `cluster, namespace, application, component, build_type, event_type` |
 | `konflux_integration_mean_duration_seconds_30d` | integration | `cluster, namespace, application, component, scenario, optional, test_type, event_type` |
 | `konflux_integration_mean_wait_seconds_30d` | integration | `cluster, namespace, application, component, scenario, optional, test_type, event_type` |
 | `konflux_integration_total_count_30d` | integration | `cluster, namespace, application, component, scenario, optional, test_type, event_type` |
 | `konflux_integration_success_count_30d` | integration | `cluster, namespace, application, component, scenario, optional, test_type, event_type` |
 | `konflux_integration_failure_count_30d` | integration | `cluster, namespace, application, component, scenario, optional, test_type, event_type, reason` |
+| `konflux_integration_duration_slo_breach` | integration | `cluster, namespace, application, component, scenario, optional, test_type, event_type` |
 | `konflux_release_cr_mean_duration_seconds_30d` | release | `cluster, namespace, application, component, automated, event_type` |
 | `konflux_release_cr_mean_wait_seconds_30d` | release | `cluster, namespace, application, component, automated, event_type` |
 | `konflux_release_cr_total_count_30d` | release | `cluster, namespace, application, component, automated, event_type` |
 | `konflux_release_cr_success_count_30d` | release | `cluster, namespace, application, component, automated, event_type` |
 | `konflux_release_cr_failure_count_30d` | release | `cluster, namespace, application, component, automated, event_type, reason` |
+| `konflux_release_cr_duration_slo_breach` | release | `cluster, namespace, application, component, automated, event_type` |
 
 **Metric definitions**:
 - **Duration metrics** (`mean_duration_seconds_30d`): Mean execution time for **successful workloads only** (startTime to completionTime for PipelineRuns; startTime to completionTime for Releases). Failed workloads are excluded from this average.
@@ -85,6 +156,7 @@ All metrics are **Gauges** over a rolling 30-day window of daily aggregated buck
 - **Total count** (`total_count_30d`): Count of all completed workloads (successful + failed) in the rolling window
 - **Success count** (`success_count_30d`): Count of successful workloads in the rolling window. Enables correct volume-weighted aggregation across dimensions: `sum(success_count) / sum(total_count)`.
 - **Failure count** (`failure_count_30d`): Count of failed workloads, broken down by failure reason. Useful for root cause analysis.
+- **Duration SLO breach** (`duration_slo_breach`): 1 if the component's duration SLO is breached, 0 otherwise. Not emitted when data is insufficient (success_count < 10 or days_with_data < 3). By default, a component is in breach when >=5% of its daily mean durations over the past 30 days exceed the 30-day mean + 1 standard deviation. Thresholds and breach percentages can be overridden per tenant/application/component via the config file (see [Custom SLO thresholds](#custom-slo-thresholds)).
 
 **Derived metrics** (can be computed from the above):
 - **Success rate**: `success_count_30d / total_count_30d` (or 0 when total_count_30d == 0)
@@ -177,12 +249,12 @@ go test -mod=mod -count=1 ./exporters/kaexporter/...
 
 **High truncation counts:**
 - Monitor `konflux_ka_exporter_truncations_total{resource="pipelineruns"}`
-- Namespaces with >10,000 PLRs in 30 days will truncate
-- Gap-filling mechanism automatically retries (see [DESIGN.md](DESIGN.md#2-gap-filling-for-busy-namespaces))
+- Truncation is expected during cold-start bootstrap for high-volume tenants (>30,000 items in 30 days) and resolves automatically via gap-fill retries across subsequent collection cycles
+- In steady state (36h window, 1,500 item cap), truncation is normal for the busiest tenants and does not affect 30-day accuracy since most data is already in the rolling store
 
 **Memory usage growing:**
-- Expected memory: ~50-100 MB depending on label cardinality
-- Check number of unique label combinations (namespaces × applications × components)
+- Expected memory: ~50-100 MB in stage, ~1 GB in production depending on label cardinality
+- Check number of unique label combinations (namespaces x applications x components)
 - Consider filtering to specific namespaces via `TENANT_NAMESPACE`
 
 ---

--- a/exporters/kaexporter/build.go
+++ b/exporters/kaexporter/build.go
@@ -12,10 +12,10 @@ type BuildSLO30d struct {
 }
 
 // newBuildSLO30d initializes build 30d SLO metrics
-func newBuildSLO30d() *BuildSLO30d {
+func newBuildSLO30d(sloConfig *SLOConfig) *BuildSLO30d {
 	labels := []string{"cluster", "namespace", "application", "component", "build_type", "event_type"}
 	return &BuildSLO30d{
-		SLOGaugeSet: newSLOGaugeSet("konflux_build", "build", labels),
+		SLOGaugeSet: newSLOGaugeSet("konflux_build", "build", labels, sloConfig, metricBuildDuration),
 	}
 }
 
@@ -70,10 +70,10 @@ func (m *BuildSLO30d) recordObservation(
 }
 
 // updateGauges reads from the rolling store and updates the 30d SLO gauges
-func (m *BuildSLO30d) updateGauges(store *Store) {
+func (m *BuildSLO30d) updateGauges(store *Store, skipBreachNamespaces map[string]bool) {
 	m.SLOGaugeSet.UpdateFromStore(store, metricBuildDuration, func(ls LabelSet) []string {
 		return []string{ls.Cluster, ls.Namespace, ls.Application, ls.Component, ls.BuildType, ls.EventType}
-	})
+	}, skipBreachNamespaces)
 }
 
 // Describe implements prometheus.Collector

--- a/exporters/kaexporter/collector.go
+++ b/exporters/kaexporter/collector.go
@@ -113,9 +113,12 @@ func (e *KAExporter) runCollection() {
 		now := time.Now().Unix()
 		e.lastScrapeSuccessGauge.Set(float64(now))
 		e.lastScrapeSuccessAt.Store(now)
-		e.buildSLO.updateGauges(e.rollingStore)
-		e.integrationSLO.updateGauges(e.rollingStore)
-		e.releaseSLO.updateGauges(e.rollingStore)
+
+		skipBreach := skipBreachNamespacesFromStates(e.bootstrapStates)
+
+		e.buildSLO.updateGauges(e.rollingStore, skipBreach)
+		e.integrationSLO.updateGauges(e.rollingStore, skipBreach)
+		e.releaseSLO.updateGauges(e.rollingStore, skipBreach)
 
 		// coldStart flag now managed per-namespace; check if all namespaces are bootstrapped
 		if e.coldStart {

--- a/exporters/kaexporter/config.go
+++ b/exporters/kaexporter/config.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -12,7 +13,339 @@ import (
 
 // KAConfig represents the YAML configuration file for the exporter.
 type KAConfig struct {
-	ExcludeNamespaces []string `yaml:"excludeNamespaces"`
+	ExcludeNamespaces []string   `yaml:"excludeNamespaces"`
+	CustomSLO         *SLOConfig `yaml:"customSLO,omitempty"`
+}
+
+// ThresholdMatch is a label-conditional override: if all non-empty fields
+// match the current LabelSet, Value is used. Empty fields are wildcards.
+type ThresholdMatch struct {
+	Scenario  string  `yaml:"scenario,omitempty"`
+	EventType string  `yaml:"event_type,omitempty"`
+	BuildType string  `yaml:"build_type,omitempty"`
+	Automated string  `yaml:"automated,omitempty"`
+	Value     float64 `yaml:"value"`
+}
+
+// ThresholdValue supports two YAML forms:
+//   - simple scalar:  build_duration_threshold_seconds: 7200
+//   - object form:    build_duration_threshold_seconds:
+//                       default: 7200
+//                       matches:
+//                         - event_type: push
+//                           value: 5400
+type ThresholdValue struct {
+	Default *float64         `yaml:"default,omitempty"`
+	Matches []ThresholdMatch `yaml:"matches,omitempty"`
+}
+
+func (tv *ThresholdValue) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		v, err := strconv.ParseFloat(value.Value, 64)
+		if err != nil {
+			return fmt.Errorf("threshold value: %w", err)
+		}
+		tv.Default = &v
+		return nil
+	}
+	type plain ThresholdValue
+	return value.Decode((*plain)(tv))
+}
+
+// ResolveValue checks matches first (first match wins), falls back to Default.
+// Returns (0, false) when neither matches nor default apply.
+func (tv *ThresholdValue) ResolveValue(ls LabelSet) (float64, bool) {
+	if tv == nil {
+		return 0, false
+	}
+	for _, m := range tv.Matches {
+		if m.Scenario != "" && m.Scenario != ls.Scenario {
+			continue
+		}
+		if m.EventType != "" && m.EventType != ls.EventType {
+			continue
+		}
+		if m.BuildType != "" && m.BuildType != ls.BuildType {
+			continue
+		}
+		if m.Automated != "" && m.Automated != ls.Automated {
+			continue
+		}
+		return m.Value, true
+	}
+	if tv.Default != nil {
+		return *tv.Default, true
+	}
+	return 0, false
+}
+
+// SLOThresholds holds overridable SLO parameters. Pointer fields: nil means
+// "inherit from parent level." Set at any level in the tenant -> application
+// -> component hierarchy.
+type SLOThresholds struct {
+	BuildDurationThresholdSeconds       *ThresholdValue `yaml:"build_duration_threshold_seconds,omitempty"`
+	BuildDurationBreachPercentage       *ThresholdValue `yaml:"build_duration_breach_percentage,omitempty"`
+	IntegrationDurationThresholdSeconds *ThresholdValue `yaml:"integration_duration_threshold_seconds,omitempty"`
+	IntegrationDurationBreachPercentage *ThresholdValue `yaml:"integration_duration_breach_percentage,omitempty"`
+	ReleaseDurationThresholdSeconds     *ThresholdValue `yaml:"release_duration_threshold_seconds,omitempty"`
+	ReleaseDurationBreachPercentage     *ThresholdValue `yaml:"release_duration_breach_percentage,omitempty"`
+}
+
+func (t *SLOThresholds) durationThresholdFor(domain string) *ThresholdValue {
+	switch domain {
+	case metricBuildDuration:
+		return t.BuildDurationThresholdSeconds
+	case metricIntegrationDuration:
+		return t.IntegrationDurationThresholdSeconds
+	case metricReleaseDuration:
+		return t.ReleaseDurationThresholdSeconds
+	}
+	return nil
+}
+
+func (t *SLOThresholds) breachPercentageFor(domain string) *ThresholdValue {
+	switch domain {
+	case metricBuildDuration:
+		return t.BuildDurationBreachPercentage
+	case metricIntegrationDuration:
+		return t.IntegrationDurationBreachPercentage
+	case metricReleaseDuration:
+		return t.ReleaseDurationBreachPercentage
+	}
+	return nil
+}
+
+// ComponentSLOConfig holds SLO overrides for a specific component.
+type ComponentSLOConfig struct {
+	SLOThresholds `yaml:",inline"`
+}
+
+// ApplicationSLOConfig holds SLO overrides for an application and its components.
+type ApplicationSLOConfig struct {
+	SLOThresholds `yaml:",inline"`
+	Components    map[string]*ComponentSLOConfig `yaml:"components,omitempty"`
+}
+
+// TenantSLOConfig holds SLO overrides for a tenant namespace and its applications.
+type TenantSLOConfig struct {
+	SLOThresholds `yaml:",inline"`
+	Applications  map[string]*ApplicationSLOConfig `yaml:"applications,omitempty"`
+}
+
+// SLOConfig holds the full SLO override hierarchy: defaults -> tenants ->
+// applications -> components.
+type SLOConfig struct {
+	SLOThresholds `yaml:",inline"`
+	Tenants       map[string]*TenantSLOConfig `yaml:"tenants,omitempty"`
+}
+
+// ResolvedSLO holds the effective SLO parameters for a specific label set
+// after cascading through the config hierarchy. nil fields mean "use
+// hardcoded defaults."
+type ResolvedSLO struct {
+	DurationThreshold *float64
+	BreachPercentage  *float64
+}
+
+// Sanitize walks the SLO config hierarchy and nils out any invalid values,
+// logging a warning for each. The exporter starts normally with valid
+// overrides applied and invalid ones ignored.
+func (c *SLOConfig) Sanitize() {
+	if c == nil {
+		return
+	}
+	c.sanitize("customSLO")
+	for name, tenant := range c.Tenants {
+		if tenant == nil {
+			continue
+		}
+		prefix := fmt.Sprintf("customSLO.tenants.%s", name)
+		tenant.sanitize(prefix)
+		for appName, app := range tenant.Applications {
+			if app == nil {
+				continue
+			}
+			appPrefix := fmt.Sprintf("%s.applications.%s", prefix, appName)
+			app.sanitize(appPrefix)
+			for compName, comp := range app.Components {
+				if comp == nil {
+					continue
+				}
+				compPrefix := fmt.Sprintf("%s.components.%s", appPrefix, compName)
+				comp.sanitize(compPrefix)
+			}
+		}
+	}
+}
+
+func (t *SLOThresholds) sanitize(prefix string) {
+	thresholds := []*struct {
+		name string
+		val  **ThresholdValue
+	}{
+		{"build_duration_threshold_seconds", &t.BuildDurationThresholdSeconds},
+		{"integration_duration_threshold_seconds", &t.IntegrationDurationThresholdSeconds},
+		{"release_duration_threshold_seconds", &t.ReleaseDurationThresholdSeconds},
+	}
+	for _, th := range thresholds {
+		sanitizeThresholdValue(th.val, prefix, th.name, func(v float64) bool { return v > 0 }, "must be > 0")
+	}
+
+	percentages := []*struct {
+		name string
+		val  **ThresholdValue
+	}{
+		{"build_duration_breach_percentage", &t.BuildDurationBreachPercentage},
+		{"integration_duration_breach_percentage", &t.IntegrationDurationBreachPercentage},
+		{"release_duration_breach_percentage", &t.ReleaseDurationBreachPercentage},
+	}
+	for _, pct := range percentages {
+		sanitizeThresholdValue(pct.val, prefix, pct.name, func(v float64) bool { return v > 0 && v <= 1 }, "must be in (0, 1]")
+	}
+}
+
+func sanitizeThresholdValue(tvp **ThresholdValue, prefix, name string, valid func(float64) bool, rule string) {
+	tv := *tvp
+	if tv == nil {
+		return
+	}
+	if tv.Default != nil && !valid(*tv.Default) {
+		log.Printf("WARNING: %s.%s: %s, got %g; ignoring default", prefix, name, rule, *tv.Default)
+		tv.Default = nil
+	}
+	validMatches := tv.Matches[:0]
+	for _, m := range tv.Matches {
+		if !valid(m.Value) {
+			log.Printf("WARNING: %s.%s: match %s, got %g; ignoring match entry", prefix, name, rule, m.Value)
+			continue
+		}
+		if m.Scenario == "" && m.EventType == "" && m.BuildType == "" && m.Automated == "" {
+			log.Printf("WARNING: %s.%s: match entry has no filter fields (matches everything); use 'default' instead; ignoring match entry", prefix, name)
+			continue
+		}
+		validMatches = append(validMatches, m)
+	}
+	tv.Matches = validMatches
+	if tv.Default == nil && len(tv.Matches) == 0 {
+		*tvp = nil
+	}
+}
+
+// Resolve returns the effective SLO thresholds for a specific label set,
+// cascading: component -> application -> tenant (namespace) -> defaults.
+// At each level, a ThresholdValue is only applied when ResolveValue returns
+// ok=true for the given labels, preserving higher-level values when a
+// lower-level ThresholdValue has no matching entry.
+func (c *SLOConfig) Resolve(ls LabelSet, domain string) ResolvedSLO {
+	if c == nil {
+		return ResolvedSLO{}
+	}
+
+	var result ResolvedSLO
+
+	resolveThreshold := func(tv *ThresholdValue) {
+		if tv == nil {
+			return
+		}
+		if v, ok := tv.ResolveValue(ls); ok {
+			result.DurationThreshold = &v
+		}
+	}
+	resolvePercentage := func(tv *ThresholdValue) {
+		if tv == nil {
+			return
+		}
+		if v, ok := tv.ResolveValue(ls); ok {
+			result.BreachPercentage = &v
+		}
+	}
+
+	resolveThreshold(c.durationThresholdFor(domain))
+	resolvePercentage(c.breachPercentageFor(domain))
+
+	tenantCfg := c.Tenants[ls.Namespace]
+	if tenantCfg == nil {
+		return result
+	}
+	resolveThreshold(tenantCfg.durationThresholdFor(domain))
+	resolvePercentage(tenantCfg.breachPercentageFor(domain))
+
+	appCfg := tenantCfg.Applications[ls.Application]
+	if appCfg == nil {
+		return result
+	}
+	resolveThreshold(appCfg.durationThresholdFor(domain))
+	resolvePercentage(appCfg.breachPercentageFor(domain))
+
+	compCfg := appCfg.Components[ls.Component]
+	if compCfg == nil {
+		return result
+	}
+	resolveThreshold(compCfg.durationThresholdFor(domain))
+	resolvePercentage(compCfg.breachPercentageFor(domain))
+
+	return result
+}
+
+func logSLOOverrides(c *SLOConfig) {
+	if c == nil {
+		return
+	}
+	logThresholdValue := func(prefix, name string, tv *ThresholdValue) {
+		if tv == nil {
+			return
+		}
+		if tv.Default != nil {
+			log.Printf("  SLO override: %s.%s = %g", prefix, name, *tv.Default)
+		}
+		for _, m := range tv.Matches {
+			var filters []string
+			if m.Scenario != "" {
+				filters = append(filters, "scenario="+m.Scenario)
+			}
+			if m.EventType != "" {
+				filters = append(filters, "event_type="+m.EventType)
+			}
+			if m.BuildType != "" {
+				filters = append(filters, "build_type="+m.BuildType)
+			}
+			if m.Automated != "" {
+				filters = append(filters, "automated="+m.Automated)
+			}
+			log.Printf("  SLO override: %s.%s [%s] = %g", prefix, name, strings.Join(filters, ", "), m.Value)
+		}
+	}
+	logThresholds := func(prefix string, t *SLOThresholds) {
+		logThresholdValue(prefix, "build_duration_threshold_seconds", t.BuildDurationThresholdSeconds)
+		logThresholdValue(prefix, "build_duration_breach_percentage", t.BuildDurationBreachPercentage)
+		logThresholdValue(prefix, "integration_duration_threshold_seconds", t.IntegrationDurationThresholdSeconds)
+		logThresholdValue(prefix, "integration_duration_breach_percentage", t.IntegrationDurationBreachPercentage)
+		logThresholdValue(prefix, "release_duration_threshold_seconds", t.ReleaseDurationThresholdSeconds)
+		logThresholdValue(prefix, "release_duration_breach_percentage", t.ReleaseDurationBreachPercentage)
+	}
+
+	logThresholds("defaults", &c.SLOThresholds)
+	for tName, tenant := range c.Tenants {
+		if tenant == nil {
+			continue
+		}
+		prefix := fmt.Sprintf("tenants.%s", tName)
+		logThresholds(prefix, &tenant.SLOThresholds)
+		for aName, app := range tenant.Applications {
+			if app == nil {
+				continue
+			}
+			aPrefix := fmt.Sprintf("%s.applications.%s", prefix, aName)
+			logThresholds(aPrefix, &app.SLOThresholds)
+			for cName, comp := range app.Components {
+				if comp == nil {
+					continue
+				}
+				cPrefix := fmt.Sprintf("%s.components.%s", aPrefix, cName)
+				logThresholds(cPrefix, &comp.SLOThresholds)
+			}
+		}
+	}
 }
 
 // namespaceFilter holds parsed exclusion rules for namespace filtering.

--- a/exporters/kaexporter/config_test.go
+++ b/exporters/kaexporter/config_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -149,6 +151,889 @@ func TestLoadConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLoadConfigWithCustomSLO(t *testing.T) {
+	t.Run("full customSLO hierarchy parses correctly", func(t *testing.T) {
+		content := `excludeNamespaces:
+  - rhtap-releng-tenant
+customSLO:
+  build_duration_breach_percentage: 0.05
+  tenants:
+    a-team-tenant:
+      integration_duration_threshold_seconds: 3600
+      applications:
+        heavy-app:
+          integration_duration_breach_percentage: 0.10
+          components:
+            slow-builder:
+              build_duration_threshold_seconds: 7200
+`
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+		cfg, err := loadConfig(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.CustomSLO == nil {
+			t.Fatal("CustomSLO is nil")
+		}
+		if cfg.CustomSLO.BuildDurationBreachPercentage == nil || cfg.CustomSLO.BuildDurationBreachPercentage.Default == nil || *cfg.CustomSLO.BuildDurationBreachPercentage.Default != 0.05 {
+			t.Error("global build_duration_breach_percentage not parsed")
+		}
+		tenant := cfg.CustomSLO.Tenants["a-team-tenant"]
+		if tenant == nil {
+			t.Fatal("tenant a-team-tenant not parsed")
+		}
+		if tenant.IntegrationDurationThresholdSeconds == nil || tenant.IntegrationDurationThresholdSeconds.Default == nil || *tenant.IntegrationDurationThresholdSeconds.Default != 3600 {
+			t.Error("tenant integration_duration_threshold_seconds not parsed")
+		}
+		app := tenant.Applications["heavy-app"]
+		if app == nil {
+			t.Fatal("application heavy-app not parsed")
+		}
+		if app.IntegrationDurationBreachPercentage == nil || app.IntegrationDurationBreachPercentage.Default == nil || *app.IntegrationDurationBreachPercentage.Default != 0.10 {
+			t.Error("application integration_duration_breach_percentage not parsed")
+		}
+		comp := app.Components["slow-builder"]
+		if comp == nil {
+			t.Fatal("component slow-builder not parsed")
+		}
+		if comp.BuildDurationThresholdSeconds == nil || comp.BuildDurationThresholdSeconds.Default == nil || *comp.BuildDurationThresholdSeconds.Default != 7200 {
+			t.Error("component build_duration_threshold_seconds not parsed")
+		}
+	})
+
+	t.Run("customSLO only without excludeNamespaces", func(t *testing.T) {
+		content := `customSLO:
+  build_duration_breach_percentage: 0.10
+  tenants:
+    my-tenant:
+      build_duration_threshold_seconds: 3600
+`
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+		cfg, err := loadConfig(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(cfg.ExcludeNamespaces) != 0 {
+			t.Errorf("ExcludeNamespaces should be empty, got %v", cfg.ExcludeNamespaces)
+		}
+		if cfg.CustomSLO == nil {
+			t.Fatal("CustomSLO should not be nil")
+		}
+		if cfg.CustomSLO.BuildDurationBreachPercentage == nil || cfg.CustomSLO.BuildDurationBreachPercentage.Default == nil || *cfg.CustomSLO.BuildDurationBreachPercentage.Default != 0.10 {
+			t.Error("global build_duration_breach_percentage not parsed")
+		}
+		tenant := cfg.CustomSLO.Tenants["my-tenant"]
+		if tenant == nil || tenant.BuildDurationThresholdSeconds == nil || tenant.BuildDurationThresholdSeconds.Default == nil || *tenant.BuildDurationThresholdSeconds.Default != 3600 {
+			t.Error("tenant threshold not parsed")
+		}
+		f, err := newNamespaceFilter(cfg)
+		if err != nil {
+			t.Fatalf("newNamespaceFilter error: %v", err)
+		}
+		got := f.apply([]string{"ns-a", "ns-b"})
+		if len(got) != 2 {
+			t.Errorf("filter should exclude nothing, got %v", got)
+		}
+	})
+
+	t.Run("object-form ThresholdValue parses and resolves through loadConfig", func(t *testing.T) {
+		content := `customSLO:
+  tenants:
+    my-tenant:
+      integration_duration_threshold_seconds: 2000
+      applications:
+        my-app:
+          components:
+            my-comp:
+              integration_duration_threshold_seconds:
+                default: 1800
+                matches:
+                  - scenario: ec-scan
+                    value: 300
+                  - scenario: long-test
+                    event_type: push
+                    value: 5400
+              build_duration_breach_percentage:
+                matches:
+                  - event_type: push
+                    value: 0.10
+`
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+		cfg, err := loadConfig(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.CustomSLO == nil {
+			t.Fatal("CustomSLO is nil")
+		}
+
+		// Verify struct was parsed correctly
+		comp := cfg.CustomSLO.Tenants["my-tenant"].Applications["my-app"].Components["my-comp"]
+		if comp == nil {
+			t.Fatal("component not parsed")
+		}
+		tv := comp.IntegrationDurationThresholdSeconds
+		if tv == nil {
+			t.Fatal("integration threshold not parsed")
+		}
+		if tv.Default == nil || *tv.Default != 1800 {
+			t.Errorf("expected Default=1800, got %v", tv.Default)
+		}
+		if len(tv.Matches) != 2 {
+			t.Fatalf("expected 2 matches, got %d", len(tv.Matches))
+		}
+		bpct := comp.BuildDurationBreachPercentage
+		if bpct == nil {
+			t.Fatal("breach percentage not parsed")
+		}
+		if bpct.Default != nil {
+			t.Errorf("expected nil Default for matches-only, got %v", *bpct.Default)
+		}
+		if len(bpct.Matches) != 1 || bpct.Matches[0].EventType != "push" || bpct.Matches[0].Value != 0.10 {
+			t.Errorf("breach percentage match: got %+v", bpct.Matches)
+		}
+
+		// Verify resolution through the full YAML-parsed config
+		cfg.CustomSLO.Sanitize()
+
+		// ec-scan scenario -> match fires, threshold=300
+		r := cfg.CustomSLO.Resolve(LabelSet{Namespace: "my-tenant", Application: "my-app", Component: "my-comp", Scenario: "ec-scan"}, metricIntegrationDuration)
+		if r.DurationThreshold == nil || *r.DurationThreshold != 300 {
+			t.Errorf("ec-scan: expected threshold=300, got %v", r.DurationThreshold)
+		}
+
+		// long-test + push -> match fires, threshold=5400
+		r = cfg.CustomSLO.Resolve(LabelSet{Namespace: "my-tenant", Application: "my-app", Component: "my-comp", Scenario: "long-test", EventType: "push"}, metricIntegrationDuration)
+		if r.DurationThreshold == nil || *r.DurationThreshold != 5400 {
+			t.Errorf("long-test+push: expected threshold=5400, got %v", r.DurationThreshold)
+		}
+
+		// long-test + pull_request -> no match, falls to component default=1800
+		r = cfg.CustomSLO.Resolve(LabelSet{Namespace: "my-tenant", Application: "my-app", Component: "my-comp", Scenario: "long-test", EventType: "pull_request"}, metricIntegrationDuration)
+		if r.DurationThreshold == nil || *r.DurationThreshold != 1800 {
+			t.Errorf("long-test+pull_request: expected default threshold=1800, got %v", r.DurationThreshold)
+		}
+
+		// unknown-scenario -> no match, falls to component default=1800 (not tenant 2000)
+		r = cfg.CustomSLO.Resolve(LabelSet{Namespace: "my-tenant", Application: "my-app", Component: "my-comp", Scenario: "other"}, metricIntegrationDuration)
+		if r.DurationThreshold == nil || *r.DurationThreshold != 1800 {
+			t.Errorf("other scenario: expected component default=1800, got %v", r.DurationThreshold)
+		}
+
+		// unknown component -> falls to tenant=2000 (component matches don't apply)
+		r = cfg.CustomSLO.Resolve(LabelSet{Namespace: "my-tenant", Application: "my-app", Component: "other-comp", Scenario: "ec-scan"}, metricIntegrationDuration)
+		if r.DurationThreshold == nil || *r.DurationThreshold != 2000 {
+			t.Errorf("other component: expected tenant threshold=2000, got %v", r.DurationThreshold)
+		}
+
+		// breach percentage: push event -> match fires, 0.10
+		r = cfg.CustomSLO.Resolve(LabelSet{Namespace: "my-tenant", Application: "my-app", Component: "my-comp", EventType: "push"}, metricBuildDuration)
+		if r.BreachPercentage == nil || *r.BreachPercentage != 0.10 {
+			t.Errorf("push breach pct: expected 0.10, got %v", r.BreachPercentage)
+		}
+
+		// breach percentage: pull_request -> no match, no default -> nil (built-in default used)
+		r = cfg.CustomSLO.Resolve(LabelSet{Namespace: "my-tenant", Application: "my-app", Component: "my-comp", EventType: "pull_request"}, metricBuildDuration)
+		if r.BreachPercentage != nil {
+			t.Errorf("pull_request breach pct: expected nil (no match, no default), got %v", *r.BreachPercentage)
+		}
+	})
+
+	t.Run("no customSLO section is backward compatible", func(t *testing.T) {
+		content := `excludeNamespaces:
+  - rhtap-releng-tenant
+`
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+		cfg, err := loadConfig(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.CustomSLO != nil {
+			t.Errorf("CustomSLO should be nil when not in YAML, got %+v", cfg.CustomSLO)
+		}
+	})
+}
+
+// ── ThresholdValue Tests ─────────────────────────────────────────────────────
+
+func thresholdValueSimple(v float64) *ThresholdValue {
+	return &ThresholdValue{Default: float64Ptr(v)}
+}
+
+func TestThresholdValueUnmarshalYAML(t *testing.T) {
+	t.Run("simple scalar", func(t *testing.T) {
+		var tv ThresholdValue
+		content := []byte("7200")
+		if err := yaml.Unmarshal(content, &tv); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tv.Default == nil || *tv.Default != 7200 {
+			t.Errorf("expected Default=7200, got %v", tv.Default)
+		}
+		if len(tv.Matches) != 0 {
+			t.Errorf("expected no Matches, got %v", tv.Matches)
+		}
+	})
+
+	t.Run("object with default and matches", func(t *testing.T) {
+		content := []byte(`
+default: 7200
+matches:
+  - event_type: push
+    value: 5400
+  - scenario: ec-scan
+    event_type: pull_request
+    value: 300
+`)
+		var tv ThresholdValue
+		if err := yaml.Unmarshal(content, &tv); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tv.Default == nil || *tv.Default != 7200 {
+			t.Errorf("expected Default=7200, got %v", tv.Default)
+		}
+		if len(tv.Matches) != 2 {
+			t.Fatalf("expected 2 matches, got %d", len(tv.Matches))
+		}
+		if tv.Matches[0].EventType != "push" || tv.Matches[0].Value != 5400 {
+			t.Errorf("match[0]: got %+v", tv.Matches[0])
+		}
+		if tv.Matches[1].Scenario != "ec-scan" || tv.Matches[1].EventType != "pull_request" || tv.Matches[1].Value != 300 {
+			t.Errorf("match[1]: got %+v", tv.Matches[1])
+		}
+	})
+
+	t.Run("object with only matches, no default", func(t *testing.T) {
+		content := []byte(`
+matches:
+  - scenario: aap-conforma
+    value: 0.10
+`)
+		var tv ThresholdValue
+		if err := yaml.Unmarshal(content, &tv); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tv.Default != nil {
+			t.Errorf("expected nil Default, got %v", *tv.Default)
+		}
+		if len(tv.Matches) != 1 {
+			t.Fatalf("expected 1 match, got %d", len(tv.Matches))
+		}
+	})
+
+	t.Run("invalid scalar is rejected", func(t *testing.T) {
+		var tv ThresholdValue
+		content := []byte(`"not-a-number"`)
+		if err := yaml.Unmarshal(content, &tv); err == nil {
+			t.Fatal("expected error for non-numeric scalar")
+		}
+	})
+
+	t.Run("backward compat: simple value in SLOThresholds", func(t *testing.T) {
+		content := []byte(`build_duration_threshold_seconds: 3600`)
+		var th SLOThresholds
+		if err := yaml.Unmarshal(content, &th); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if th.BuildDurationThresholdSeconds == nil {
+			t.Fatal("expected non-nil BuildDurationThresholdSeconds")
+		}
+		if th.BuildDurationThresholdSeconds.Default == nil || *th.BuildDurationThresholdSeconds.Default != 3600 {
+			t.Errorf("expected Default=3600, got %v", th.BuildDurationThresholdSeconds)
+		}
+	})
+
+	t.Run("object form in SLOThresholds", func(t *testing.T) {
+		content := []byte(`
+integration_duration_threshold_seconds:
+  default: 1800
+  matches:
+    - scenario: ec-scan
+      value: 300
+`)
+		var th SLOThresholds
+		if err := yaml.Unmarshal(content, &th); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tv := th.IntegrationDurationThresholdSeconds
+		if tv == nil {
+			t.Fatal("expected non-nil IntegrationDurationThresholdSeconds")
+		}
+		if tv.Default == nil || *tv.Default != 1800 {
+			t.Errorf("expected Default=1800, got %v", tv.Default)
+		}
+		if len(tv.Matches) != 1 || tv.Matches[0].Scenario != "ec-scan" {
+			t.Errorf("expected 1 match for ec-scan, got %v", tv.Matches)
+		}
+	})
+}
+
+func TestThresholdValueResolveValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		tv        *ThresholdValue
+		ls        LabelSet
+		wantValue float64
+		wantOK    bool
+	}{
+		{"nil returns false", nil, LabelSet{}, 0, false},
+		{"default only", thresholdValueSimple(7200), LabelSet{}, 7200, true},
+		{
+			"match hits before default",
+			&ThresholdValue{Default: float64Ptr(7200), Matches: []ThresholdMatch{{EventType: "push", Value: 5400}}},
+			LabelSet{EventType: "push"}, 5400, true,
+		},
+		{
+			"no match falls to default",
+			&ThresholdValue{Default: float64Ptr(7200), Matches: []ThresholdMatch{{EventType: "push", Value: 5400}}},
+			LabelSet{EventType: "pull_request"}, 7200, true,
+		},
+		{
+			"no match and no default returns false",
+			&ThresholdValue{Matches: []ThresholdMatch{{EventType: "push", Value: 5400}}},
+			LabelSet{EventType: "pull_request"}, 0, false,
+		},
+		{
+			"partial label match: only scenario set",
+			&ThresholdValue{Matches: []ThresholdMatch{{Scenario: "ec-scan", Value: 300}}},
+			LabelSet{Scenario: "ec-scan", EventType: "push"}, 300, true,
+		},
+		{
+			"first match wins",
+			&ThresholdValue{Matches: []ThresholdMatch{
+				{EventType: "push", Value: 1000},
+				{EventType: "push", Scenario: "integration", Value: 2000},
+			}},
+			LabelSet{EventType: "push", Scenario: "integration"}, 1000, true,
+		},
+		{
+			"multi-field match requires all fields",
+			&ThresholdValue{Matches: []ThresholdMatch{{Scenario: "ec-scan", EventType: "push", Value: 300}}},
+			LabelSet{Scenario: "ec-scan", EventType: "pull_request"}, 0, false,
+		},
+		{
+			"build_type match",
+			&ThresholdValue{Matches: []ThresholdMatch{{BuildType: "docker-builds", Value: 9000}}},
+			LabelSet{BuildType: "docker-builds"}, 9000, true,
+		},
+		{
+			"automated match",
+			&ThresholdValue{Matches: []ThresholdMatch{{Automated: "true", Value: 600}}},
+			LabelSet{Automated: "true"}, 600, true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, ok := tt.tv.ResolveValue(tt.ls)
+			if ok != tt.wantOK || v != tt.wantValue {
+				t.Errorf("expected (%g, %v), got (%g, %v)", tt.wantValue, tt.wantOK, v, ok)
+			}
+		})
+	}
+}
+
+// ── SLO Config Resolution Tests ──────────────────────────────────────────────
+
+func float64Ptr(v float64) *float64 { return &v }
+
+func TestSLOConfigResolve(t *testing.T) {
+	ls := func(ns, app, comp string) LabelSet {
+		return LabelSet{Namespace: ns, Application: app, Component: comp}
+	}
+
+	resolveTests := []struct {
+		name           string
+		cfg            *SLOConfig
+		ls             LabelSet
+		domain         string
+		wantThreshold  *float64
+		wantBreachPct  *float64
+	}{
+		{
+			name:   "nil SLOConfig returns zero ResolvedSLO",
+			cfg:    nil,
+			ls:     ls("ns", "app", "comp"),
+			domain: metricBuildDuration,
+		},
+		{
+			name:   "empty SLOConfig returns zero ResolvedSLO",
+			cfg:    &SLOConfig{},
+			ls:     ls("ns", "app", "comp"),
+			domain: metricBuildDuration,
+		},
+		{
+			name: "global defaults apply when no tenant match",
+			cfg: &SLOConfig{SLOThresholds: SLOThresholds{
+				BuildDurationBreachPercentage: thresholdValueSimple(0.10),
+			}},
+			ls:            ls("unknown-tenant", "app", "comp"),
+			domain:        metricBuildDuration,
+			wantBreachPct: float64Ptr(0.10),
+		},
+		{
+			name: "tenant override cascades",
+			cfg: &SLOConfig{
+				SLOThresholds: SLOThresholds{BuildDurationBreachPercentage: thresholdValueSimple(0.05)},
+				Tenants: map[string]*TenantSLOConfig{
+					"my-tenant": {SLOThresholds: SLOThresholds{BuildDurationThresholdSeconds: thresholdValueSimple(3600)}},
+				},
+			},
+			ls:            ls("my-tenant", "app", "comp"),
+			domain:        metricBuildDuration,
+			wantThreshold: float64Ptr(3600),
+			wantBreachPct: float64Ptr(0.05),
+		},
+		{
+			name: "application override cascades over tenant",
+			cfg: newSLOCfg().
+				tenant("my-tenant").buildThreshold(3600).
+				app("my-app").buildThreshold(1800).
+				build(),
+			ls:            ls("my-tenant", "my-app", "comp"),
+			domain:        metricBuildDuration,
+			wantThreshold: float64Ptr(1800),
+		},
+		{
+			name: "component override cascades over application",
+			cfg: newSLOCfg().
+				tenant("my-tenant").buildThreshold(3600).
+				app("my-app").buildThreshold(1800).
+				comp("my-comp", SLOThresholds{BuildDurationThresholdSeconds: thresholdValueSimple(7200)}).
+				build(),
+			ls:            ls("my-tenant", "my-app", "my-comp"),
+			domain:        metricBuildDuration,
+			wantThreshold: float64Ptr(7200),
+		},
+		{
+			name: "partial override: percentage at component, threshold from tenant",
+			cfg: newSLOCfg().
+				tenant("my-tenant").buildThreshold(3600).
+				app("my-app").
+				comp("my-comp", SLOThresholds{BuildDurationBreachPercentage: thresholdValueSimple(0.15)}).
+				build(),
+			ls:            ls("my-tenant", "my-app", "my-comp"),
+			domain:        metricBuildDuration,
+			wantThreshold: float64Ptr(3600),
+			wantBreachPct: float64Ptr(0.15),
+		},
+		{
+			name: "domain isolation: build threshold does not affect integration",
+			cfg: &SLOConfig{SLOThresholds: SLOThresholds{
+				BuildDurationThresholdSeconds: thresholdValueSimple(3600),
+			}},
+			ls:     ls("ns", "app", "comp"),
+			domain: metricIntegrationDuration,
+		},
+		{
+			name: "unknown tenant falls back to global",
+			cfg: &SLOConfig{
+				SLOThresholds: SLOThresholds{BuildDurationBreachPercentage: thresholdValueSimple(0.08)},
+				Tenants: map[string]*TenantSLOConfig{
+					"known-tenant": {SLOThresholds: SLOThresholds{BuildDurationBreachPercentage: thresholdValueSimple(0.20)}},
+				},
+			},
+			ls:            ls("unknown-tenant", "app", "comp"),
+			domain:        metricBuildDuration,
+			wantBreachPct: float64Ptr(0.08),
+		},
+		{
+			name: "integration domain cascades correctly",
+			cfg: newSLOCfg().
+				tenant("my-tenant").integrationThreshold(1800).
+				app("my-app").
+				comp("my-comp", SLOThresholds{IntegrationDurationBreachPercentage: thresholdValueSimple(0.15)}).
+				build(),
+			ls:            ls("my-tenant", "my-app", "my-comp"),
+			domain:        metricIntegrationDuration,
+			wantThreshold: float64Ptr(1800),
+			wantBreachPct: float64Ptr(0.15),
+		},
+		{
+			name: "release domain cascades correctly",
+			cfg: newSLOCfg().releaseBreachPct(0.08).
+				tenant("my-tenant").
+				app("my-app").releaseThreshold(7200).
+				build(),
+			ls:            ls("my-tenant", "my-app", "my-comp"),
+			domain:        metricReleaseDuration,
+			wantThreshold: float64Ptr(7200),
+			wantBreachPct: float64Ptr(0.08),
+		},
+		{
+			name: "unknown application falls back to tenant",
+			cfg: &SLOConfig{
+				Tenants: map[string]*TenantSLOConfig{
+					"my-tenant": {
+						SLOThresholds: SLOThresholds{BuildDurationThresholdSeconds: thresholdValueSimple(3600)},
+						Applications: map[string]*ApplicationSLOConfig{
+							"known-app": {SLOThresholds: SLOThresholds{BuildDurationThresholdSeconds: thresholdValueSimple(1800)}},
+						},
+					},
+				},
+			},
+			ls:            ls("my-tenant", "unknown-app", "comp"),
+			domain:        metricBuildDuration,
+			wantThreshold: float64Ptr(3600),
+		},
+	}
+	for _, tt := range resolveTests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := tt.cfg.Resolve(tt.ls, tt.domain)
+			if tt.wantThreshold == nil {
+				if r.DurationThreshold != nil {
+					t.Errorf("expected nil threshold, got %v", *r.DurationThreshold)
+				}
+			} else {
+				if r.DurationThreshold == nil || *r.DurationThreshold != *tt.wantThreshold {
+					t.Errorf("expected threshold=%v, got %v", *tt.wantThreshold, r.DurationThreshold)
+				}
+			}
+			if tt.wantBreachPct == nil {
+				if r.BreachPercentage != nil {
+					t.Errorf("expected nil breach_percentage, got %v", *r.BreachPercentage)
+				}
+			} else {
+				if r.BreachPercentage == nil || *r.BreachPercentage != *tt.wantBreachPct {
+					t.Errorf("expected breach_percentage=%v, got %v", *tt.wantBreachPct, r.BreachPercentage)
+				}
+			}
+		})
+	}
+
+	t.Run("match-based threshold at component level", func(t *testing.T) {
+		c := newSLOCfg().
+			tenant("my-tenant").
+			app("my-app").
+			comp("my-comp", SLOThresholds{
+				IntegrationDurationThresholdSeconds: &ThresholdValue{
+					Default: float64Ptr(1800),
+					Matches: []ThresholdMatch{
+						{Scenario: "ec-scan", Value: 300},
+						{EventType: "pull_request", Value: 900},
+					},
+				},
+			}).
+			build()
+		r := c.Resolve(LabelSet{Namespace: "my-tenant", Application: "my-app", Component: "my-comp", Scenario: "ec-scan"}, metricIntegrationDuration)
+		if r.DurationThreshold == nil || *r.DurationThreshold != 300 {
+			t.Errorf("expected match threshold=300, got %v", r.DurationThreshold)
+		}
+		r = c.Resolve(LabelSet{Namespace: "my-tenant", Application: "my-app", Component: "my-comp", EventType: "pull_request"}, metricIntegrationDuration)
+		if r.DurationThreshold == nil || *r.DurationThreshold != 900 {
+			t.Errorf("expected match threshold=900, got %v", r.DurationThreshold)
+		}
+		r = c.Resolve(LabelSet{Namespace: "my-tenant", Application: "my-app", Component: "my-comp", EventType: "push"}, metricIntegrationDuration)
+		if r.DurationThreshold == nil || *r.DurationThreshold != 1800 {
+			t.Errorf("expected default threshold=1800, got %v", r.DurationThreshold)
+		}
+	})
+
+	t.Run("no-match at lower level preserves parent value", func(t *testing.T) {
+		c := newSLOCfg().
+			tenant("my-tenant").integrationThreshold(5000).
+			app("my-app").
+			comp("my-comp", SLOThresholds{
+				IntegrationDurationThresholdSeconds: &ThresholdValue{
+					Matches: []ThresholdMatch{
+						{Scenario: "ec-scan", Value: 300},
+					},
+				},
+			}).
+			build()
+		r := c.Resolve(LabelSet{Namespace: "my-tenant", Application: "my-app", Component: "my-comp", Scenario: "full-integration"}, metricIntegrationDuration)
+		if r.DurationThreshold == nil || *r.DurationThreshold != 5000 {
+			t.Errorf("expected parent threshold=5000 preserved when no match at component, got %v", r.DurationThreshold)
+		}
+	})
+}
+
+func TestSLOConfigSanitize(t *testing.T) {
+	t.Run("nil config does not panic", func(t *testing.T) {
+		var c *SLOConfig
+		c.Sanitize()
+	})
+
+	t.Run("valid config is unchanged", func(t *testing.T) {
+		c := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				BuildDurationThresholdSeconds: thresholdValueSimple(3600),
+				BuildDurationBreachPercentage: thresholdValueSimple(0.05),
+			},
+			Tenants: map[string]*TenantSLOConfig{
+				"my-tenant": {
+					SLOThresholds: SLOThresholds{
+						IntegrationDurationBreachPercentage: thresholdValueSimple(0.10),
+					},
+				},
+			},
+		}
+		c.Sanitize()
+		if c.BuildDurationThresholdSeconds == nil || c.BuildDurationThresholdSeconds.Default == nil || *c.BuildDurationThresholdSeconds.Default != 3600 {
+			t.Error("valid threshold should be unchanged")
+		}
+		if c.BuildDurationBreachPercentage == nil || c.BuildDurationBreachPercentage.Default == nil || *c.BuildDurationBreachPercentage.Default != 0.05 {
+			t.Error("valid percentage should be unchanged")
+		}
+		tenantPct := c.Tenants["my-tenant"].IntegrationDurationBreachPercentage
+		if tenantPct == nil || tenantPct.Default == nil || *tenantPct.Default != 0.10 {
+			t.Error("valid tenant percentage should be unchanged")
+		}
+	})
+
+	t.Run("negative threshold is nilled out", func(t *testing.T) {
+		c := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				BuildDurationThresholdSeconds: thresholdValueSimple(-100),
+			},
+		}
+		c.Sanitize()
+		if c.BuildDurationThresholdSeconds != nil {
+			t.Error("negative threshold should be nilled out")
+		}
+	})
+
+	t.Run("zero threshold is nilled out", func(t *testing.T) {
+		c := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				IntegrationDurationThresholdSeconds: thresholdValueSimple(0),
+			},
+		}
+		c.Sanitize()
+		if c.IntegrationDurationThresholdSeconds != nil {
+			t.Error("zero threshold should be nilled out")
+		}
+	})
+
+	t.Run("breach percentage > 1 is nilled out", func(t *testing.T) {
+		c := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				BuildDurationBreachPercentage: thresholdValueSimple(20),
+			},
+		}
+		c.Sanitize()
+		if c.BuildDurationBreachPercentage != nil {
+			t.Error("percentage > 1 should be nilled out")
+		}
+	})
+
+	t.Run("breach percentage = 0 is nilled out", func(t *testing.T) {
+		c := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				ReleaseDurationBreachPercentage: thresholdValueSimple(0),
+			},
+		}
+		c.Sanitize()
+		if c.ReleaseDurationBreachPercentage != nil {
+			t.Error("percentage = 0 should be nilled out")
+		}
+	})
+
+	t.Run("invalid value at component level is nilled out", func(t *testing.T) {
+		c := newSLOCfg().
+			tenant("my-tenant").
+			app("my-app").
+			comp("my-comp", SLOThresholds{BuildDurationThresholdSeconds: thresholdValueSimple(-50)}).
+			build()
+		c.Sanitize()
+		if c.Tenants["my-tenant"].Applications["my-app"].Components["my-comp"].BuildDurationThresholdSeconds != nil {
+			t.Error("invalid component threshold should be nilled out")
+		}
+	})
+
+	t.Run("breach percentage = 1 is valid and unchanged", func(t *testing.T) {
+		c := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				BuildDurationBreachPercentage: thresholdValueSimple(1.0),
+			},
+		}
+		c.Sanitize()
+		if c.BuildDurationBreachPercentage == nil || c.BuildDurationBreachPercentage.Default == nil || *c.BuildDurationBreachPercentage.Default != 1.0 {
+			t.Error("percentage = 1.0 should be valid and unchanged")
+		}
+	})
+
+	t.Run("valid values survive alongside invalid ones", func(t *testing.T) {
+		c := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				BuildDurationThresholdSeconds: thresholdValueSimple(3600),
+				BuildDurationBreachPercentage: thresholdValueSimple(20),
+			},
+		}
+		c.Sanitize()
+		if c.BuildDurationThresholdSeconds == nil || c.BuildDurationThresholdSeconds.Default == nil || *c.BuildDurationThresholdSeconds.Default != 3600 {
+			t.Error("valid threshold should survive")
+		}
+		if c.BuildDurationBreachPercentage != nil {
+			t.Error("invalid percentage should be nilled out")
+		}
+	})
+
+	t.Run("invalid match entries are filtered out", func(t *testing.T) {
+		c := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				BuildDurationThresholdSeconds: &ThresholdValue{
+					Default: float64Ptr(3600),
+					Matches: []ThresholdMatch{
+						{EventType: "push", Value: 5400},
+						{EventType: "pull_request", Value: -100},
+						{Scenario: "ec-scan", Value: 300},
+					},
+				},
+			},
+		}
+		c.Sanitize()
+		tv := c.BuildDurationThresholdSeconds
+		if tv == nil {
+			t.Fatal("ThresholdValue should not be nil (has valid default and matches)")
+		}
+		if len(tv.Matches) != 2 {
+			t.Fatalf("expected 2 valid matches, got %d", len(tv.Matches))
+		}
+		if tv.Matches[0].Value != 5400 || tv.Matches[1].Value != 300 {
+			t.Errorf("wrong surviving matches: %+v", tv.Matches)
+		}
+	})
+
+	t.Run("invalid default nilled, valid matches survive", func(t *testing.T) {
+		c := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				BuildDurationThresholdSeconds: &ThresholdValue{
+					Default: float64Ptr(-1),
+					Matches: []ThresholdMatch{
+						{EventType: "push", Value: 5400},
+					},
+				},
+			},
+		}
+		c.Sanitize()
+		tv := c.BuildDurationThresholdSeconds
+		if tv == nil {
+			t.Fatal("ThresholdValue should survive (has valid match)")
+		}
+		if tv.Default != nil {
+			t.Error("invalid default should be nilled")
+		}
+		if len(tv.Matches) != 1 {
+			t.Errorf("valid match should survive, got %d matches", len(tv.Matches))
+		}
+	})
+
+	t.Run("all invalid: entire ThresholdValue nilled out", func(t *testing.T) {
+		c := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				BuildDurationThresholdSeconds: &ThresholdValue{
+					Default: float64Ptr(-1),
+					Matches: []ThresholdMatch{
+						{EventType: "push", Value: -100},
+					},
+				},
+			},
+		}
+		c.Sanitize()
+		if c.BuildDurationThresholdSeconds != nil {
+			t.Error("entirely invalid ThresholdValue should be nilled out")
+		}
+	})
+
+	t.Run("filter-less match entry is rejected", func(t *testing.T) {
+		c := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				BuildDurationThresholdSeconds: &ThresholdValue{
+					Default: float64Ptr(3600),
+					Matches: []ThresholdMatch{
+						{Value: 5400},
+						{EventType: "push", Value: 1800},
+					},
+				},
+			},
+		}
+		c.Sanitize()
+		tv := c.BuildDurationThresholdSeconds
+		if tv == nil {
+			t.Fatal("ThresholdValue should not be nil (has valid default and filtered match)")
+		}
+		if len(tv.Matches) != 1 {
+			t.Fatalf("expected 1 surviving match (filter-less dropped), got %d", len(tv.Matches))
+		}
+		if tv.Matches[0].EventType != "push" || tv.Matches[0].Value != 1800 {
+			t.Errorf("wrong surviving match: %+v", tv.Matches[0])
+		}
+	})
+
+	t.Run("filter-less match as only match with no default nils ThresholdValue", func(t *testing.T) {
+		c := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				BuildDurationThresholdSeconds: &ThresholdValue{
+					Matches: []ThresholdMatch{
+						{Value: 5400},
+					},
+				},
+			},
+		}
+		c.Sanitize()
+		if c.BuildDurationThresholdSeconds != nil {
+			t.Error("ThresholdValue with only a filter-less match and no default should be nilled out")
+		}
+	})
+
+	t.Run("invalid breach percentage matches are filtered out", func(t *testing.T) {
+		c := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				BuildDurationBreachPercentage: &ThresholdValue{
+					Default: float64Ptr(0.05),
+					Matches: []ThresholdMatch{
+						{EventType: "push", Value: 0.10},
+						{EventType: "pull_request", Value: 1.5},
+						{Scenario: "ec-scan", Value: 0},
+					},
+				},
+			},
+		}
+		c.Sanitize()
+		tv := c.BuildDurationBreachPercentage
+		if tv == nil {
+			t.Fatal("ThresholdValue should not be nil (has valid default and match)")
+		}
+		if len(tv.Matches) != 1 {
+			t.Fatalf("expected 1 valid match, got %d", len(tv.Matches))
+		}
+		if tv.Matches[0].EventType != "push" || tv.Matches[0].Value != 0.10 {
+			t.Errorf("wrong surviving match: %+v", tv.Matches[0])
+		}
+	})
+
+	t.Run("nil map values in hierarchy do not panic", func(t *testing.T) {
+		c := &SLOConfig{
+			Tenants: map[string]*TenantSLOConfig{
+				"nil-tenant": nil,
+				"real-tenant": {
+					Applications: map[string]*ApplicationSLOConfig{
+						"nil-app": nil,
+						"real-app": {
+							Components: map[string]*ComponentSLOConfig{
+								"nil-comp": nil,
+							},
+						},
+					},
+				},
+			},
+		}
+		c.Sanitize()
+	})
 }
 
 func TestLoadConfig_FileNotFound(t *testing.T) {

--- a/exporters/kaexporter/exporter.go
+++ b/exporters/kaexporter/exporter.go
@@ -154,6 +154,22 @@ func isTimeBefore(a, b string) bool {
 	return tA.Before(tB)
 }
 
+// skipBreachNamespacesFromStates returns the set of namespaces that have not
+// completed their 30-day bootstrap. Breach evaluation is suppressed for these
+// namespaces to prevent false positives from partial data.
+func skipBreachNamespacesFromStates(states map[string]*nsBootstrapState) map[string]bool {
+	var skip map[string]bool
+	for ns, state := range states {
+		if !state.Bootstrapped && state.GapAttempts < maxGapFillAttempts {
+			if skip == nil {
+				skip = make(map[string]bool)
+			}
+			skip[ns] = true
+		}
+	}
+	return skip
+}
+
 // ── Retry configuration ───────────────────────────────────────────────────────
 
 // retryConfig holds exponential backoff parameters for KubeArchive API retries
@@ -348,6 +364,7 @@ func NewKAExporter() (*KAExporter, error) {
 	fixedNS := strings.TrimSpace(os.Getenv(namespaceEnvVar))
 
 	var nsFilter *namespaceFilter
+	var sloConfig *SLOConfig
 	if configFile := strings.TrimSpace(os.Getenv(kaConfigFileEnv)); configFile != "" {
 		cfg, err := loadConfig(configFile)
 		if err != nil {
@@ -357,8 +374,16 @@ func NewKAExporter() (*KAExporter, error) {
 		if err != nil {
 			return nil, fmt.Errorf("load config: %w", err)
 		}
+		sloConfig = cfg.CustomSLO
+		if sloConfig != nil {
+			sloConfig.Sanitize()
+		}
 		log.Printf("Namespace filter: loaded from %s (%d exact, %d pattern rules)",
 			configFile, len(nsFilter.exactMatches), len(nsFilter.patterns))
+		if sloConfig != nil {
+			log.Printf("Custom SLO config: loaded from %s", configFile)
+			logSLOOverrides(sloConfig)
+		}
 	} else {
 		nsFilter, _ = newNamespaceFilter(nil)
 		log.Printf("Namespace filter: no config file specified, no namespaces excluded")
@@ -452,9 +477,9 @@ func NewKAExporter() (*KAExporter, error) {
 	}
 
 	// Initialize 30d SLO metric modules
-	e.buildSLO = newBuildSLO30d()
-	e.integrationSLO = newIntegrationSLO30d()
-	e.releaseSLO = newReleaseSLO30d()
+	e.buildSLO = newBuildSLO30d(sloConfig)
+	e.integrationSLO = newIntegrationSLO30d(sloConfig)
+	e.releaseSLO = newReleaseSLO30d(sloConfig)
 
 	// Initialize rolling store (in-memory only, no persistence)
 	e.rollingStore = NewStore()

--- a/exporters/kaexporter/integration.go
+++ b/exporters/kaexporter/integration.go
@@ -12,10 +12,10 @@ type IntegrationSLO30d struct {
 }
 
 // newIntegrationSLO30d initializes integration 30d SLO metrics
-func newIntegrationSLO30d() *IntegrationSLO30d {
+func newIntegrationSLO30d(sloConfig *SLOConfig) *IntegrationSLO30d {
 	labels := []string{"cluster", "namespace", "application", "component", "scenario", "optional", "test_type", "event_type"}
 	return &IntegrationSLO30d{
-		SLOGaugeSet: newSLOGaugeSet("konflux_integration", "integration test", labels),
+		SLOGaugeSet: newSLOGaugeSet("konflux_integration", "integration test", labels, sloConfig, metricIntegrationDuration),
 	}
 }
 
@@ -81,10 +81,10 @@ func (m *IntegrationSLO30d) recordObservation(
 }
 
 // updateGauges reads from the rolling store and updates the 30d SLO gauges
-func (m *IntegrationSLO30d) updateGauges(store *Store) {
+func (m *IntegrationSLO30d) updateGauges(store *Store, skipBreachNamespaces map[string]bool) {
 	m.SLOGaugeSet.UpdateFromStore(store, metricIntegrationDuration, func(ls LabelSet) []string {
 		return []string{ls.Cluster, ls.Namespace, ls.Application, ls.Component, ls.Scenario, ls.Optional, ls.TestType, ls.EventType}
-	})
+	}, skipBreachNamespaces)
 }
 
 // Describe implements prometheus.Collector

--- a/exporters/kaexporter/metrics_test.go
+++ b/exporters/kaexporter/metrics_test.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
 // ── Build Metrics Tests ───────────────────────────────────────────────────────
@@ -43,7 +47,7 @@ func TestBuildRecordObservation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			store := NewStore()
-			slo := newBuildSLO30d()
+			slo := newBuildSLO30d(nil)
 			slo.recordObservation(store, "test-cluster", "test-ns", "test-app", "test-comp", tt.plr)
 
 			recorded := false
@@ -52,11 +56,11 @@ func TestBuildRecordObservation(t *testing.T) {
 				if tt.wantRecorded {
 					assertEqual(t, "BuildType", ls.BuildType, tt.wantBuildType)
 					assertEqual(t, "EventType", ls.EventType, tt.wantEventType)
-					assertEqual(t, "TotalCount", window.ComputeTotalCount(), int64(1))
+					assertEqual(t, "TotalCount", window.ComputeTotalCount(testCutoff()), int64(1))
 					if tt.wantSucceeded {
-						assertEqual(t, "SuccessCount", window.ComputeSuccessCount(), int64(1))
+						assertEqual(t, "SuccessCount", window.ComputeSuccessCount(testCutoff()), int64(1))
 					} else {
-						assertEqual(t, "SuccessCount", window.ComputeSuccessCount(), int64(0))
+						assertEqual(t, "SuccessCount", window.ComputeSuccessCount(testCutoff()), int64(0))
 					}
 				}
 			})
@@ -102,7 +106,7 @@ func TestIntegrationRecordObservation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			store := NewStore()
-			slo := newIntegrationSLO30d()
+			slo := newIntegrationSLO30d(nil)
 			slo.recordObservation(store, "test-cluster", "test-ns", "test-app", "test-comp", tt.plr)
 
 			recorded := false
@@ -198,7 +202,7 @@ func TestReleaseRecordObservation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			store := NewStore()
-			slo := newReleaseSLO30d()
+			slo := newReleaseSLO30d(nil)
 			slo.recordObservation(store, "test-cluster", "test-ns", "test-app", "test-comp", tt.release)
 
 			recorded := false
@@ -208,9 +212,9 @@ func TestReleaseRecordObservation(t *testing.T) {
 					assertEqual(t, "Automated", ls.Automated, tt.wantAutomated)
 					assertEqual(t, "EventType", ls.EventType, tt.wantEventType)
 					if tt.wantSucceeded {
-						assertEqual(t, "SuccessCount", window.ComputeSuccessCount(), int64(1))
+						assertEqual(t, "SuccessCount", window.ComputeSuccessCount(testCutoff()), int64(1))
 					} else {
-						assertEqual(t, "SuccessCount", window.ComputeSuccessCount(), int64(0))
+						assertEqual(t, "SuccessCount", window.ComputeSuccessCount(testCutoff()), int64(0))
 					}
 				}
 			})
@@ -224,7 +228,7 @@ func TestReleaseRecordObservation(t *testing.T) {
 func TestEdgeCases(t *testing.T) {
 	t.Run("negative duration is not recorded", func(t *testing.T) {
 		store := NewStore()
-		slo := newBuildSLO30d()
+		slo := newBuildSLO30d(nil)
 		plr := NewPLR().UID("bad-time").
 			CreatedAt(secondsAgo(3600)).
 			CompletedAt(secondsAgo(3900)). // Before creation
@@ -243,7 +247,7 @@ func TestEdgeCases(t *testing.T) {
 
 	t.Run("deduplication", func(t *testing.T) {
 		store := NewStore()
-		slo := newBuildSLO30d()
+		slo := newBuildSLO30d(nil)
 		plr := NewPLR().UID("same-build").
 			Times(secondsAgo(3600), secondsAgo(3590), secondsAgo(3300)).
 			Pipeline("docker-build").Succeeded().Build()
@@ -253,7 +257,7 @@ func TestEdgeCases(t *testing.T) {
 
 		var totalCount int64
 		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
-			totalCount = window.ComputeTotalCount()
+			totalCount = window.ComputeTotalCount(testCutoff())
 		})
 		assertEqual(t, "TotalCount", totalCount, int64(1))
 	})
@@ -264,14 +268,14 @@ func TestEdgeCases(t *testing.T) {
 func TestUpdateGauges(t *testing.T) {
 	t.Run("empty store does not panic", func(t *testing.T) {
 		store := NewStore()
-		newBuildSLO30d().updateGauges(store)
-		newIntegrationSLO30d().updateGauges(store)
-		newReleaseSLO30d().updateGauges(store)
+		newBuildSLO30d(nil).updateGauges(store, nil)
+		newIntegrationSLO30d(nil).updateGauges(store, nil)
+		newReleaseSLO30d(nil).updateGauges(store, nil)
 	})
 
 	t.Run("with data", func(t *testing.T) {
 		store := NewStore()
-		buildSLO := newBuildSLO30d()
+		buildSLO := newBuildSLO30d(nil)
 		now := time.Now().UTC()
 
 		for i := 0; i < 10; i++ {
@@ -289,16 +293,16 @@ func TestUpdateGauges(t *testing.T) {
 			)
 		}
 
-		buildSLO.updateGauges(store)
+		buildSLO.updateGauges(store, nil)
 
 		metricCount := 0
 		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
 			metricCount++
-			totalCount := window.ComputeTotalCount()
+			totalCount := window.ComputeTotalCount(testCutoff())
 			if totalCount == 0 {
 				t.Error("TotalCount should not be 0")
 			}
-			successCount := window.ComputeSuccessCount()
+			successCount := window.ComputeSuccessCount(testCutoff())
 			if successCount < 0 || successCount > totalCount {
 				t.Errorf("SuccessCount %d out of valid range [0, %d]", successCount, totalCount)
 			}
@@ -310,7 +314,7 @@ func TestUpdateGauges(t *testing.T) {
 
 	t.Run("all failures - no duration metrics emitted", func(t *testing.T) {
 		store := NewStore()
-		buildSLO := newBuildSLO30d()
+		buildSLO := newBuildSLO30d(nil)
 		now := time.Now().UTC()
 
 		for i := 0; i < 5; i++ {
@@ -322,11 +326,11 @@ func TestUpdateGauges(t *testing.T) {
 			)
 		}
 
-		buildSLO.updateGauges(store)
+		buildSLO.updateGauges(store, nil)
 
 		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
-			assertEqual(t, "TotalCount", window.ComputeTotalCount(), int64(5))
-			assertEqual(t, "SuccessCount", window.ComputeSuccessCount(), int64(0))
+			assertEqual(t, "TotalCount", window.ComputeTotalCount(testCutoff()), int64(5))
+			assertEqual(t, "SuccessCount", window.ComputeSuccessCount(testCutoff()), int64(0))
 		})
 	})
 }
@@ -336,7 +340,7 @@ func TestUpdateGauges(t *testing.T) {
 func TestQueueTimeMetrics(t *testing.T) {
 	t.Run("build with valid wait time", func(t *testing.T) {
 		store := NewStore()
-		slo := newBuildSLO30d()
+		slo := newBuildSLO30d(nil)
 		plr := NewPLR().UID("wait-test-1").
 			Times(secondsAgo(3600), secondsAgo(3450), secondsAgo(3150)).
 			Pipeline("docker-build").Succeeded().Build()
@@ -344,13 +348,13 @@ func TestQueueTimeMetrics(t *testing.T) {
 		slo.recordObservation(store, "test-cluster", "test-ns", "test-app", "test-comp", plr)
 
 		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
-			assertFloat(t, "WaitMean", window.ComputeWaitMean(), 150.0)
+			assertFloat(t, "WaitMean", window.ComputeWaitMean(testCutoff()), 150.0)
 		})
 	})
 
 	t.Run("build with missing startTime is rejected", func(t *testing.T) {
 		store := NewStore()
-		slo := newBuildSLO30d()
+		slo := newBuildSLO30d(nil)
 		plr := NewPLR().UID("wait-test-2").
 			CreatedAt(secondsAgo(3600)).
 			CompletedAt(secondsAgo(3300)).
@@ -369,7 +373,7 @@ func TestQueueTimeMetrics(t *testing.T) {
 
 	t.Run("build with zero wait time", func(t *testing.T) {
 		store := NewStore()
-		slo := newBuildSLO30d()
+		slo := newBuildSLO30d(nil)
 		plr := NewPLR().UID("wait-test-3").
 			Times(secondsAgo(3600), secondsAgo(3600), secondsAgo(3300)).
 			Pipeline("docker-build").Succeeded().Build()
@@ -377,7 +381,7 @@ func TestQueueTimeMetrics(t *testing.T) {
 		slo.recordObservation(store, "test-cluster", "test-ns", "test-app", "test-comp", plr)
 
 		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
-			assertFloat(t, "WaitMean", window.ComputeWaitMean(), 0.0)
+			assertFloat(t, "WaitMean", window.ComputeWaitMean(testCutoff()), 0.0)
 		})
 	})
 
@@ -396,8 +400,8 @@ func TestQueueTimeMetrics(t *testing.T) {
 		}
 
 		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
-			assertFloat(t, "WaitMean", window.ComputeWaitMean(), 30.0)
-			assertEqual(t, "TotalCount", window.ComputeTotalCount(), int64(5))
+			assertFloat(t, "WaitMean", window.ComputeWaitMean(testCutoff()), 30.0)
+			assertEqual(t, "TotalCount", window.ComputeTotalCount(testCutoff()), int64(5))
 		})
 	})
 
@@ -409,8 +413,7 @@ func TestQueueTimeMetrics(t *testing.T) {
 		for i, wt := range []float64{10, 20, 30} {
 			store.RecordObservation(
 				metricBuildDuration, fmt.Sprintf("success-%d", i), now.Add(-time.Duration(i)*time.Hour),
-				LabelSet{Cluster: "c", Namespace: "ns", Application: "app", Component: "comp",
-					BuildType: "docker-builds", EventType: "push"},
+				buildLabelShort,
 				300.0, wt, true, "",
 			)
 		}
@@ -418,22 +421,21 @@ func TestQueueTimeMetrics(t *testing.T) {
 		for i, wt := range []float64{100, 200} {
 			store.RecordObservation(
 				metricBuildDuration, fmt.Sprintf("failed-%d", i), now.Add(-time.Duration(i+10)*time.Hour),
-				LabelSet{Cluster: "c", Namespace: "ns", Application: "app", Component: "comp",
-					BuildType: "docker-builds", EventType: "push"},
+				buildLabelShort,
 				0, wt, false, "Failed",
 			)
 		}
 
 		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
-			assertFloat(t, "WaitMean", window.ComputeWaitMean(), 20.0) // (10+20+30)/3
-			assertEqual(t, "SuccessCount", window.ComputeSuccessCount(), int64(3))
-			assertEqual(t, "TotalCount", window.ComputeTotalCount(), int64(5))
+			assertFloat(t, "WaitMean", window.ComputeWaitMean(testCutoff()), 20.0) // (10+20+30)/3
+			assertEqual(t, "SuccessCount", window.ComputeSuccessCount(testCutoff()), int64(3))
+			assertEqual(t, "TotalCount", window.ComputeTotalCount(testCutoff()), int64(5))
 		})
 	})
 
 	t.Run("release queue time", func(t *testing.T) {
 		store := NewStore()
-		slo := newReleaseSLO30d()
+		slo := newReleaseSLO30d(nil)
 		release := NewRelease().Name("release-wait-test").
 			Times(secondsAgo(3600), secondsAgo(3300), secondsAgo(2700)).
 			App("app").Component("comp").PACEventType("push").Automated(true).Succeeded().Build()
@@ -441,13 +443,13 @@ func TestQueueTimeMetrics(t *testing.T) {
 		slo.recordObservation(store, "test-cluster", "test-ns", "app", "comp", release)
 
 		store.ForEachWindow(metricReleaseDuration, func(ls LabelSet, window *MetricWindow) {
-			assertFloat(t, "WaitMean", window.ComputeWaitMean(), 300.0)
+			assertFloat(t, "WaitMean", window.ComputeWaitMean(testCutoff()), 300.0)
 		})
 	})
 
 	t.Run("release with missing startTime is rejected", func(t *testing.T) {
 		store := NewStore()
-		slo := newReleaseSLO30d()
+		slo := newReleaseSLO30d(nil)
 		release := NewRelease().Name("release-no-start").
 			CreatedAt(secondsAgo(3600)).
 			CompletedAt(secondsAgo(2700)).
@@ -503,8 +505,7 @@ func TestStoreCleanup(t *testing.T) {
 		store := NewStore()
 		now := time.Now().UTC()
 
-		labels := LabelSet{Cluster: "c", Namespace: "ns", Application: "app", Component: "comp",
-			BuildType: "docker-builds", EventType: "push"}
+		labels := buildLabelShort
 
 		// Old observations (should be excluded from 30-day calculations)
 		store.RecordObservation(metricBuildDuration, "old-build", now.AddDate(0, 0, -35), labels, 300.0, 10.0, true, "")
@@ -515,10 +516,10 @@ func TestStoreCleanup(t *testing.T) {
 		store.RecordObservation(metricBuildDuration, "fresh", now.AddDate(0, 0, -1), labels, 100.0, 3.0, true, "")
 
 		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
-			assertFloat(t, "SuccessMean", window.ComputeSuccessMean(), 150.0)
-			assertFloat(t, "WaitMean", window.ComputeWaitMean(), 4.0)
-			assertEqual(t, "SuccessCount", window.ComputeSuccessCount(), int64(2))
-			assertEqual(t, "TotalCount", window.ComputeTotalCount(), int64(2))
+			assertFloat(t, "SuccessMean", window.ComputeSuccessMean(testCutoff()), 150.0)
+			assertFloat(t, "WaitMean", window.ComputeWaitMean(testCutoff()), 4.0)
+			assertEqual(t, "SuccessCount", window.ComputeSuccessCount(testCutoff()), int64(2))
+			assertEqual(t, "TotalCount", window.ComputeTotalCount(testCutoff()), int64(2))
 		})
 	})
 
@@ -526,8 +527,7 @@ func TestStoreCleanup(t *testing.T) {
 		store := NewStore()
 		now := time.Now().UTC()
 
-		labels := LabelSet{Cluster: "c", Namespace: "ns", Application: "app", Component: "comp",
-			BuildType: "docker-builds", EventType: "push"}
+		labels := buildLabelShort
 
 		// Old failure (should be excluded)
 		store.RecordObservation(metricBuildDuration, "old-failure", now.AddDate(0, 0, -35), labels, 0, 0, false, "OldError")
@@ -538,7 +538,7 @@ func TestStoreCleanup(t *testing.T) {
 		store.RecordObservation(metricBuildDuration, "recent-3", now.AddDate(0, 0, -15), labels, 0, 0, false, "AnotherError")
 
 		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
-			reasons := window.ComputeFailureReasons()
+			reasons := window.ComputeFailureReasons(testCutoff())
 			if _, exists := reasons["OldError"]; exists {
 				t.Error("OldError should be excluded")
 			}
@@ -633,6 +633,431 @@ func TestUpdateBootstrapState(t *testing.T) {
 	})
 }
 
+// -- SLO Breach Tests -----------------------------------------------------
+
+func TestComputeSuccessStdDev(t *testing.T) {
+	t.Run("uniform values have zero stddev", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		for i := 0; i < 10; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("u-%d", i),
+				now.Add(-time.Duration(i)*time.Hour), labels, 300.0, 10.0, true, "")
+		}
+
+		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+			assertFloat(t, "StdDev", window.ComputeSuccessStdDev(testCutoff()), 0.0)
+		})
+	})
+
+	t.Run("known values", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		// Durations: 100, 200, 300, 400, 500 -> mean=300, variance=20000, stddev~141.42
+		durations := []float64{100, 200, 300, 400, 500}
+		for i, d := range durations {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("k-%d", i),
+				now.Add(-time.Duration(i)*time.Hour), labels, d, 10.0, true, "")
+		}
+
+		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+			got := window.ComputeSuccessStdDev(testCutoff())
+			want := math.Sqrt(20000.0) // ~ 141.42
+			if math.Abs(got-want) > 0.01 {
+				t.Errorf("StdDev = %f, want %f", got, want)
+			}
+		})
+	})
+
+	t.Run("single observation returns zero", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		store.RecordObservation(metricBuildDuration, "single", now, labels, 300.0, 10.0, true, "")
+
+		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+			assertFloat(t, "StdDev", window.ComputeSuccessStdDev(testCutoff()), 0.0)
+		})
+	})
+
+	t.Run("only failures returns zero", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		for i := 0; i < 5; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("f-%d", i),
+				now.Add(-time.Duration(i)*time.Hour), labels, 0, 0, false, "Failed")
+		}
+
+		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+			assertFloat(t, "StdDev", window.ComputeSuccessStdDev(testCutoff()), 0.0)
+		})
+	})
+}
+
+func TestCountBreachingDays(t *testing.T) {
+	t.Run("no breaching days", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		// All durations are 300s, threshold is 500s -> no breaches
+		for i := 0; i < 10; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("nb-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, 300.0, 10.0, true, "")
+		}
+
+		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+			breaching, total := window.CountBreachingDays(testCutoff(),500.0)
+			assertEqual(t, "breachingDays", breaching, 0)
+			assertEqual(t, "totalDays", total, 10)
+		})
+	})
+
+	t.Run("some breaching days", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		// Days 0-4: duration 300s (below threshold)
+		for i := 0; i < 5; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("low-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, 300.0, 10.0, true, "")
+		}
+		// Days 5-6: duration 600s (above threshold of 400)
+		for i := 5; i < 7; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("high-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, 600.0, 10.0, true, "")
+		}
+
+		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+			breaching, total := window.CountBreachingDays(testCutoff(),400.0)
+			assertEqual(t, "breachingDays", breaching, 2)
+			assertEqual(t, "totalDays", total, 7)
+		})
+	})
+
+	t.Run("daily mean exactly equal to threshold is not breaching", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		// All durations are 400s, threshold is 400 -> dailyMean == threshold, strict > means no breach
+		for i := 0; i < 10; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("eq-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, 400.0, 10.0, true, "")
+		}
+
+		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+			breaching, total := window.CountBreachingDays(testCutoff(), 400.0)
+			assertEqual(t, "breachingDays", breaching, 0)
+			assertEqual(t, "totalDays", total, 10)
+		})
+	})
+
+	t.Run("days with only failures are skipped", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		// Day 0: successful observation
+		store.RecordObservation(metricBuildDuration, "s-0", now, labels, 300.0, 10.0, true, "")
+		// Day 1: only failures
+		store.RecordObservation(metricBuildDuration, "f-1",
+			now.Add(-24*time.Hour), labels, 0, 0, false, "Failed")
+
+		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+			breaching, total := window.CountBreachingDays(testCutoff(),500.0)
+			assertEqual(t, "breachingDays", breaching, 0)
+			assertEqual(t, "totalDays", total, 1) // Only 1 day has successful observations
+		})
+	})
+}
+
+func TestBuildDurationSLOBreach(t *testing.T) {
+	t.Run("breach triggered when daily means exceed threshold", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		// 20 days of normal builds at 300s
+		for i := 3; i < 23; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("normal-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, 300.0, 10.0, true, "")
+		}
+		// 3 recent days with dramatically higher duration (900s)
+		for i := 0; i < 3; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("slow-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, 900.0, 10.0, true, "")
+		}
+
+		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+			successCount := window.ComputeSuccessCount(testCutoff())
+			if successCount < minSuccessCountForSLO {
+				t.Fatalf("expected >= %d successes, got %d", minSuccessCountForSLO, successCount)
+			}
+
+			mean30d := window.ComputeSuccessMean(testCutoff())
+			stddev30d := window.ComputeSuccessStdDev(testCutoff())
+			threshold := mean30d + sloThresholdK*stddev30d
+
+			breachingDays, totalDays := window.CountBreachingDays(testCutoff(),threshold)
+			if totalDays < minDaysWithDataForSLO {
+				t.Fatalf("expected >= %d days with data, got %d", minDaysWithDataForSLO, totalDays)
+			}
+
+			breachFraction := float64(breachingDays) / float64(totalDays)
+			if breachFraction < sloBreachPercentage {
+				t.Errorf("expected breach: %d/%d days (%.1f%%) >= %.1f%%, threshold=%.1f (mean=%.1f + stddev=%.1f)",
+					breachingDays, totalDays, breachFraction*100, sloBreachPercentage*100, threshold, mean30d, stddev30d)
+			}
+		})
+
+		buildSLO := newBuildSLO30d(nil)
+		buildSLO.updateGauges(store, nil)
+
+		m := &dto.Metric{}
+		buildSLO.durationSLOBreach.WithLabelValues("c", "ns", "app", "comp", "docker-builds", "push").Write(m) //nolint:errcheck
+		if m.GetGauge().GetValue() != 1 {
+			t.Errorf("expected breach gauge=1, got %v", m.GetGauge().GetValue())
+		}
+	})
+
+	t.Run("no breach when all durations are consistent", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		for i := 0; i < 20; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("consistent-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, 300.0, 10.0, true, "")
+		}
+
+		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+			mean30d := window.ComputeSuccessMean(testCutoff())
+			stddev30d := window.ComputeSuccessStdDev(testCutoff())
+			threshold := mean30d + sloThresholdK*stddev30d
+
+			assertFloat(t, "stddev", stddev30d, 0.0)
+			assertFloat(t, "threshold", threshold, mean30d)
+
+			breachingDays, totalDays := window.CountBreachingDays(testCutoff(),threshold)
+			assertEqual(t, "breachingDays", breachingDays, 0)
+			if totalDays < minDaysWithDataForSLO {
+				t.Fatalf("expected >= %d days with data, got %d", minDaysWithDataForSLO, totalDays)
+			}
+		})
+
+		buildSLO := newBuildSLO30d(nil)
+		buildSLO.updateGauges(store, nil)
+
+		m := &dto.Metric{}
+		buildSLO.durationSLOBreach.WithLabelValues("c", "ns", "app", "comp", "docker-builds", "push").Write(m) //nolint:errcheck
+		if m.GetGauge().GetValue() != 0 {
+			t.Errorf("expected breach gauge=0, got %v", m.GetGauge().GetValue())
+		}
+	})
+
+	t.Run("single day with data skips SLO evaluation", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		// 15 observations all on the same day - enough total count (>10)
+		// but only 1 day with data (< minDaysWithDataForSLO=3)
+		for i := 0; i < 15; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("single-day-%d", i),
+				now.Add(-time.Duration(i)*time.Minute), labels, 900.0, 10.0, true, "")
+		}
+
+		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+			successCount := window.ComputeSuccessCount(testCutoff())
+			if successCount < minSuccessCountForSLO {
+				t.Fatalf("expected >= %d successes, got %d", minSuccessCountForSLO, successCount)
+			}
+			mean30d := window.ComputeSuccessMean(testCutoff())
+			stddev30d := window.ComputeSuccessStdDev(testCutoff())
+			threshold := mean30d + sloThresholdK*stddev30d
+			_, totalDays := window.CountBreachingDays(testCutoff(),threshold)
+			if totalDays >= minDaysWithDataForSLO {
+				t.Errorf("expected < %d days with data, got %d", minDaysWithDataForSLO, totalDays)
+			}
+		})
+
+		buildSLO := newBuildSLO30d(nil)
+		buildSLO.updateGauges(store, nil)
+
+		ch := make(chan prometheus.Metric, 100)
+		buildSLO.durationSLOBreach.Collect(ch)
+		close(ch)
+		count := 0
+		for range ch {
+			count++
+		}
+		if count != 0 {
+			t.Error("breach metric should not be emitted when days with data < minDaysWithDataForSLO")
+		}
+	})
+
+	t.Run("insufficient data skips SLO evaluation", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		// Only 5 observations - below minSuccessCountForSLO (10)
+		for i := 0; i < 5; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("sparse-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, 900.0, 10.0, true, "")
+		}
+
+		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+			successCount := window.ComputeSuccessCount(testCutoff())
+			if successCount >= minSuccessCountForSLO {
+				t.Errorf("expected < %d successes, got %d", minSuccessCountForSLO, successCount)
+			}
+		})
+
+		buildSLO := newBuildSLO30d(nil)
+		buildSLO.updateGauges(store, nil)
+
+		ch := make(chan prometheus.Metric, 100)
+		buildSLO.durationSLOBreach.Collect(ch)
+		close(ch)
+		count := 0
+		for range ch {
+			count++
+		}
+		if count != 0 {
+			t.Error("breach metric should not be emitted when successCount < minSuccessCountForSLO")
+		}
+	})
+
+	t.Run("boundary: exactly at breach percentage triggers breach", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		// 19 days at 300s, 1 day at 600s with fixed threshold=400
+		// -> 1/20 = 5% == sloBreachPercentage (0.05), >= fires -> breach=1
+		for i := 0; i < 19; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("norm-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, 300.0, 10.0, true, "")
+		}
+		store.RecordObservation(metricBuildDuration, "slow-0",
+			now.Add(-19*24*time.Hour), labels, 600.0, 10.0, true, "")
+
+		cfg := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				BuildDurationThresholdSeconds: thresholdValueSimple(400),
+			},
+		}
+		buildSLO := newBuildSLO30d(cfg)
+		buildSLO.updateGauges(store, nil)
+
+		m := &dto.Metric{}
+		buildSLO.durationSLOBreach.WithLabelValues("c", "ns", "app", "comp", "docker-builds", "push").Write(m) //nolint:errcheck
+		if m.GetGauge().GetValue() != 1 {
+			t.Errorf("expected breach=1 at exact boundary (1/20=5%%), got %v", m.GetGauge().GetValue())
+		}
+	})
+
+	t.Run("boundary: just below breach percentage does not trigger", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		// 20 days all at 300s with fixed threshold=400
+		// -> 0/20 = 0% < 5% -> breach=0
+		for i := 0; i < 20; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("norm-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, 300.0, 10.0, true, "")
+		}
+
+		cfg := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				BuildDurationThresholdSeconds: thresholdValueSimple(400),
+			},
+		}
+		buildSLO := newBuildSLO30d(cfg)
+		buildSLO.updateGauges(store, nil)
+
+		m := &dto.Metric{}
+		buildSLO.durationSLOBreach.WithLabelValues("c", "ns", "app", "comp", "docker-builds", "push").Write(m) //nolint:errcheck
+		if m.GetGauge().GetValue() != 0 {
+			t.Errorf("expected breach=0 below boundary (0/20=0%%), got %v", m.GetGauge().GetValue())
+		}
+	})
+
+	t.Run("existing metrics unchanged after adding breach gauge", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		durations := []float64{100, 200, 300, 400, 500}
+		for i, d := range durations {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("existing-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, d, float64(10+i*2), true, "")
+		}
+
+		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+			assertFloat(t, "SuccessMean", window.ComputeSuccessMean(testCutoff()), 300.0)
+			assertEqual(t, "TotalCount", window.ComputeTotalCount(testCutoff()), int64(5))
+			assertEqual(t, "SuccessCount", window.ComputeSuccessCount(testCutoff()), int64(5))
+		})
+
+		buildSLO := newBuildSLO30d(nil)
+		buildSLO.updateGauges(store, nil)
+
+		// Verify store values are unchanged after updateGauges
+		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+			assertFloat(t, "SuccessMean after update", window.ComputeSuccessMean(testCutoff()), 300.0)
+			assertEqual(t, "TotalCount after update", window.ComputeTotalCount(testCutoff()), int64(5))
+			assertEqual(t, "SuccessCount after update", window.ComputeSuccessCount(testCutoff()), int64(5))
+		})
+	})
+
+	t.Run("empty store does not panic", func(t *testing.T) {
+		store := NewStore()
+		buildSLO := newBuildSLO30d(nil)
+		buildSLO.updateGauges(store, nil)
+	})
+
+	t.Run("zero-duration workloads suppress breach metric", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		for i := 0; i < 20; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("zero-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, 0, 0, true, "")
+		}
+
+		store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+			assertFloat(t, "SuccessMean", window.ComputeSuccessMean(testCutoff()), 0.0)
+			assertFloat(t, "SuccessStdDev", window.ComputeSuccessStdDev(testCutoff()), 0.0)
+		})
+
+		buildSLO := newBuildSLO30d(nil)
+		buildSLO.updateGauges(store, nil)
+
+		ch := make(chan prometheus.Metric, 100)
+		buildSLO.durationSLOBreach.Collect(ch)
+		close(ch)
+		count := 0
+		for range ch {
+			count++
+		}
+		if count != 0 {
+			t.Error("breach metric should not be emitted when threshold=0 (zero-duration workloads)")
+		}
+	})
+}
+
 // ── Gap-Fill State Transition Tests ──────────────────────────────────────────
 
 func TestUpdateGapFillState(t *testing.T) {
@@ -719,7 +1144,760 @@ func TestUpdateGapFillState(t *testing.T) {
 	})
 }
 
+func TestSumSquaredSecondsAccumulation(t *testing.T) {
+	store := NewStore()
+	now := time.Now().UTC()
+	labels := buildLabelShort
+
+	durations := []float64{100, 200, 300}
+	for i, d := range durations {
+		store.RecordObservation(metricBuildDuration, fmt.Sprintf("sq-%d", i),
+			now.Add(-time.Duration(i)*time.Hour), labels, d, 10.0, true, "")
+	}
+
+	store.ForEachWindow(metricBuildDuration, func(ls LabelSet, window *MetricWindow) {
+		var totalSumSq float64
+		for _, b := range window.Buckets {
+			totalSumSq += b.SuccessSumSquaredSeconds
+		}
+		// 100^2 + 200^2 + 300^2 = 10000 + 40000 + 90000 = 140000
+		assertFloat(t, "SumSquaredSeconds", totalSumSq, 140000.0)
+	})
+}
+
+// ── Integration Duration SLO Breach Tests ────────────────────────────────────
+
+func TestIntegrationDurationSLOBreach(t *testing.T) {
+	integrationLabels := integrationLabelShort
+
+	t.Run("breach triggered when daily means exceed threshold", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+
+		for i := 3; i < 23; i++ {
+			store.RecordObservation(metricIntegrationDuration, fmt.Sprintf("normal-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), integrationLabels, 300.0, 10.0, true, "")
+		}
+		for i := 0; i < 3; i++ {
+			store.RecordObservation(metricIntegrationDuration, fmt.Sprintf("slow-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), integrationLabels, 900.0, 10.0, true, "")
+		}
+
+		store.ForEachWindow(metricIntegrationDuration, func(ls LabelSet, window *MetricWindow) {
+			mean30d := window.ComputeSuccessMean(testCutoff())
+			stddev30d := window.ComputeSuccessStdDev(testCutoff())
+			threshold := mean30d + sloThresholdK*stddev30d
+			breachingDays, totalDays := window.CountBreachingDays(testCutoff(),threshold)
+			breachFraction := float64(breachingDays) / float64(totalDays)
+			if breachFraction < sloBreachPercentage {
+				t.Errorf("expected breach: %d/%d = %.1f%% >= %.1f%%",
+					breachingDays, totalDays, breachFraction*100, sloBreachPercentage*100)
+			}
+		})
+
+		slo := newIntegrationSLO30d(nil)
+		slo.updateGauges(store, nil)
+
+		m := &dto.Metric{}
+		slo.durationSLOBreach.WithLabelValues("c", "ns", "app", "comp", "my-scenario", "false", "integration", "push").Write(m) //nolint:errcheck
+		if m.GetGauge().GetValue() != 1 {
+			t.Errorf("expected breach gauge=1, got %v", m.GetGauge().GetValue())
+		}
+	})
+
+	t.Run("no breach when durations are consistent", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+
+		for i := 0; i < 20; i++ {
+			store.RecordObservation(metricIntegrationDuration, fmt.Sprintf("consistent-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), integrationLabels, 300.0, 10.0, true, "")
+		}
+
+		store.ForEachWindow(metricIntegrationDuration, func(ls LabelSet, window *MetricWindow) {
+			stddev30d := window.ComputeSuccessStdDev(testCutoff())
+			assertFloat(t, "stddev", stddev30d, 0.0)
+		})
+
+		slo := newIntegrationSLO30d(nil)
+		slo.updateGauges(store, nil)
+
+		m := &dto.Metric{}
+		slo.durationSLOBreach.WithLabelValues("c", "ns", "app", "comp", "my-scenario", "false", "integration", "push").Write(m) //nolint:errcheck
+		if m.GetGauge().GetValue() != 0 {
+			t.Errorf("expected breach gauge=0, got %v", m.GetGauge().GetValue())
+		}
+	})
+
+	t.Run("insufficient data skips evaluation", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+
+		for i := 0; i < 5; i++ {
+			store.RecordObservation(metricIntegrationDuration, fmt.Sprintf("sparse-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), integrationLabels, 900.0, 10.0, true, "")
+		}
+
+		store.ForEachWindow(metricIntegrationDuration, func(ls LabelSet, window *MetricWindow) {
+			if window.ComputeSuccessCount(testCutoff()) >= minSuccessCountForSLO {
+				t.Errorf("expected < %d successes", minSuccessCountForSLO)
+			}
+		})
+
+		slo := newIntegrationSLO30d(nil)
+		slo.updateGauges(store, nil)
+	})
+
+	t.Run("empty store does not panic", func(t *testing.T) {
+		store := NewStore()
+		slo := newIntegrationSLO30d(nil)
+		slo.updateGauges(store, nil)
+	})
+}
+
+// ── Release Duration SLO Breach Tests ────────────────────────────────────────
+
+func TestReleaseDurationSLOBreach(t *testing.T) {
+	releaseLabels := releaseLabelShort
+
+	t.Run("breach triggered when daily means exceed threshold", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+
+		for i := 3; i < 23; i++ {
+			store.RecordObservation(metricReleaseDuration, fmt.Sprintf("normal-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), releaseLabels, 600.0, 10.0, true, "")
+		}
+		for i := 0; i < 3; i++ {
+			store.RecordObservation(metricReleaseDuration, fmt.Sprintf("slow-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), releaseLabels, 1800.0, 10.0, true, "")
+		}
+
+		store.ForEachWindow(metricReleaseDuration, func(ls LabelSet, window *MetricWindow) {
+			mean30d := window.ComputeSuccessMean(testCutoff())
+			stddev30d := window.ComputeSuccessStdDev(testCutoff())
+			threshold := mean30d + sloThresholdK*stddev30d
+			breachingDays, totalDays := window.CountBreachingDays(testCutoff(),threshold)
+			breachFraction := float64(breachingDays) / float64(totalDays)
+			if breachFraction < sloBreachPercentage {
+				t.Errorf("expected breach: %d/%d = %.1f%% >= %.1f%%",
+					breachingDays, totalDays, breachFraction*100, sloBreachPercentage*100)
+			}
+		})
+
+		slo := newReleaseSLO30d(nil)
+		slo.updateGauges(store, nil)
+
+		m := &dto.Metric{}
+		slo.durationSLOBreach.WithLabelValues("c", "ns", "app", "comp", "true", "push").Write(m) //nolint:errcheck
+		if m.GetGauge().GetValue() != 1 {
+			t.Errorf("expected breach gauge=1, got %v", m.GetGauge().GetValue())
+		}
+	})
+
+	t.Run("no breach when durations are consistent", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+
+		for i := 0; i < 20; i++ {
+			store.RecordObservation(metricReleaseDuration, fmt.Sprintf("consistent-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), releaseLabels, 600.0, 10.0, true, "")
+		}
+
+		slo := newReleaseSLO30d(nil)
+		slo.updateGauges(store, nil)
+
+		m := &dto.Metric{}
+		slo.durationSLOBreach.WithLabelValues("c", "ns", "app", "comp", "true", "push").Write(m) //nolint:errcheck
+		if m.GetGauge().GetValue() != 0 {
+			t.Errorf("expected breach gauge=0, got %v", m.GetGauge().GetValue())
+		}
+	})
+
+	t.Run("insufficient data skips evaluation", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+
+		for i := 0; i < 5; i++ {
+			store.RecordObservation(metricReleaseDuration, fmt.Sprintf("sparse-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), releaseLabels, 1800.0, 10.0, true, "")
+		}
+
+		slo := newReleaseSLO30d(nil)
+		slo.updateGauges(store, nil)
+	})
+
+	t.Run("empty store does not panic", func(t *testing.T) {
+		store := NewStore()
+		slo := newReleaseSLO30d(nil)
+		slo.updateGauges(store, nil)
+	})
+}
+
+// ── SLO Config Override Tests ────────────────────────────────────────────────
+
+func TestSLOBreachWithConfigOverrides(t *testing.T) {
+	buildLabels := LabelSet{Cluster: "c", Namespace: "my-tenant", Application: "my-app", Component: "my-comp",
+		BuildType: "docker-builds", EventType: "push"}
+
+	populateConsistentBuilds := func(store *Store, labels LabelSet, duration float64, count int) {
+		now := time.Now().UTC()
+		for i := 0; i < count; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("b-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, duration, 10.0, true, "")
+		}
+	}
+
+	// Table-driven: consistent 300s builds, varying config hierarchy level and threshold
+	hierarchyTests := []struct {
+		name        string
+		cfg         *SLOConfig
+		wantBreach  float64
+		addOtherNS  bool        // also populate other-tenant (no override)
+		wantOther   float64     // expected breach for other-tenant when addOtherNS=true
+	}{
+		{
+			name: "global threshold exceeded",
+			cfg: &SLOConfig{
+				SLOThresholds: SLOThresholds{
+					BuildDurationThresholdSeconds: thresholdValueSimple(200),
+				},
+			},
+			wantBreach: 1,
+		},
+		{
+			name: "global threshold not exceeded",
+			cfg: &SLOConfig{
+				SLOThresholds: SLOThresholds{
+					BuildDurationThresholdSeconds: thresholdValueSimple(500),
+				},
+			},
+			wantBreach: 0,
+		},
+		{
+			name: "tenant-scoped override only affects matching namespace",
+			cfg: &SLOConfig{
+				Tenants: map[string]*TenantSLOConfig{
+					"my-tenant": {
+						SLOThresholds: SLOThresholds{
+							BuildDurationThresholdSeconds: thresholdValueSimple(200),
+						},
+					},
+				},
+			},
+			wantBreach: 1,
+			addOtherNS: true,
+			wantOther:  0,
+		},
+		{
+			name: "component overrides tenant",
+			cfg: newSLOCfg().
+				tenant("my-tenant").buildThreshold(500).
+				app("my-app").
+				comp("my-comp", SLOThresholds{BuildDurationThresholdSeconds: thresholdValueSimple(200)}).
+				build(),
+			wantBreach: 1,
+		},
+	}
+	for _, tt := range hierarchyTests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewStore()
+			populateConsistentBuilds(store, buildLabels, 300.0, 20)
+
+			if tt.addOtherNS {
+				otherLabels := buildLabels
+				otherLabels.Namespace = "other-tenant"
+				populateConsistentBuilds(store, otherLabels, 300.0, 20)
+			}
+
+			slo := newBuildSLO30d(tt.cfg)
+			slo.updateGauges(store, nil)
+
+			m := &dto.Metric{}
+			slo.durationSLOBreach.WithLabelValues("c", "my-tenant", "my-app", "my-comp", "docker-builds", "push").Write(m) //nolint:errcheck
+			if m.GetGauge().GetValue() != tt.wantBreach {
+				t.Errorf("my-tenant: expected breach=%v, got %v", tt.wantBreach, m.GetGauge().GetValue())
+			}
+
+			if tt.addOtherNS {
+				m = &dto.Metric{}
+				slo.durationSLOBreach.WithLabelValues("c", "other-tenant", "my-app", "my-comp", "docker-builds", "push").Write(m) //nolint:errcheck
+				if m.GetGauge().GetValue() != tt.wantOther {
+					t.Errorf("other-tenant: expected breach=%v, got %v", tt.wantOther, m.GetGauge().GetValue())
+				}
+			}
+		})
+	}
+
+	t.Run("breach percentage override relaxes threshold", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+
+		// 17 days at 300s, 3 days at 600s -> with stddev, 3 days breach
+		// 3/20 = 15% -> default 5% would trigger, but 20% override should not
+		for i := 0; i < 17; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("norm-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), buildLabels, 300.0, 10.0, true, "")
+		}
+		for i := 17; i < 20; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("slow-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), buildLabels, 600.0, 10.0, true, "")
+		}
+
+		cfg := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				BuildDurationBreachPercentage: thresholdValueSimple(0.20),
+			},
+		}
+		slo := newBuildSLO30d(cfg)
+		slo.updateGauges(store, nil)
+
+		m := &dto.Metric{}
+		slo.durationSLOBreach.WithLabelValues("c", "my-tenant", "my-app", "my-comp", "docker-builds", "push").Write(m) //nolint:errcheck
+		if m.GetGauge().GetValue() != 0 {
+			t.Errorf("expected breach=0 with 20%% override (15%% < 20%%), got %v", m.GetGauge().GetValue())
+		}
+	})
+
+	t.Run("integration domain override does not affect build", func(t *testing.T) {
+		store := NewStore()
+		populateConsistentBuilds(store, buildLabels, 300.0, 20)
+
+		cfg := &SLOConfig{
+			SLOThresholds: SLOThresholds{
+				IntegrationDurationThresholdSeconds: thresholdValueSimple(100),
+			},
+		}
+
+		resolved := cfg.Resolve(buildLabels, metricBuildDuration)
+		if resolved.DurationThreshold != nil {
+			t.Errorf("integration threshold should not apply to build, got %v", *resolved.DurationThreshold)
+		}
+
+		slo := newBuildSLO30d(cfg)
+		slo.updateGauges(store, nil)
+
+		m := &dto.Metric{}
+		slo.durationSLOBreach.WithLabelValues("c", "my-tenant", "my-app", "my-comp", "docker-builds", "push").Write(m) //nolint:errcheck
+		if m.GetGauge().GetValue() != 0 {
+			t.Errorf("expected breach=0 (integration override should not affect build domain), got %v", m.GetGauge().GetValue())
+		}
+	})
+}
+
+// ── Match-Based Config End-to-End Tests ──────────────────────────────────────
+
+func TestSLOBreachWithMatchBasedConfig(t *testing.T) {
+	now := time.Now().UTC()
+
+	populateIntegrationData := func(store *Store, scenario, eventType string, duration float64, count int) {
+		ls := LabelSet{
+			Cluster: "c", Namespace: "my-tenant", Application: "my-app", Component: "my-comp",
+			Scenario: scenario, EventType: eventType, TestType: "integration", Optional: "true",
+		}
+		for i := 0; i < count; i++ {
+			store.RecordObservation(metricIntegrationDuration,
+				fmt.Sprintf("%s-%s-%d", scenario, eventType, i),
+				now.Add(-time.Duration(i*24)*time.Hour), ls, duration, 5.0, true, "")
+		}
+	}
+
+	t.Run("different scenarios get different breach verdicts", func(t *testing.T) {
+		store := NewStore()
+
+		// ec-scan runs at ~50s, long-test push at ~800s, long-test PR at ~60s
+		populateIntegrationData(store, "ec-scan", "push", 50.0, 20)
+		populateIntegrationData(store, "long-test", "push", 800.0, 20)
+		populateIntegrationData(store, "long-test", "pull_request", 60.0, 20)
+
+		cfg := newSLOCfg().
+			tenant("my-tenant").
+			app("my-app").
+			comp("my-comp", SLOThresholds{
+				IntegrationDurationThresholdSeconds: &ThresholdValue{
+					Default: float64Ptr(120),
+					Matches: []ThresholdMatch{
+						{Scenario: "ec-scan", Value: 300},
+						{Scenario: "long-test", EventType: "push", Value: 900},
+					},
+				},
+			}).
+			build()
+
+		slo := newIntegrationSLO30d(cfg)
+		slo.updateGauges(store, nil)
+
+		type breachResult struct {
+			scenario  string
+			eventType string
+			breach    float64
+		}
+		var results []breachResult
+
+		store.ForEachWindow(metricIntegrationDuration, func(ls LabelSet, window *MetricWindow) {
+			if ls.Component != "my-comp" {
+				return
+			}
+			labels := []string{ls.Cluster, ls.Namespace, ls.Application, ls.Component, ls.Scenario, ls.Optional, ls.TestType, ls.EventType}
+
+			m := &dto.Metric{}
+			slo.durationSLOBreach.WithLabelValues(labels...).Write(m) //nolint:errcheck
+			results = append(results, breachResult{
+				scenario:  ls.Scenario,
+				eventType: ls.EventType,
+				breach:    m.GetGauge().GetValue(),
+			})
+		})
+
+		for _, r := range results {
+			switch {
+			case r.scenario == "ec-scan" && r.eventType == "push":
+				// 50s mean vs 300 threshold -> no breach
+				if r.breach != 0 {
+					t.Errorf("ec-scan/push: expected breach=0 (50s < 300s threshold), got %v", r.breach)
+				}
+			case r.scenario == "long-test" && r.eventType == "push":
+				// 800s mean vs 900 threshold -> no breach
+				if r.breach != 0 {
+					t.Errorf("long-test/push: expected breach=0 (800s < 900s match threshold), got %v", r.breach)
+				}
+			case r.scenario == "long-test" && r.eventType == "pull_request":
+				// 60s mean vs 120 default -> no breach
+				if r.breach != 0 {
+					t.Errorf("long-test/pull_request: expected breach=0 (60s < 120s default), got %v", r.breach)
+				}
+			}
+		}
+		if len(results) != 3 {
+			t.Errorf("expected 3 series with breach metrics, got %d", len(results))
+		}
+	})
+
+	t.Run("uncovered scenario falls to default and breaches", func(t *testing.T) {
+		store := NewStore()
+
+		// uncovered-scenario runs at 800s, only match is for ec-scan
+		populateIntegrationData(store, "uncovered-scenario", "push", 800.0, 20)
+
+		cfg := newSLOCfg().
+			tenant("my-tenant").
+			app("my-app").
+			comp("my-comp", SLOThresholds{
+				IntegrationDurationThresholdSeconds: &ThresholdValue{
+					Default: float64Ptr(120),
+					Matches: []ThresholdMatch{
+						{Scenario: "ec-scan", Value: 300},
+					},
+				},
+			}).
+			build()
+
+		slo := newIntegrationSLO30d(cfg)
+		slo.updateGauges(store, nil)
+
+		var found bool
+		store.ForEachWindow(metricIntegrationDuration, func(ls LabelSet, window *MetricWindow) {
+			if ls.Scenario != "uncovered-scenario" {
+				return
+			}
+			found = true
+			labels := []string{ls.Cluster, ls.Namespace, ls.Application, ls.Component, ls.Scenario, ls.Optional, ls.TestType, ls.EventType}
+			m := &dto.Metric{}
+			slo.durationSLOBreach.WithLabelValues(labels...).Write(m) //nolint:errcheck
+			if m.GetGauge().GetValue() != 1 {
+				t.Errorf("uncovered-scenario: expected breach=1 (800s > 120s default), got %v", m.GetGauge().GetValue())
+			}
+		})
+		if !found {
+			t.Error("uncovered-scenario series not found in store")
+		}
+	})
+
+	t.Run("matches-only config with no default preserves parent threshold", func(t *testing.T) {
+		store := NewStore()
+
+		// other-scenario runs at 800s; component has matches-only (no default),
+		// tenant has threshold=5000 which should be preserved
+		populateIntegrationData(store, "other-scenario", "push", 800.0, 20)
+
+		cfg := newSLOCfg().
+			tenant("my-tenant").integrationThreshold(5000).
+			app("my-app").
+			comp("my-comp", SLOThresholds{
+				IntegrationDurationThresholdSeconds: &ThresholdValue{
+					Matches: []ThresholdMatch{
+						{Scenario: "ec-scan", Value: 300},
+					},
+				},
+			}).
+			build()
+
+		slo := newIntegrationSLO30d(cfg)
+		slo.updateGauges(store, nil)
+
+		store.ForEachWindow(metricIntegrationDuration, func(ls LabelSet, window *MetricWindow) {
+			if ls.Scenario != "other-scenario" {
+				return
+			}
+			labels := []string{ls.Cluster, ls.Namespace, ls.Application, ls.Component, ls.Scenario, ls.Optional, ls.TestType, ls.EventType}
+			m := &dto.Metric{}
+			slo.durationSLOBreach.WithLabelValues(labels...).Write(m) //nolint:errcheck
+			// 800s vs tenant threshold 5000 (preserved because component match didn't fire) -> no breach
+			if m.GetGauge().GetValue() != 0 {
+				t.Errorf("other-scenario: expected breach=0 (800s < 5000s parent threshold), got %v", m.GetGauge().GetValue())
+			}
+		})
+	})
+
+	t.Run("unmatched scenario with no parent threshold falls to mean+stddev", func(t *testing.T) {
+		store := NewStore()
+
+		// ec-scan: 50s mean. Match sets fixed threshold=60, and 50 < 60 -> no breach.
+		// If it fell to mean+stddev instead, threshold would be ~50 (stddev~=0),
+		// and daily means = 50, not > 50, also no breach -- so we need ec-scan
+		// to prove the match fires by using a threshold that differs from mean+stddev.
+		populateIntegrationData(store, "ec-scan", "push", 50.0, 20)
+
+		// other-scenario: consistent 300s with a few spikes.
+		// mean+stddev with consistent data -> stddev~=0, threshold~=300,
+		// daily means = 300, not > 300 -> no breach under statistical baseline.
+		// BUT if a fixed threshold like ec-scan's 60 were applied, 300 >> 60 -> breach.
+		// So breach=0 here proves it's using mean+stddev, not the ec-scan match.
+		populateIntegrationData(store, "other-scenario", "push", 300.0, 20)
+
+		cfg := newSLOCfg().
+			tenant("my-tenant").
+			app("my-app").
+			comp("my-comp", SLOThresholds{
+				IntegrationDurationThresholdSeconds: &ThresholdValue{
+					Matches: []ThresholdMatch{
+						{Scenario: "ec-scan", Value: 60},
+					},
+				},
+			}).
+			build()
+
+		slo := newIntegrationSLO30d(cfg)
+		slo.updateGauges(store, nil)
+
+		store.ForEachWindow(metricIntegrationDuration, func(ls LabelSet, window *MetricWindow) {
+			labels := []string{ls.Cluster, ls.Namespace, ls.Application, ls.Component, ls.Scenario, ls.Optional, ls.TestType, ls.EventType}
+			m := &dto.Metric{}
+			slo.durationSLOBreach.WithLabelValues(labels...).Write(m) //nolint:errcheck
+
+			switch ls.Scenario {
+			case "ec-scan":
+				// 50s mean vs 60 fixed threshold -> no breach
+				if m.GetGauge().GetValue() != 0 {
+					t.Errorf("ec-scan: expected breach=0 (50s < 60s match threshold), got %v", m.GetGauge().GetValue())
+				}
+			case "other-scenario":
+				// 300s consistent -> mean+stddev threshold ~300, daily means not > 300 -> no breach
+				// If the ec-scan match (60) leaked here, 300 >> 60 would breach=1
+				if m.GetGauge().GetValue() != 0 {
+					t.Errorf("other-scenario: expected breach=0 (using mean+stddev, not ec-scan's 60s), got %v", m.GetGauge().GetValue())
+				}
+			}
+		})
+	})
+}
+
+// ── Skip Breach Map Construction Tests ───────────────────────────────────────
+
+func TestSkipBreachNamespacesFromStates(t *testing.T) {
+	tests := []struct {
+		name        string
+		states      map[string]*nsBootstrapState
+		wantNil     bool
+		wantLen     int
+		wantPresent []string
+		wantAbsent  []string
+	}{
+		{
+			name:    "nil map returns nil",
+			states:  nil,
+			wantNil: true,
+		},
+		{
+			name: "all bootstrapped returns nil",
+			states: map[string]*nsBootstrapState{
+				"ns-a": {Bootstrapped: true},
+				"ns-b": {Bootstrapped: true},
+			},
+			wantNil: true,
+		},
+		{
+			name: "mixed states returns only un-bootstrapped",
+			states: map[string]*nsBootstrapState{
+				"bootstrapped-ns": {Bootstrapped: true},
+				"pending-ns":      {Bootstrapped: false},
+				"another-pending": {Bootstrapped: false, GapAttempts: 2},
+			},
+			wantLen:     2,
+			wantPresent: []string{"pending-ns", "another-pending"},
+			wantAbsent:  []string{"bootstrapped-ns"},
+		},
+		{
+			name: "all un-bootstrapped returns all",
+			states: map[string]*nsBootstrapState{
+				"ns-a": {Bootstrapped: false},
+				"ns-b": {Bootstrapped: false},
+			},
+			wantLen:     2,
+			wantPresent: []string{"ns-a", "ns-b"},
+		},
+		{
+			name: "exhausted retries not skipped",
+			states: map[string]*nsBootstrapState{
+				"still-trying": {Bootstrapped: false, GapAttempts: 3},
+				"gave-up":      {Bootstrapped: false, GapAttempts: 5},
+			},
+			wantLen:     1,
+			wantPresent: []string{"still-trying"},
+			wantAbsent:  []string{"gave-up"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skip := skipBreachNamespacesFromStates(tt.states)
+			if tt.wantNil {
+				if skip != nil {
+					t.Errorf("expected nil, got %v", skip)
+				}
+				return
+			}
+			if len(skip) != tt.wantLen {
+				t.Fatalf("expected %d entries, got %d: %v", tt.wantLen, len(skip), skip)
+			}
+			for _, ns := range tt.wantPresent {
+				if !skip[ns] {
+					t.Errorf("%s should be in skip set", ns)
+				}
+			}
+			for _, ns := range tt.wantAbsent {
+				if skip[ns] {
+					t.Errorf("%s should not be in skip set", ns)
+				}
+			}
+		})
+	}
+}
+
+// ── Gap-Fill Breach Skip Tests ───────────────────────────────────────────────
+
+func TestBreachSkippedDuringGapFill(t *testing.T) {
+	labels := LabelSet{Cluster: "c", Namespace: "gapfill-tenant", Application: "app", Component: "comp",
+		BuildType: "docker-builds", EventType: "push"}
+
+	populateBreachingData := func(store *Store) {
+		now := time.Now().UTC()
+		for i := 3; i < 23; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("normal-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, 300.0, 10.0, true, "")
+		}
+		for i := 0; i < 3; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("slow-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, 900.0, 10.0, true, "")
+		}
+	}
+
+	t.Run("breach emitted when namespace is not in skip set", func(t *testing.T) {
+		store := NewStore()
+		populateBreachingData(store)
+
+		slo := newBuildSLO30d(nil)
+		slo.updateGauges(store, nil)
+
+		ch := make(chan prometheus.Metric, 100)
+		slo.durationSLOBreach.Collect(ch)
+		close(ch)
+		count := 0
+		for range ch {
+			count++
+		}
+		if count == 0 {
+			t.Error("breach metric should be emitted when namespace is not skipped")
+		}
+	})
+
+	t.Run("breach not emitted when namespace is in skip set", func(t *testing.T) {
+		store := NewStore()
+		populateBreachingData(store)
+
+		skip := map[string]bool{"gapfill-tenant": true}
+		slo := newBuildSLO30d(nil)
+		slo.updateGauges(store, skip)
+
+		ch := make(chan prometheus.Metric, 100)
+		slo.durationSLOBreach.Collect(ch)
+		close(ch)
+		count := 0
+		for range ch {
+			count++
+		}
+		if count != 0 {
+			t.Error("breach metric should NOT be emitted when namespace is being gap-filled")
+		}
+	})
+
+	t.Run("base metrics still emitted when namespace is in skip set", func(t *testing.T) {
+		store := NewStore()
+		populateBreachingData(store)
+
+		skip := map[string]bool{"gapfill-tenant": true}
+		slo := newBuildSLO30d(nil)
+		slo.updateGauges(store, skip)
+
+		ch := make(chan prometheus.Metric, 100)
+		slo.totalCount30d.Collect(ch)
+		close(ch)
+		count := 0
+		for range ch {
+			count++
+		}
+		if count == 0 {
+			t.Error("base metrics (total_count) should still be emitted during gap-fill")
+		}
+	})
+
+	t.Run("other namespaces unaffected by skip set", func(t *testing.T) {
+		store := NewStore()
+		populateBreachingData(store)
+
+		otherLabels := labels
+		otherLabels.Namespace = "healthy-tenant"
+		now := time.Now().UTC()
+		for i := 3; i < 23; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("other-normal-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), otherLabels, 300.0, 10.0, true, "")
+		}
+		for i := 0; i < 3; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("other-slow-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), otherLabels, 900.0, 10.0, true, "")
+		}
+
+		skip := map[string]bool{"gapfill-tenant": true}
+		slo := newBuildSLO30d(nil)
+		slo.updateGauges(store, skip)
+
+		ch := make(chan prometheus.Metric, 100)
+		slo.durationSLOBreach.Collect(ch)
+		close(ch)
+		count := 0
+		for range ch {
+			count++
+		}
+		if count != 1 {
+			t.Errorf("expected 1 breach metric (healthy-tenant only), got %d", count)
+		}
+	})
+}
+
 // ── Test Helpers ──────────────────────────────────────────────────────────────
+
+func testCutoff() string {
+	return time.Now().UTC().AddDate(0, 0, -30).Format("2006-01-02")
+}
 
 func assertEqual[T comparable](t *testing.T, name string, got, want T) {
 	t.Helper()
@@ -734,3 +1912,4 @@ func assertFloat(t *testing.T, name string, got, want float64) {
 		t.Errorf("%s = %f, want %f", name, got, want)
 	}
 }
+

--- a/exporters/kaexporter/release.go
+++ b/exporters/kaexporter/release.go
@@ -17,10 +17,10 @@ type ReleaseSLO30d struct {
 }
 
 // newReleaseSLO30d initializes release 30d SLO metrics
-func newReleaseSLO30d() *ReleaseSLO30d {
+func newReleaseSLO30d(sloConfig *SLOConfig) *ReleaseSLO30d {
 	labels := []string{"cluster", "namespace", "application", "component", "automated", "event_type"}
 	return &ReleaseSLO30d{
-		SLOGaugeSet: newSLOGaugeSet("konflux_release_cr", "Release CR", labels),
+		SLOGaugeSet: newSLOGaugeSet("konflux_release_cr", "Release CR", labels, sloConfig, metricReleaseDuration),
 	}
 }
 
@@ -110,10 +110,10 @@ func (m *ReleaseSLO30d) recordAllFromIndex(
 }
 
 // updateGauges reads from the rolling store and updates the 30d SLO gauges
-func (m *ReleaseSLO30d) updateGauges(store *Store) {
+func (m *ReleaseSLO30d) updateGauges(store *Store, skipBreachNamespaces map[string]bool) {
 	m.SLOGaugeSet.UpdateFromStore(store, metricReleaseDuration, func(ls LabelSet) []string {
 		return []string{ls.Cluster, ls.Namespace, ls.Application, ls.Component, ls.Automated, ls.EventType}
-	})
+	}, skipBreachNamespaces)
 }
 
 // Describe implements prometheus.Collector

--- a/exporters/kaexporter/rolling_store.go
+++ b/exporters/kaexporter/rolling_store.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -53,12 +54,13 @@ func (l LabelSet) String() string {
 
 // DailyBucket holds per-day aggregates for one label set.
 type DailyBucket struct {
-	Day               string           `json:"day"`
-	Count             int64            `json:"count"`               // All completed PLRs
-	SuccessCount      int64            `json:"success_count"`       // Count of successful PLRs
-	SuccessSumSeconds float64          `json:"success_sum_seconds"` // Duration sum of successful PLRs
-	WaitSumSeconds    float64          `json:"wait_sum_seconds"`    // Wait time sum ofsuccesful PLRs
-	FailureReasons    map[string]int64 `json:"failure_reasons"`     // Failure count by reason
+	Day                      string           `json:"day"`
+	Count                    int64            `json:"count"`                        // All completed PLRs
+	SuccessCount             int64            `json:"success_count"`                // Count of successful PLRs
+	SuccessSumSeconds        float64          `json:"success_sum_seconds"`          // Duration sum of successful PLRs
+	SuccessSumSquaredSeconds float64          `json:"success_sum_squared_seconds"`  // Sum of squared durations (for stddev)
+	WaitSumSeconds           float64          `json:"wait_sum_seconds"`             // Wait time sum of successful PLRs
+	FailureReasons           map[string]int64 `json:"failure_reasons"`              // Failure count by reason
 }
 
 // MetricWindow is a fixed 30-day circular buffer indexed by day offset.
@@ -128,6 +130,7 @@ func (s *Store) RecordObservation(
 	if succeeded {
 		bucket.SuccessCount++
 		bucket.SuccessSumSeconds += durationSeconds
+		bucket.SuccessSumSquaredSeconds += durationSeconds * durationSeconds
 		// Only accumulate wait time for successful PLRs to match SuccessCount denominator
 		if waitSeconds >= 0 {
 			bucket.WaitSumSeconds += waitSeconds
@@ -143,8 +146,7 @@ func (s *Store) RecordObservation(
 }
 
 // ComputeSuccessMean returns the mean duration for successful PLRs only.
-func (w *MetricWindow) ComputeSuccessMean() float64 {
-	cutoff := time.Now().UTC().AddDate(0, 0, -30).Format("2006-01-02")
+func (w *MetricWindow) ComputeSuccessMean(cutoff string) float64 {
 	var sum float64
 	var count int64
 	for i := range w.Buckets {
@@ -161,8 +163,7 @@ func (w *MetricWindow) ComputeSuccessMean() float64 {
 }
 
 // ComputeWaitMean returns the mean wait time across successful observations only.
-func (w *MetricWindow) ComputeWaitMean() float64 {
-	cutoff := time.Now().UTC().AddDate(0, 0, -30).Format("2006-01-02")
+func (w *MetricWindow) ComputeWaitMean(cutoff string) float64 {
 	var sum float64
 	var count int64
 	for i := range w.Buckets {
@@ -180,8 +181,7 @@ func (w *MetricWindow) ComputeWaitMean() float64 {
 
 // ComputeTotalCount returns the total Count across all fresh buckets (within 30 days).
 // Used for both empty window detection and total_count_30d gauge.
-func (w *MetricWindow) ComputeTotalCount() int64 {
-	cutoff := time.Now().UTC().AddDate(0, 0, -30).Format("2006-01-02")
+func (w *MetricWindow) ComputeTotalCount(cutoff string) int64 {
 	var count int64
 	for i := range w.Buckets {
 		if w.Buckets[i].Day == "" || w.Buckets[i].Day <= cutoff {
@@ -194,8 +194,7 @@ func (w *MetricWindow) ComputeTotalCount() int64 {
 
 // ComputeSuccessCount returns the total number of successful observations (within 30 days).
 // Used to determine if mean_duration_30d metrics should be emitted (only when successes exist).
-func (w *MetricWindow) ComputeSuccessCount() int64 {
-	cutoff := time.Now().UTC().AddDate(0, 0, -30).Format("2006-01-02")
+func (w *MetricWindow) ComputeSuccessCount(cutoff string) int64 {
 	var count int64
 	for i := range w.Buckets {
 		if w.Buckets[i].Day == "" || w.Buckets[i].Day <= cutoff {
@@ -208,8 +207,7 @@ func (w *MetricWindow) ComputeSuccessCount() int64 {
 
 // ComputeFailureReasons returns aggregated failure counts by reason across all buckets.
 // Skips stale buckets (older than 30 days from today).
-func (w *MetricWindow) ComputeFailureReasons() map[string]int64 {
-	cutoff := time.Now().UTC().AddDate(0, 0, -30).Format("2006-01-02")
+func (w *MetricWindow) ComputeFailureReasons(cutoff string) map[string]int64 {
 	aggregated := make(map[string]int64)
 	for i := range w.Buckets {
 		if w.Buckets[i].Day == "" || w.Buckets[i].Day <= cutoff {
@@ -220,6 +218,49 @@ func (w *MetricWindow) ComputeFailureReasons() map[string]int64 {
 		}
 	}
 	return aggregated
+}
+
+// ComputeSuccessStdDev returns the population standard deviation of successful
+// durations across all fresh buckets (within 30 days).
+func (w *MetricWindow) ComputeSuccessStdDev(cutoff string) float64 {
+	var sum, sumSq float64
+	var count int64
+	for i := range w.Buckets {
+		if w.Buckets[i].Day == "" || w.Buckets[i].Day <= cutoff {
+			continue
+		}
+		sum += w.Buckets[i].SuccessSumSeconds
+		sumSq += w.Buckets[i].SuccessSumSquaredSeconds
+		count += w.Buckets[i].SuccessCount
+	}
+	if count <= 1 {
+		return 0
+	}
+	mean := sum / float64(count)
+	variance := (sumSq / float64(count)) - (mean * mean)
+	if variance < 0 {
+		variance = 0
+	}
+	return math.Sqrt(variance)
+}
+
+// CountBreachingDays counts how many daily buckets (with successful observations)
+// have a daily mean duration exceeding the given threshold.
+func (w *MetricWindow) CountBreachingDays(cutoff string, threshold float64) (breachingDays, totalDaysWithData int) {
+	for i := range w.Buckets {
+		if w.Buckets[i].Day == "" || w.Buckets[i].Day <= cutoff {
+			continue
+		}
+		if w.Buckets[i].SuccessCount == 0 {
+			continue
+		}
+		totalDaysWithData++
+		dailyMean := w.Buckets[i].SuccessSumSeconds / float64(w.Buckets[i].SuccessCount)
+		if dailyMean > threshold {
+			breachingDays++
+		}
+	}
+	return breachingDays, totalDaysWithData
 }
 
 // PruneSeenKeys removes entries older than retention.
@@ -266,18 +307,21 @@ func (s *Store) getOrCreateLocked(metricName string, labelSet LabelSet) *MetricW
 
 // SLOGaugeSet holds the common set of 30-day SLO gauges shared across
 // build, integration, and release metrics. Domain-specific modules embed
-// this struct and add their own record logic + any extra gauges.
+// this struct and add their own record logic.
 type SLOGaugeSet struct {
-	mean30d         *prometheus.GaugeVec
-	meanWait30d     *prometheus.GaugeVec
-	totalCount30d   *prometheus.GaugeVec
-	successCount30d *prometheus.GaugeVec
-	failureCount30d *prometheus.GaugeVec
+	mean30d           *prometheus.GaugeVec
+	meanWait30d       *prometheus.GaugeVec
+	totalCount30d     *prometheus.GaugeVec
+	successCount30d   *prometheus.GaugeVec
+	failureCount30d   *prometheus.GaugeVec
+	durationSLOBreach *prometheus.GaugeVec
+	sloConfig         *SLOConfig
+	domain            string
 }
 
 // newSLOGaugeSet creates the common gauge set. The failureCount gauge
 // automatically appends a "reason" label to the provided base labels.
-func newSLOGaugeSet(prefix, helpContext string, labels []string) SLOGaugeSet {
+func newSLOGaugeSet(prefix, helpContext string, labels []string, sloConfig *SLOConfig, domain string) SLOGaugeSet {
 	failureLabels := make([]string, len(labels)+1)
 	copy(failureLabels, labels)
 	failureLabels[len(labels)] = "reason"
@@ -303,42 +347,91 @@ func newSLOGaugeSet(prefix, helpContext string, labels []string) SLOGaugeSet {
 			Name: prefix + "_failure_count_30d",
 			Help: fmt.Sprintf("%s failure count over the past 30 days, broken down by failure reason.", helpContext),
 		}, failureLabels),
+		durationSLOBreach: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: prefix + "_duration_slo_breach",
+			Help: fmt.Sprintf("1 if %s duration SLO is breached (daily means exceed configured threshold for configured percentage of days), 0 otherwise. Not emitted when data is insufficient.", helpContext),
+		}, labels),
+		sloConfig: sloConfig,
+		domain:    domain,
 	}
 }
 
 // UpdateFromStore resets all gauges and repopulates from the rolling store.
 // labelExtractor converts a LabelSet into the ordered label values for this gauge set.
-func (s *SLOGaugeSet) UpdateFromStore(store *Store, metricName string, labelExtractor func(LabelSet) []string) {
+// skipBreachNamespaces, when non-nil, suppresses breach evaluation for namespaces
+// that have not completed their 30-day bootstrap (prevents false positives from
+// partial data during gap-fill).
+func (s *SLOGaugeSet) UpdateFromStore(store *Store, metricName string, labelExtractor func(LabelSet) []string, skipBreachNamespaces map[string]bool) {
 	s.mean30d.Reset()
 	s.meanWait30d.Reset()
 	s.totalCount30d.Reset()
 	s.successCount30d.Reset()
 	s.failureCount30d.Reset()
+	s.durationSLOBreach.Reset()
+
+	cutoff := time.Now().UTC().AddDate(0, 0, -30).Format("2006-01-02")
 
 	store.ForEachWindow(metricName, func(ls LabelSet, window *MetricWindow) {
-		totalCount := window.ComputeTotalCount()
+		totalCount := window.ComputeTotalCount(cutoff)
 		if totalCount == 0 {
 			return
 		}
 
 		labels := labelExtractor(ls)
 
-		successCount := window.ComputeSuccessCount()
+		successCount := window.ComputeSuccessCount(cutoff)
 
 		s.totalCount30d.WithLabelValues(labels...).Set(float64(totalCount))
 		s.successCount30d.WithLabelValues(labels...).Set(float64(successCount))
 
+		var successMean float64
 		if successCount > 0 {
-			s.mean30d.WithLabelValues(labels...).Set(window.ComputeSuccessMean())
-			s.meanWait30d.WithLabelValues(labels...).Set(window.ComputeWaitMean())
+			successMean = window.ComputeSuccessMean(cutoff)
+			s.mean30d.WithLabelValues(labels...).Set(successMean)
+			s.meanWait30d.WithLabelValues(labels...).Set(window.ComputeWaitMean(cutoff))
 		}
 
-		for reason, count := range window.ComputeFailureReasons() {
+		for reason, count := range window.ComputeFailureReasons(cutoff) {
 			reasonLabels := make([]string, len(labels)+1)
 			copy(reasonLabels, labels)
 			reasonLabels[len(labels)] = reason
 			s.failureCount30d.WithLabelValues(reasonLabels...).Set(float64(count))
 		}
+
+		// SLO breach evaluation skip for namespaces still gap-filling
+		if skipBreachNamespaces[ls.Namespace] {
+			return
+		}
+		if successCount < minSuccessCountForSLO {
+			return
+		}
+
+		resolved := s.sloConfig.Resolve(ls, s.domain)
+
+		var threshold float64
+		if resolved.DurationThreshold != nil {
+			threshold = *resolved.DurationThreshold
+		} else {
+			threshold = successMean + sloThresholdK*window.ComputeSuccessStdDev(cutoff)
+		}
+		if threshold <= 0 {
+			return
+		}
+
+		breachPct := sloBreachPercentage
+		if resolved.BreachPercentage != nil {
+			breachPct = *resolved.BreachPercentage
+		}
+
+		breachingDays, totalDays := window.CountBreachingDays(cutoff, threshold)
+		if totalDays < minDaysWithDataForSLO {
+			return
+		}
+		var breach float64
+		if float64(breachingDays)/float64(totalDays) >= breachPct {
+			breach = 1
+		}
+		s.durationSLOBreach.WithLabelValues(labels...).Set(breach)
 	})
 }
 
@@ -349,6 +442,7 @@ func (s *SLOGaugeSet) Describe(ch chan<- *prometheus.Desc) {
 	s.totalCount30d.Describe(ch)
 	s.successCount30d.Describe(ch)
 	s.failureCount30d.Describe(ch)
+	s.durationSLOBreach.Describe(ch)
 }
 
 // Collect emits current metric values for all gauges in the set.
@@ -358,6 +452,7 @@ func (s *SLOGaugeSet) Collect(ch chan<- prometheus.Metric) {
 	s.totalCount30d.Collect(ch)
 	s.successCount30d.Collect(ch)
 	s.failureCount30d.Collect(ch)
+	s.durationSLOBreach.Collect(ch)
 }
 
 // Metric names used by the exporter.
@@ -366,3 +461,12 @@ const (
 	metricIntegrationDuration = "integration_duration"
 	metricReleaseDuration     = "release_duration"
 )
+
+// SLO breach evaluation constants.
+const (
+	sloThresholdK         = 1.0  // threshold = mean + k*stddev
+	sloBreachPercentage   = 0.05 // fraction of daily means that must exceed threshold
+	minSuccessCountForSLO = 10   // minimum observations before evaluating SLO
+	minDaysWithDataForSLO = 3    // minimum days with successful observations before evaluating SLO
+)
+

--- a/exporters/kaexporter/test_helpers_test.go
+++ b/exporters/kaexporter/test_helpers_test.go
@@ -1,0 +1,183 @@
+package main
+
+// ── LabelSet test constants ─────────────────────────────────────────────────
+
+var (
+	buildLabelShort = LabelSet{
+		Cluster: "c", Namespace: "ns", Application: "app", Component: "comp",
+		BuildType: "docker-builds", EventType: "push",
+	}
+	integrationLabelShort = LabelSet{
+		Cluster: "c", Namespace: "ns", Application: "app", Component: "comp",
+		Scenario: "my-scenario", Optional: "false", TestType: "integration", EventType: "push",
+	}
+	releaseLabelShort = LabelSet{
+		Cluster: "c", Namespace: "ns", Application: "app", Component: "comp",
+		Automated: "true", EventType: "push",
+	}
+)
+
+// ── SLOConfig builder ───────────────────────────────────────────────────────
+
+type sloConfigBuilder struct {
+	cfg SLOConfig
+}
+
+func newSLOCfg() *sloConfigBuilder {
+	return &sloConfigBuilder{}
+}
+
+//nolint:unused
+func (b *sloConfigBuilder) buildThreshold(v float64) *sloConfigBuilder {
+	b.cfg.BuildDurationThresholdSeconds = thresholdValueSimple(v)
+	return b
+}
+
+//nolint:unused
+func (b *sloConfigBuilder) buildBreachPct(v float64) *sloConfigBuilder {
+	b.cfg.BuildDurationBreachPercentage = thresholdValueSimple(v)
+	return b
+}
+
+//nolint:unused
+func (b *sloConfigBuilder) integrationThreshold(v float64) *sloConfigBuilder {
+	b.cfg.IntegrationDurationThresholdSeconds = thresholdValueSimple(v)
+	return b
+}
+
+//nolint:unused
+func (b *sloConfigBuilder) integrationBreachPct(v float64) *sloConfigBuilder {
+	b.cfg.IntegrationDurationBreachPercentage = thresholdValueSimple(v)
+	return b
+}
+
+//nolint:unused
+func (b *sloConfigBuilder) releaseThreshold(v float64) *sloConfigBuilder {
+	b.cfg.ReleaseDurationThresholdSeconds = thresholdValueSimple(v)
+	return b
+}
+
+func (b *sloConfigBuilder) releaseBreachPct(v float64) *sloConfigBuilder {
+	b.cfg.ReleaseDurationBreachPercentage = thresholdValueSimple(v)
+	return b
+}
+
+func (b *sloConfigBuilder) tenant(name string) *tenantBuilder {
+	if b.cfg.Tenants == nil {
+		b.cfg.Tenants = make(map[string]*TenantSLOConfig)
+	}
+	t := &TenantSLOConfig{}
+	b.cfg.Tenants[name] = t
+	return &tenantBuilder{root: b, cfg: t}
+}
+
+func (b *sloConfigBuilder) build() *SLOConfig {
+	return &b.cfg
+}
+
+// ── Tenant builder ──────────────────────────────────────────────────────────
+
+type tenantBuilder struct {
+	root *sloConfigBuilder
+	cfg  *TenantSLOConfig
+}
+
+func (tb *tenantBuilder) buildThreshold(v float64) *tenantBuilder {
+	tb.cfg.BuildDurationThresholdSeconds = thresholdValueSimple(v)
+	return tb
+}
+
+//nolint:unused
+func (tb *tenantBuilder) buildBreachPct(v float64) *tenantBuilder {
+	tb.cfg.BuildDurationBreachPercentage = thresholdValueSimple(v)
+	return tb
+}
+
+func (tb *tenantBuilder) integrationThreshold(v float64) *tenantBuilder {
+	tb.cfg.IntegrationDurationThresholdSeconds = thresholdValueSimple(v)
+	return tb
+}
+
+//nolint:unused
+func (tb *tenantBuilder) integrationBreachPct(v float64) *tenantBuilder {
+	tb.cfg.IntegrationDurationBreachPercentage = thresholdValueSimple(v)
+	return tb
+}
+
+//nolint:unused
+func (tb *tenantBuilder) releaseThreshold(v float64) *tenantBuilder {
+	tb.cfg.ReleaseDurationThresholdSeconds = thresholdValueSimple(v)
+	return tb
+}
+
+//nolint:unused
+func (tb *tenantBuilder) releaseBreachPct(v float64) *tenantBuilder {
+	tb.cfg.ReleaseDurationBreachPercentage = thresholdValueSimple(v)
+	return tb
+}
+
+func (tb *tenantBuilder) app(name string) *appBuilder {
+	if tb.cfg.Applications == nil {
+		tb.cfg.Applications = make(map[string]*ApplicationSLOConfig)
+	}
+	a := &ApplicationSLOConfig{}
+	tb.cfg.Applications[name] = a
+	return &appBuilder{tenant: tb, cfg: a}
+}
+
+func (tb *tenantBuilder) build() *SLOConfig {
+	return tb.root.build()
+}
+
+// ── App builder ─────────────────────────────────────────────────────────────
+
+type appBuilder struct {
+	tenant *tenantBuilder
+	cfg    *ApplicationSLOConfig
+}
+
+func (ab *appBuilder) buildThreshold(v float64) *appBuilder {
+	ab.cfg.BuildDurationThresholdSeconds = thresholdValueSimple(v)
+	return ab
+}
+
+//nolint:unused
+func (ab *appBuilder) buildBreachPct(v float64) *appBuilder {
+	ab.cfg.BuildDurationBreachPercentage = thresholdValueSimple(v)
+	return ab
+}
+
+//nolint:unused
+func (ab *appBuilder) integrationThreshold(v float64) *appBuilder {
+	ab.cfg.IntegrationDurationThresholdSeconds = thresholdValueSimple(v)
+	return ab
+}
+
+//nolint:unused
+func (ab *appBuilder) integrationBreachPct(v float64) *appBuilder {
+	ab.cfg.IntegrationDurationBreachPercentage = thresholdValueSimple(v)
+	return ab
+}
+
+func (ab *appBuilder) releaseThreshold(v float64) *appBuilder {
+	ab.cfg.ReleaseDurationThresholdSeconds = thresholdValueSimple(v)
+	return ab
+}
+
+//nolint:unused
+func (ab *appBuilder) releaseBreachPct(v float64) *appBuilder {
+	ab.cfg.ReleaseDurationBreachPercentage = thresholdValueSimple(v)
+	return ab
+}
+
+func (ab *appBuilder) comp(name string, thresholds SLOThresholds) *appBuilder {
+	if ab.cfg.Components == nil {
+		ab.cfg.Components = make(map[string]*ComponentSLOConfig)
+	}
+	ab.cfg.Components[name] = &ComponentSLOConfig{SLOThresholds: thresholds}
+	return ab
+}
+
+func (ab *appBuilder) build() *SLOConfig {
+	return ab.tenant.build()
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/lib/pq v1.12.3
 	github.com/prometheus/client_golang v1.23.2
+	k8s.io/apimachinery v0.35.3
 )
 
 require (
@@ -48,7 +49,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/api v0.35.3 // indirect
-	k8s.io/apimachinery v0.35.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260618221249-bc653b64f974 // indirect
 	k8s.io/utils v0.0.0-20260617174310-a95e086a2553 // indirect
@@ -69,7 +69,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sys v0.46.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/client-go v0.35.3
 	sigs.k8s.io/controller-runtime v0.23.3
 )


### PR DESCRIPTION
### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

Jira: [PVO11Y-5367](https://redhat.atlassian.net/browse/PVO11Y-5367)

Add duration SLO breach gauge (1/0) for build, integration, and release metrics. Breaches when >=5% of daily mean durations over 30 days exceed mean + 1 stddev. Suppressed during bootstrap gap-fill to avoid false positives.

Config file gains a customSLO section for overriding thresholds and breach percentages per tenant, application, or component.

Once those custom overrides are needed, they will be happening in infra-deployments as needed.

We might need to increase memory limits a bit with this change, will see how stage handles.

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [X] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [X] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [X] **Pipeline Finished Successfully**


---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.


[PVO11Y-5367]: https://redhat.atlassian.net/browse/PVO11Y-5367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ