### PR TITLE
feat(PVO11Y-5370): add Konflux UX SLO dashboard

### DIFF
--- a/dashboards/grafana-dashboard-konflux-tenant-ux-metrics.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-tenant-ux-metrics.configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: grafana-dashboard-grafana-dashboard-konflux-tenant-ux-metrics.configmap
+  name: grafana-dashboard-konflux-tenant-ux-metrics
   labels:
     grafana_dashboard: "true"
   annotations:

--- a/dashboards/grafana-dashboard-konflux-tenant-ux-metrics.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-tenant-ux-metrics.configmap.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: grafana-dashboard-grafana-dashboard-konflux-tenant-ux-slo.configmap
+  name: grafana-dashboard-grafana-dashboard-konflux-tenant-ux-metrics.configmap
   labels:
     grafana_dashboard: "true"
   annotations:
     grafana-folder: /grafana-dashboard-definitions/RHTAP
 data:
-  grafana-dashboard-konflux-tenant-ux-slo.json: |-
+  grafana-dashboard-konflux-tenant-ux-metrics.json: |-
     {
       "annotations": {
         "list": [
@@ -7323,7 +7323,7 @@ data:
       },
       "timepicker": {},
       "timezone": "UTC",
-      "title": "Konflux Tenant-Level UX SLO",
-      "uid": "konflux-tenant-ux-slo",
+      "title": "Konflux Tenant-Level UX Metrics",
+      "uid": "konflux-tenant-ux-metrics",
       "version": 1
     }

--- a/dashboards/grafana-dashboard-konflux-ux-slo.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ux-slo.configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: grafana-dashboard-grafana-dashboard-konflux-ux-slo.configmap
+  name: grafana-dashboard-konflux-ux-slo
   labels:
     grafana_dashboard: "true"
   annotations:

--- a/dashboards/grafana-dashboard-konflux-ux-slo.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ux-slo.configmap.yaml
@@ -25,6 +25,7 @@ data:
           }
         ]
       },
+      "id": null,
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,

--- a/dashboards/grafana-dashboard-konflux-ux-slo.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ux-slo.configmap.yaml
@@ -103,7 +103,7 @@ data:
                 "type": "prometheus",
                 "uid": "${Datasource}"
               },
-              "expr": "count by (source_cluster) (\n  konflux_cluster:kueue_admission_wait_time_seconds:saturation_7d{\n    source_cluster=~\"$Cluster\"\n  } > 0.05\n)",
+              "expr": "sum by (source_cluster) (\n  konflux_cluster:kueue_admission_wait_time_seconds:saturation_7d{\n    source_cluster=~\"$Cluster\"\n  } > bool 0.05\n)",
               "instant": true,
               "legendFormat": "{{source_cluster}}",
               "refId": "A"
@@ -178,7 +178,7 @@ data:
                 "type": "prometheus",
                 "uid": "${Datasource}"
               },
-              "expr": "count by (source_cluster) (\n  konflux_build_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  } == 1\n)\n/\ncount by (source_cluster) (\n  konflux_build_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  }\n)",
+              "expr": "sum by (source_cluster) (\n  konflux_build_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  } == bool 1\n)\n/\ncount by (source_cluster) (\n  konflux_build_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  }\n)",
               "instant": true,
               "legendFormat": "{{source_cluster}}",
               "refId": "A"
@@ -253,7 +253,7 @@ data:
                 "type": "prometheus",
                 "uid": "${Datasource}"
               },
-              "expr": "count by (source_cluster) (\n  konflux_integration_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  } == 1\n)\n/\ncount by (source_cluster) (\n  konflux_integration_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  }\n)",
+              "expr": "sum by (source_cluster) (\n  konflux_integration_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  } == bool 1\n)\n/\ncount by (source_cluster) (\n  konflux_integration_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  }\n)",
               "instant": true,
               "legendFormat": "{{source_cluster}}",
               "refId": "A"
@@ -328,7 +328,7 @@ data:
                 "type": "prometheus",
                 "uid": "${Datasource}"
               },
-              "expr": "count by (source_cluster) (\n  konflux_release_cr_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  } == 1\n)\n/\ncount by (source_cluster) (\n  konflux_release_cr_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  }\n)",
+              "expr": "sum by (source_cluster) (\n  konflux_release_cr_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  } == bool 1\n)\n/\ncount by (source_cluster) (\n  konflux_release_cr_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  }\n)",
               "instant": true,
               "legendFormat": "{{source_cluster}}",
               "refId": "A"

