### PR TITLE
chore(KFLUXVNGD-1096): add caddy recording rules

### DIFF
--- a/rhobs/recording/konflux_ui_availability_recording_rules.yaml
+++ b/rhobs/recording/konflux_ui_availability_recording_rules.yaml
@@ -43,3 +43,30 @@ spec:
 
         - record: nginx_otel_http_request_errors:rate24h_stddev
           expr: stddev_over_time(nginx_otel_http_request_errors:rate5m[24h])
+
+        # Caddy UI proxy HTTP 4xx/5xx rates (replaces nginx_otel_* once alerts switch).
+        # Source is histogram _count with code=; rename to status for alert parity.
+        # Caddy increments _count once per middleware handler for the same request —
+        # max without (handler, method, server) keeps a request-level rate (nginx-like),
+        # then sum across pods/instances by (job, status, source_cluster).
+        - record: caddy_http_request_errors:rate5m
+          expr: |
+            sum by (job, status, source_cluster) (
+              max without (handler, method, server) (
+                label_replace(
+                  rate(
+                    caddy_http_request_duration_seconds_count{
+                      namespace="konflux-ui",
+                      code=~"4..|5.."
+                    }[5m]
+                  ),
+                  "status", "$1", "code", "(.*)"
+                )
+              )
+            )
+
+        - record: caddy_http_request_errors:rate24h_avg
+          expr: avg_over_time(caddy_http_request_errors:rate5m[24h])
+
+        - record: caddy_http_request_errors:rate24h_stddev
+          expr: stddev_over_time(caddy_http_request_errors:rate5m[24h])

--- a/test/promql/tests/recording/konflux_ui_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/konflux_ui_availability_recording_rules_test.yaml
@@ -63,3 +63,42 @@ tests:
         exp_samples:
           - labels: konflux_up{service='dex', check='replicas-available', namespace='konflux-ui', deployment='dex'}
             value: 0
+
+  # Two middleware handlers for the same 401 collapse to one request-level rate
+  # (max of 30/60 = 0.5). 200 excluded; 502 = 6/60 = 0.1.
+  - name: CaddyHttpRequestErrorsRate5m
+    interval: 1m
+    input_series:
+      - series: 'caddy_http_request_duration_seconds_count{namespace="konflux-ui", job="proxy", code="401", handler="metrics", method="GET", server="srv0", source_cluster="stg"}'
+        values: '0+30x10'
+      - series: 'caddy_http_request_duration_seconds_count{namespace="konflux-ui", job="proxy", code="401", handler="reverse_proxy", method="GET", server="srv0", source_cluster="stg"}'
+        values: '0+30x10'
+      - series: 'caddy_http_request_duration_seconds_count{namespace="konflux-ui", job="proxy", code="200", handler="reverse_proxy", method="GET", server="srv0", source_cluster="stg"}'
+        values: '0+100x10'
+      - series: 'caddy_http_request_duration_seconds_count{namespace="konflux-ui", job="proxy", code="502", handler="reverse_proxy", method="GET", server="srv0", source_cluster="stg"}'
+        values: '0+6x10'
+    promql_expr_test:
+      - expr: caddy_http_request_errors:rate5m
+        eval_time: 6m
+        exp_samples:
+          - labels: 'caddy_http_request_errors:rate5m{job="proxy", status="401", source_cluster="stg"}'
+            value: 0.5
+          - labels: 'caddy_http_request_errors:rate5m{job="proxy", status="502", source_cluster="stg"}'
+            value: 0.1
+
+  - name: CaddyHttpRequestErrorsRate24hBaseline
+    interval: 1m
+    input_series:
+      - series: 'caddy_http_request_errors:rate5m{job="proxy", status="500", source_cluster="stg"}'
+        values: '0.2x30'
+    promql_expr_test:
+      - expr: caddy_http_request_errors:rate24h_avg
+        eval_time: 30m
+        exp_samples:
+          - labels: 'caddy_http_request_errors:rate24h_avg{job="proxy", status="500", source_cluster="stg"}'
+            value: 0.2
+      - expr: caddy_http_request_errors:rate24h_stddev
+        eval_time: 30m
+        exp_samples:
+          - labels: 'caddy_http_request_errors:rate24h_stddev{job="proxy", status="500", source_cluster="stg"}'
+            value: 0


### PR DESCRIPTION
Caddy is replacing nginx in the konflux-ui deployment. This commit adds recording rules that will be used later for alerting on caddy availability.

Assisted-by: Cursor

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
