### PR TITLE
fix(SPRE-5243:RegistryExporterNodeFailure)change alert to fire on >50…

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
@@ -52,17 +52,25 @@ spec:
         alert_routing_key: o11y
         team: o11y
 
-  # Notify o11y team when there are issues with individual nodes, but cluster-level check is still passing.
+  # Notify o11y team when a significant percentage of nodes are failing, but cluster-level check is still passing.
   - name: registry-exporter-node-availability
     interval: 1m
     rules:
     - alert: RegistryExporterNodeFailure
       expr: |
-        min by(source_cluster, tested_registry, node) (
-          registry_exporter_success
-          unless on(source_cluster, tested_registry, type)
-            (max by(source_cluster, tested_registry, type) (registry_exporter_success) == 0)
-        ) == 0
+        (
+          count by(source_cluster, tested_registry) (
+            min by(source_cluster, tested_registry, node) (
+              registry_exporter_success
+              unless on(source_cluster, tested_registry, type)
+                (max by(source_cluster, tested_registry, type) (registry_exporter_success) == 0)
+            ) == 0
+          )
+          /
+          count by(source_cluster, tested_registry) (
+            min by(source_cluster, tested_registry, node) (registry_exporter_success)
+          )
+        ) > 0.50
         and on(source_cluster, tested_registry)
           label_replace(
             konflux_up{service="registry-exporter"} == 1,
@@ -75,10 +83,11 @@ spec:
         component: registry-exporter
       annotations:
         summary: >-
-          Registry exporter running tests on node {{ $labels.node }} for registry {{ $labels.tested_registry }} in cluster {{ $labels.source_cluster }} is failing.
+          Over 50% of registry exporter nodes in cluster {{ $labels.source_cluster }} are failing tests for registry {{ $labels.tested_registry }}.
         description: >-
-          Registry exporter running tests on node {{ $labels.node }} for registry {{ $labels.tested_registry }} in cluster {{ $labels.source_cluster }} is failing.
-          At least one test type (pull, push, metadata, or authentication) has been failing for 15 minutes.
-          The cluster-level check for this registry is still passing, indicating this is a node-specific issue.
+          {{ $value | humanizePercentage }} of registry exporter nodes in cluster {{ $labels.source_cluster }} are failing tests for registry {{ $labels.tested_registry }}.
+          Over 50% of nodes have had at least one failing test type (pull, push, metadata, or authentication); this condition has persisted for 15 minutes.
+          The cluster-level check is still passing, indicating this is not a total outage.
+          Single-node failures from rolling node replacements will not trigger this alert.
         alert_routing_key: o11y
         team: o11y

--- a/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
+++ b/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
@@ -347,110 +347,9 @@ tests:
         alertname: RegistryExporterNodeFailure
         exp_alerts: []
 
-  # Registry exporter node-level alert tests
-  # Node failure when cluster is up (should alert)
-  - interval: 1m
-    input_series:
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="metadata", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="authentication", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="metadata", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="authentication", source_cluster="c1"}'
-        values: "1x16"
+  # Registry exporter node percentage alert tests
 
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: RegistryExporterNodeFailure
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              tested_registry: quay.io
-              node: node1
-              source_cluster: c1
-              slo: "false"
-              component: registry-exporter
-            exp_annotations:
-              summary: >-
-                Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
-              description: >-
-                Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
-                At least one test type (pull, push, metadata, or authentication) has been failing for 15 minutes.
-                The cluster-level check for this registry is still passing, indicating this is a node-specific issue.
-              alert_routing_key: o11y
-              team: o11y
-
-  # Node-specific failure alongside cluster-wide type failure (should alert for node-specific issue only)
-  # Push fails cluster-wide (covered by TestTypeFailure), pull fails only on node1 (node-specific)
-  - interval: 1m
-    input_series:
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="metadata", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="metadata", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="authentication", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="authentication", source_cluster="c1"}'
-        values: "1x16"
-
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: RegistryExporterNodeFailure
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              tested_registry: quay.io
-              node: node1
-              source_cluster: c1
-              slo: "false"
-              component: registry-exporter
-            exp_annotations:
-              summary: >-
-                Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
-              description: >-
-                Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
-                At least one test type (pull, push, metadata, or authentication) has been failing for 15 minutes.
-                The cluster-level check for this registry is still passing, indicating this is a node-specific issue.
-              alert_routing_key: o11y
-              team: o11y
-
-  # Node failure when cluster is down (should NOT alert)
-  - interval: 1m
-    input_series:
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
-        values: "0x16"
-
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: RegistryExporterNodeFailure
-        exp_alerts: []
-
-  # Multiple nodes failing in same cluster (should alert for each node)
+  # >50% of nodes failing (2 of 3 = 66.67%) - SHOULD alert
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
@@ -461,12 +360,6 @@ tests:
         values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node3", type="pull", source_cluster="c1"}'
         values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node3", type="push", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node3", type="metadata", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node3", type="authentication", source_cluster="c1"}'
-        values: "1x16"
 
     alert_rule_test:
       - eval_time: 15m
@@ -475,46 +368,26 @@ tests:
           - exp_labels:
               severity: warning
               tested_registry: quay.io
-              node: node1
               source_cluster: c1
               slo: "false"
               component: registry-exporter
             exp_annotations:
               summary: >-
-                Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
+                Over 50% of registry exporter nodes in cluster c1 are failing tests for registry quay.io.
               description: >-