--- a/dashboards/grafana-dashboard-konflux-ux-slo.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ux-slo.configmap.yaml
@@ -1,0 +1,993 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-grafana-dashboard-konflux-ux-slo.configmap
+  labels:
+    grafana_dashboard: "true"
+  annotations:
+    grafana-folder: /grafana-dashboard-definitions/RHTAP
+data:
+  grafana-dashboard-konflux-ux-slo.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 100,
+          "panels": [],
+          "title": "UX SLO Overview",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Datasource}"
+          },
+          "description": "Number of priority classes with saturation_7d > 5% per cluster. Any value > 0 means the cluster is in breach.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 0,
+            "y": 1
+          },
+          "id": 101,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.11",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "expr": "count by (source_cluster) (\n  konflux_cluster:kueue_admission_wait_time_seconds:saturation_7d{\n    source_cluster=~\"$Cluster\"\n  } > 0.05\n)",
+              "instant": true,
+              "legendFormat": "{{source_cluster}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Cluster Breach (priority classes > 5%)",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Datasource}"
+          },
+          "description": "Fraction of tenants in breach of build duration SLO per cluster.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "noValue": "0%",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.01
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.05
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 6,
+            "y": 1
+          },
+          "id": 102,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.11",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "expr": "count by (source_cluster) (\n  konflux_build_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  } == 1\n)\n/\ncount by (source_cluster) (\n  konflux_build_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  }\n)",
+              "instant": true,
+              "legendFormat": "{{source_cluster}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Tenants: Build Breach",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Datasource}"
+          },
+          "description": "Fraction of tenants in breach of integration duration SLO per cluster.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "noValue": "0%",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.01
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.05
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 12,
+            "y": 1
+          },
+          "id": 103,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.11",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "expr": "count by (source_cluster) (\n  konflux_integration_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  } == 1\n)\n/\ncount by (source_cluster) (\n  konflux_integration_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  }\n)",
+              "instant": true,
+              "legendFormat": "{{source_cluster}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Tenants: Integration Breach",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Datasource}"
+          },
+          "description": "Fraction of tenants in breach of release CR duration SLO per cluster.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "noValue": "0%",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.01
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.05
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 18,
+            "y": 1
+          },
+          "id": 104,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.11",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "expr": "count by (source_cluster) (\n  konflux_release_cr_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  } == 1\n)\n/\ncount by (source_cluster) (\n  konflux_release_cr_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  }\n)",
+              "instant": true,
+              "legendFormat": "{{source_cluster}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Tenants: Release Breach",
+          "type": "stat"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 7
+          },
+          "id": 1,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "description": "Fraction of the past 7 days where P95 wait time exceeded the statistical baseline (avg + 1σ). >5% indicates sustained degradation.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 0.05
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.2
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 8
+              },
+              "id": 2,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "konflux_cluster:kueue_admission_wait_time_seconds:saturation_7d{source_cluster=\"$Cluster\"}",
+                  "instant": true,
+                  "legendFormat": "{{priority_class}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "7-Day Saturation Ratio by Priority Class",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "description": "P95 admission wait time (1h window) with the statistical baseline threshold (avg + 1σ) overlaid.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "s"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": ".*threshold.*"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.lineStyle",
+                        "value": {
+                          "dash": [
+                            10,
+                            10
+                          ],
+                          "fill": "dash"
+                        }
+                      },
+                      {
+                        "id": "custom.fillOpacity",
+                        "value": 10
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "red",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 14
+              },
+              "id": 3,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "konflux_cluster:kueue_admission_wait_time_seconds:p95_1h{source_cluster=\"$Cluster\"}",
+                  "legendFormat": "{{priority_class}} - p95",
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "konflux_cluster:kueue_admission_wait_time_seconds:p95_1h_7d_avg{source_cluster=\"$Cluster\"}\n+\nkonflux_cluster:kueue_admission_wait_time_seconds:p95_1h_7d_stddev{source_cluster=\"$Cluster\"}",
+                  "legendFormat": "{{priority_class}} - threshold (avg+1σ)",
+                  "refId": "B"
+                }
+              ],
+              "title": "P95 Wait Time vs Baseline Threshold",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "description": "1 = P95 exceeds baseline threshold, 0 = within normal range.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 70,
+                    "lineInterpolation": "stepAfter",
+                    "lineWidth": 0,
+                    "showPoints": "never",
+                    "spanNulls": false
+                  },
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 22
+              },
+              "id": 4,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "konflux_cluster:kueue_admission_wait_time_seconds:saturated{source_cluster=\"$Cluster\"}",
+                  "legendFormat": "{{priority_class}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Saturation Indicator",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "description": "State timeline showing when each priority class is saturated (P95 > avg+1σ). One lane per priority class — red = saturated, green = normal.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "color": "green",
+                          "index": 0,
+                          "text": "Normal"
+                        },
+                        "1": {
+                          "color": "red",
+                          "index": 1,
+                          "text": "Saturated"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 28
+              },
+              "id": 5,
+              "options": {
+                "alignValue": "left",
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom"
+                },
+                "mergeValues": true,
+                "rowHeight": 0.8,
+                "showValue": "auto",
+                "tooltip": {
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "konflux_cluster:kueue_admission_wait_time_seconds:saturated{source_cluster=\"$Cluster\"}",
+                  "legendFormat": "{{priority_class}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Saturation State Timeline",
+              "type": "state-timeline"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "description": "Status history grid showing saturation state per priority class over time. Each cell is colored by value — red = saturated, green = normal.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "color": "green",
+                          "index": 0,
+                          "text": "Normal"
+                        },
+                        "1": {
+                          "color": "red",
+                          "index": 1,
+                          "text": "Saturated"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 36
+              },
+              "id": 6,
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom"
+                },
+                "rowHeight": 0.8,
+                "showValue": "auto",
+                "tooltip": {
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "konflux_cluster:kueue_admission_wait_time_seconds:saturated{source_cluster=\"$Cluster\"}",
+                  "legendFormat": "{{priority_class}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Saturation Status History",
+              "type": "status-history"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "description": "Tenants in breach of build duration SLO on this cluster.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 44
+              },
+              "id": 11,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "konflux_build_duration_slo_breach{source_cluster=\"$Cluster\", exported_namespace=~\"$Tenant\"}",
+                  "instant": true,
+                  "legendFormat": "{{exported_namespace}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Build Duration SLO Breach",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "description": "Tenants in breach of integration duration SLO on this cluster.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 44
+              },
+              "id": 12,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "konflux_integration_duration_slo_breach{source_cluster=\"$Cluster\", exported_namespace=~\"$Tenant\"}",
+                  "instant": true,
+                  "legendFormat": "{{exported_namespace}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Integration Duration SLO Breach",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "description": "Tenants in breach of release CR duration SLO on this cluster.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 44
+              },
+              "id": 13,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "konflux_release_cr_duration_slo_breach{source_cluster=\"$Cluster\", exported_namespace=~\"$Tenant\"}",
+                  "instant": true,
+                  "legendFormat": "{{exported_namespace}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Release CR Duration SLO Breach",
+              "type": "stat"
+            }
+          ],
+          "repeat": "Cluster",
+          "title": "Cluster UX SLO - ${Cluster}",
+          "type": "row"
+        }
+      ],
+      "preload": false,
+      "schemaVersion": 41,
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allowCustomValue": false,
+            "current": {},
+            "name": "Datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "rhtap-.*",
+            "type": "datasource"
+          },
+          {
+            "allowCustomValue": false,
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${Datasource}"
+            },
+            "definition": "label_values(konflux_cluster:kueue_admission_wait_time_seconds:p95_1h, source_cluster)",
+            "includeAll": true,
+            "multi": true,
+            "name": "Cluster",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values(konflux_cluster:kueue_admission_wait_time_seconds:p95_1h, source_cluster)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "type": "query"
+          },
+          {
+            "allowCustomValue": false,
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${Datasource}"
+            },
+            "definition": "label_values(konflux_build_duration_slo_breach{source_cluster=~\"$Cluster\"}, exported_namespace)",
+            "includeAll": true,
+            "multi": true,
+            "name": "Tenant",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values(konflux_build_duration_slo_breach{source_cluster=~\"$Cluster\"}, exported_namespace)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-7d",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "UTC",
+      "title": "Konflux UX SLO",
+      "uid": "konflux-ux-slo"
+    }

--- a/dashboards/grafana-dashboard-konflux-ux-slo.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ux-slo.configmap.yaml
@@ -365,11 +365,11 @@ data:
                       },
                       {
                         "color": "yellow",
-                        "value": 0.05
+                        "value": 0.04
                       },
                       {
                         "color": "red",
-                        "value": 0.2
+                        "value": 0.05
                       }
                     ]
                   },

--- a/dashboards/grafana-dashboard-konflux-ux-slo.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ux-slo.configmap.yaml
@@ -513,74 +513,6 @@ data:
                 "type": "prometheus",
                 "uid": "${Datasource}"
               },
-              "description": "1 = P95 exceeds baseline threshold, 0 = within normal range.",
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "custom": {
-                    "drawStyle": "line",
-                    "fillOpacity": 70,
-                    "lineInterpolation": "stepAfter",
-                    "lineWidth": 0,
-                    "showPoints": "never",
-                    "spanNulls": false
-                  },
-                  "max": 1,
-                  "min": 0,
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "red",
-                        "value": 1
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 6,
-                "w": 24,
-                "x": 0,
-                "y": 22
-              },
-              "id": 4,
-              "options": {
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom"
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "desc"
-                }
-              },
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${Datasource}"
-                  },
-                  "expr": "konflux_cluster:kueue_admission_wait_time_seconds:saturated{source_cluster=\"$Cluster\"}",
-                  "legendFormat": "{{priority_class}}",
-                  "refId": "A"
-                }
-              ],
-              "title": "Saturation Indicator",
-              "type": "timeseries"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${Datasource}"
-              },
               "description": "State timeline showing when each priority class is saturated (P95 > avg+1σ). One lane per priority class — red = saturated, green = normal.",
               "fieldConfig": {
                 "defaults": {
@@ -623,7 +555,7 @@ data:
                 "h": 8,
                 "w": 24,
                 "x": 0,
-                "y": 28
+                "y": 22
               },
               "id": 5,
               "options": {
@@ -634,7 +566,7 @@ data:
                 },
                 "mergeValues": true,
                 "rowHeight": 0.8,
-                "showValue": "auto",
+                "showValue": "never",
                 "tooltip": {
                   "mode": "single",
                   "sort": "none"
@@ -653,82 +585,6 @@ data:
               ],
               "title": "Saturation State Timeline",
               "type": "state-timeline"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${Datasource}"
-              },
-              "description": "Status history grid showing saturation state per priority class over time. Each cell is colored by value — red = saturated, green = normal.",
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "mappings": [
-                    {
-                      "options": {
-                        "0": {
-                          "color": "green",
-                          "index": 0,
-                          "text": "Normal"
-                        },
-                        "1": {
-                          "color": "red",
-                          "index": 1,
-                          "text": "Saturated"
-                        }
-                      },
-                      "type": "value"
-                    }
-                  ],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "red",
-                        "value": 1
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 8,
-                "w": 24,
-                "x": 0,
-                "y": 36
-              },
-              "id": 6,
-              "options": {
-                "legend": {
-                  "displayMode": "list",
-                  "placement": "bottom"
-                },
-                "rowHeight": 0.8,
-                "showValue": "auto",
-                "tooltip": {
-                  "mode": "single",
-                  "sort": "none"
-                }
-              },
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${Datasource}"
-                  },
-                  "expr": "konflux_cluster:kueue_admission_wait_time_seconds:saturated{source_cluster=\"$Cluster\"}",
-                  "legendFormat": "{{priority_class}}",
-                  "refId": "A"
-                }
-              ],
-              "title": "Saturation Status History",
-              "type": "status-history"
             },
             {
               "datasource": {
@@ -760,7 +616,7 @@ data:
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 44
+                "y": 30
               },
               "id": 11,
               "options": {
@@ -822,7 +678,7 @@ data:
                 "h": 6,
                 "w": 8,
                 "x": 8,
-                "y": 44
+                "y": 30
               },
               "id": 12,
               "options": {
@@ -884,7 +740,7 @@ data:
                 "h": 6,
                 "w": 8,
                 "x": 16,
-                "y": 44
+                "y": 30
               },
               "id": 13,
               "options": {


### PR DESCRIPTION
## Summary
- Renames the existing tenant UX dashboard to **Konflux Tenant-Level UX Metrics** (the existing metrics are inputs to the SLO, not SLO breach signals themselves)
- Adds a new **Konflux UX SLO** dashboard (`konflux-ux-slo`) combining cluster-level and tenant-level breach signals

### Dashboard: Konflux UX SLO

#### Overview section
- **Cluster Breach** — count of priority classes with `saturation_7d > 5%` per cluster (green / red)
- **Tenants: Build / Integration / Release Breach** — fraction of breaching tenants per cluster (green < 4%, yellow 4–5%, red ≥ 5%)

#### Per-cluster expandable rows (repeat on `$Cluster` variable)
- **7-Day Saturation Ratio by Priority Class** — stat panel, percentunit, thresholds at 4% (yellow) and 5% (red)
- **P95 Wait Time vs Baseline Threshold** — timeseries with dashed red threshold line (avg + 1σ)
- **Saturation State Timeline** — `state-timeline` panel, one lane per priority class, green = normal / red = saturated, no value labels
- **Build / Integration / Release Duration SLO Breach** — per-tenant stat panels

#### Variables
- `Datasource` — prometheus, filtered to `rhtap-.*`
- `Cluster` — multi-select from `p95_1h` label values
- `Tenant` — multi-select from `konflux_build_duration_slo_breach` label values scoped to selected clusters

<img width="1489" height="1002" alt="Screenshot 2026-08-06 at 11 58 51" src="https://github.com/user-attachments/assets/f8dfd78d-e602-47ec-84ae-6d30cb511ec2" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)