-                Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
-                At least one test type (pull, push, metadata, or authentication) has been failing for 15 minutes.
-                The cluster-level check for this registry is still passing, indicating this is a node-specific issue.
-              alert_routing_key: o11y
-              team: o11y
-          - exp_labels:
-              severity: warning
-              tested_registry: quay.io
-              node: node2
-              source_cluster: c1
-              slo: "false"
-              component: registry-exporter
-            exp_annotations:
-              summary: >-
-                Registry exporter running tests on node node2 for registry quay.io in cluster c1 is failing.
-              description: >-
-                Registry exporter running tests on node node2 for registry quay.io in cluster c1 is failing.
-                At least one test type (pull, push, metadata, or authentication) has been failing for 15 minutes.
-                The cluster-level check for this registry is still passing, indicating this is a node-specific issue.
+                66.67% of registry exporter nodes in cluster c1 are failing tests for registry quay.io.
+                Over 50% of nodes have had at least one failing test type (pull, push, metadata, or authentication); this condition has persisted for 15 minutes.
+                The cluster-level check is still passing, indicating this is not a total outage.
+                Single-node failures from rolling node replacements will not trigger this alert.
               alert_routing_key: o11y
               team: o11y
 
-  # Node failure suppressed when a test type fails cluster-wide (should NOT alert - covered by TestTypeFailure)
+  # Exactly 50% of nodes failing (1 of 2) - should NOT alert (threshold is strictly >50%, tolerates single-node rolling update)
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
         values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
-        values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
         values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
         values: "1x16"
@@ -524,18 +397,52 @@ tests:
         alertname: RegistryExporterNodeFailure
         exp_alerts: []
 
-  # Node recovers before 15 minutes (should NOT alert)
+  # All node failures are cluster-wide type failures - should NOT alert (covered by RegistryExporterTestTypeFailure)
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
+        values: "1x16"
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RegistryExporterNodeFailure
+        exp_alerts: []
+
+  # Cluster check is down - should NOT alert (covered by RegistryExporterDown)
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node3", type="pull", source_cluster="c1"}'
+        values: "0x16"
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RegistryExporterNodeFailure
+        exp_alerts: []
+
+  # Nodes recover before 15 minutes - should NOT alert
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
         values: "1x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
         values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
-        values: "1x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node3", type="pull", source_cluster="c1"}'
         values: "1x16"
 
     alert_rule_test:
@@ -543,26 +450,24 @@ tests:
         alertname: RegistryExporterNodeFailure
         exp_alerts: []
 
-  # Node has ANY test type failing (not all) - should still alert
+  # >50% nodes failing across multiple registries - each alerts independently
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
         values: "1x16"
+      - series: 'konflux_up{service="registry-exporter", check="registry.example.com", source_cluster="c1"}'
+        values: "1x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
         values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="metadata", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="authentication", source_cluster="c1"}'
-        values: "1x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node3", type="pull", source_cluster="c1"}'
         values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="metadata", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="authentication", source_cluster="c1"}'
+      - series: 'registry_exporter_success{tested_registry="registry.example.com", node="node1", type="pull", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="registry.example.com", node="node2", type="pull", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="registry.example.com", node="node3", type="pull", source_cluster="c1"}'
         values: "1x16"
 
     alert_rule_test:
@@ -572,16 +477,52 @@ tests:
           - exp_labels:
               severity: warning
               tested_registry: quay.io
-              node: node1
               source_cluster: c1
               slo: "false"
               component: registry-exporter
             exp_annotations:
               summary: >-
-                Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
+                Over 50% of registry exporter nodes in cluster c1 are failing tests for registry quay.io.
               description: >-
-                Registry exporter running tests on node node1 for registry quay.io in cluster c1 is failing.
-                At least one test type (pull, push, metadata, or authentication) has been failing for 15 minutes.
-                The cluster-level check for this registry is still passing, indicating this is a node-specific issue.
+                66.67% of registry exporter nodes in cluster c1 are failing tests for registry quay.io.
+                Over 50% of nodes have had at least one failing test type (pull, push, metadata, or authentication); this condition has persisted for 15 minutes.
+                The cluster-level check is still passing, indicating this is not a total outage.
+                Single-node failures from rolling node replacements will not trigger this alert.
               alert_routing_key: o11y
               team: o11y
+          - exp_labels:
+              severity: warning
+              tested_registry: registry.example.com
+              source_cluster: c1
+              slo: "false"
+              component: registry-exporter
+            exp_annotations:
+              summary: >-
+                Over 50% of registry exporter nodes in cluster c1 are failing tests for registry registry.example.com.
+              description: >-
+                66.67% of registry exporter nodes in cluster c1 are failing tests for registry registry.example.com.
+                Over 50% of nodes have had at least one failing test type (pull, push, metadata, or authentication); this condition has persisted for 15 minutes.
+                The cluster-level check is still passing, indicating this is not a total outage.
+                Single-node failures from rolling node replacements will not trigger this alert.
+              alert_routing_key: o11y
+              team: o11y
+
+  # Push fails cluster-wide + pull fails on 1 of 2 nodes (50%) - NodeFailure should NOT alert
+  # (push excluded by unless clause; remaining pull failure is only 1/2 = 50%, not >50%)
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
+        values: "1x16"
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RegistryExporterNodeFailure
+        exp_alerts: []


### PR DESCRIPTION

### Description

- Changes RegistryExporterNodeFailure from a per-node alert to a cluster-level ratio alert.
- The for: 15m only guarantees the >50% ratio held for 15 minutes, not
  per-node continuous failure
- Updates unit tests to match new aggregated semantics.

## Why
Single-node failures during rolling node replacements were generating noise. The new threshold only alerts when a significant portion of nodes are affected.

## Testing
Promtool unit tests pass for all scenarios.


---
