### PR TITLE
fix(alert-tuning): [SPRE-5878] suppress EtcdHighNumberOfLeaderChanges during cluster upgrades

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.cluster_capacity_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.cluster_capacity_alerts.yaml
@@ -79,7 +79,9 @@ spec:
 
       - alert: EtcdHighNumberOfLeaderChanges
         expr: |
-          increase(etcd_server_leader_changes_seen_total{namespace="openshift-etcd"}[10m]) > 2
+          (increase(etcd_server_leader_changes_seen_total{namespace="openshift-etcd"}[10m]) > 2)
+          unless on (source_cluster)
+          cluster_upgrade_ongoing
         for: 1m
         labels:
           severity: warning

--- a/rhobs/alerting/data_plane/prometheus.cluster_ongoing_updrade_alert.yaml
+++ b/rhobs/alerting/data_plane/prometheus.cluster_ongoing_updrade_alert.yaml
@@ -12,9 +12,12 @@ spec:
       rules:
         - alert: ClusterUpgradeOngoing
           expr: >-
-            (aus_cluster_version_remaining_soak_days <= -2 >= -3)
-            * on(cluster_uuid) group_left(cluster_name, current_version)
-            aus_cluster_upgrade_policy_info{org_name="RHTAP"}
+            label_replace(
+              (aus_cluster_version_remaining_soak_days <= -2 >= -3)
+              * on(cluster_uuid) group_left(cluster_name, current_version)
+              aus_cluster_upgrade_policy_info{org_name="RHTAP"},
+              "source_cluster", "$1", "cluster_name", "(.*)"
+            )
           for: 1m
           labels:
             severity: info

--- a/rhobs/recording/cluster_upgrade_recording_rules.yaml
+++ b/rhobs/recording/cluster_upgrade_recording_rules.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-cluster-upgrade
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: cluster_upgrade
+      interval: 1m
+      rules:
+        - record: cluster_upgrade_ongoing
+          expr: |
+            max by (source_cluster) (
+              ALERTS{alertname="ClusterUpgradeOngoing", alertstate="firing"}
+            )

--- a/test/promql/tests/data_plane/cluster_capacity_test.yaml
+++ b/test/promql/tests/data_plane/cluster_capacity_test.yaml
@@ -140,7 +140,7 @@ tests:
 
   - interval: 1m
     input_series:
-      # Etcd No Leader failures within threshold limit, so it will be alerted.
+      # Leader changes exceed threshold, no upgrade in progress — alert fires.
       - series: 'etcd_server_leader_changes_seen_total{namespace="openshift-etcd",source_cluster="cluster01"}'
         values: '3+2x60'
 
@@ -162,8 +162,46 @@ tests:
 
   - interval: 1m
     input_series:
-      # Etcd has Leader within threshold limit, so it will not be alerted.
-      - series: 'etcd_server_leader_changes_seen_total{source_cluster="cluster01"}'
+      # Leader changes exceed threshold BUT a cluster upgrade is ongoing for the same cluster.
+      # The unless operator suppresses the alert — upgrade-induced re-elections are expected behaviour.
+      - series: 'etcd_server_leader_changes_seen_total{namespace="openshift-etcd",source_cluster="cluster01"}'
+        values: '3+2x60'
+      - series: 'cluster_upgrade_ongoing{source_cluster="cluster01"}'
+        values: '1+0x60'
+
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: EtcdHighNumberOfLeaderChanges
+
+  - interval: 1m
+    input_series:
+      # Leader changes exceed threshold on cluster01, but the upgrade is ongoing on a DIFFERENT cluster (cluster02).
+      # Suppression is per-cluster — cluster01 alert must still fire.
+      - series: 'etcd_server_leader_changes_seen_total{namespace="openshift-etcd",source_cluster="cluster01"}'
+        values: '3+2x60'
+      - series: 'cluster_upgrade_ongoing{source_cluster="cluster02"}'
+        values: '1+0x60'
+
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: EtcdHighNumberOfLeaderChanges
+        exp_alerts:
+          - exp_labels:
+              component: etcd
+              namespace: openshift-etcd
+              severity: warning
+              source_cluster: cluster01
+            exp_annotations:
+              summary: 'Etcd high number of leader changes'
+              description: 'Etcd leader changed more than 2 times during 10 minutes in cluster cluster01.'
+              alert_routing_key: spreandinfra
+              team: o11y
+              slo: 'false'
+
+  - interval: 1m
+    input_series:
+      # Counter is stable — no leader changes, no alert.
+      - series: 'etcd_server_leader_changes_seen_total{namespace="openshift-etcd",source_cluster="cluster01"}'
         values: '1+0x60'
 
     alert_rule_test:

--- a/test/promql/tests/data_plane/cluster_upgrade_ongoing_alert_test.yaml
+++ b/test/promql/tests/data_plane/cluster_upgrade_ongoing_alert_test.yaml
@@ -22,6 +22,7 @@ tests:
               cluster_uuid: "uuid-1"
               cluster_name: "prod-cluster"
               current_version: "4.14.1"
+              source_cluster: "prod-cluster"
               alertname: ClusterUpgradeOngoing
             exp_annotations:
               summary: "Cluster prod-cluster is currently undergoing an upgrade."

--- a/test/promql/tests/recording/cluster_upgrade_recording_rules_test.yaml
+++ b/test/promql/tests/recording/cluster_upgrade_recording_rules_test.yaml
@@ -1,0 +1,29 @@
+evaluation_interval: 1m
+
+rule_files:
+  - cluster_upgrade_recording_rules.yaml
+
+tests:
+  - name: ClusterUpgradeOngoingSignalFiring
+    interval: 1m
+    input_series:
+      - series: 'ALERTS{alertname="ClusterUpgradeOngoing",alertstate="firing",source_cluster="cluster01",severity="info"}'
+        values: '1+0x10'
+
+    promql_expr_test:
+      - expr: cluster_upgrade_ongoing
+        eval_time: 5m
+        exp_samples:
+          - labels: '{__name__="cluster_upgrade_ongoing", source_cluster="cluster01"}'
+            value: 1
+
+  - name: ClusterUpgradeOngoingSignalPendingNotCaptured
+    interval: 1m
+    input_series:
+      - series: 'ALERTS{alertname="ClusterUpgradeOngoing",alertstate="pending",source_cluster="cluster01",severity="info"}'
+        values: '1+0x10'
+
+    promql_expr_test:
+      - expr: cluster_upgrade_ongoing
+        eval_time: 5m
+        exp_samples: []


### PR DESCRIPTION
## Summary

Resolves [SPRE-5878](https://redhat.atlassian.net/browse/SPRE-5878) — Alert Review & Tuning: `EtcdHighNumberOfLeaderChanges`

Suppresses the alert per-cluster during active OCP upgrades using a recording
rule as the inhibition signal, while preserving full sensitivity (`> 2`)
during normal operation.

---


`EtcdHighNumberOfLeaderChanges` generated **~109 false positive firings** across
two consecutive 14-day investigation windows with **0% actionable signal** and
zero associated PagerDuty incidents or user-impacting events.

Every firing occurred strictly within scheduled weekly OCP upgrade windows.
During a rolling upgrade, the MachineConfigOperator drains and reboots control
plane nodes one at a time — each restart forces a Raft leader re-election. A
standard 3-node etcd cluster produces 2–3 elections per upgrade (~70-minute
window), mathematically guaranteeing a crossing of the `> 2` threshold on every
upgrade cycle.

---

## Why not raise the threshold

Raising the threshold from `> 2` to `> 4` was considered and rejected. The
maximum observed `increase()` value during any upgrade was **3.158** — raising
to `> 4` would eliminate all false positives, but creates a blind spot: genuine
instability (e.g. disk pressure, network blip) causing 3–4 leader elections
during normal operation would go silently undetected. Preserving full sensitivity
(`> 2`) is the correct behaviour.

---

## Resolution

Suppress the alert **per-cluster** during active upgrades using the Prometheus
`unless` operator with a dedicated recording rule as the inhibition signal:

```promql
(increase(etcd_server_leader_changes_seen_total{namespace="openshift-etcd"}[10m]) > 2)
unless on (source_cluster)
cluster_upgrade_ongoing

Why a recording rule instead of ALERTS{} directly

The unless clause references cluster_upgrade_ongoing (a recording rule)
rather than ALERTS{alertname="ClusterUpgradeOngoing"} directly, for two
reasons:

1. alertstate ambiguity — ALERTS{} silently matches both
alertstate="firing" and alertstate="pending". The recording rule
explicitly filters alertstate="firing" — suppression only activates once
the upgrade is confirmed, not while it is still within its for: 1m window.
2. Stability — ALERTS{} is an internal Prometheus construct. A named
recording rule produces a stable, well-defined, reusable time series that
other rules can consume in the future.

Label alignment

cluster_name on aus_cluster_upgrade_policy_info maps 1:1 to
source_cluster on etcd_server_leader_changes_seen_total across all RHTAP
clusters (verified in production RHOBS — short-name format, e.g.
kflux-prd-rh03). A label_replace() on the ClusterUpgradeOngoing alert
expression copies cluster_name → source_cluster, enabling the per-cluster
join.

---
Files changed

┌─────────────────────────────────────────────────────────────────────────┬──────────────────────────────────────────────────────┐
│                                  File                                   │                        Change                        │
├─────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│                                                                         │ New — recording rule that materialises               │
│ rhobs/recording/cluster_upgrade_recording_rules.yaml                    │ cluster_upgrade_ongoing{source_cluster}=1 only when  │
│                                                                         │ ClusterUpgradeOngoing is alertstate="firing"         │
├─────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│                                                                         │ Wrapped expression in label_replace() to expose      │
│ rhobs/alerting/data_plane/prometheus.cluster_ongoing_updrade_alert.yaml │ source_cluster from cluster_name, enabling           │
│                                                                         │ per-cluster join via unless on (source_cluster)      │
├─────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│                                                                         │ Added unless on (source_cluster)                     │
│ rhobs/alerting/data_plane/prometheus.cluster_capacity_alerts.yaml       │ cluster_upgrade_ongoing inhibition; threshold        │
│                                                                         │ remains > 2                                          │
├─────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ test/promql/tests/data_plane/cluster_upgrade_ongoing_alert_test.yaml    │ Added source_cluster label assertion (now present    │
│                                                                         │ due to label_replace)                                │
├─────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│                                                                         │ Fixed pre-existing vacuous test (missing namespace   │
│ test/promql/tests/data_plane/cluster_capacity_test.yaml                 │ label); added suppression, per-cluster specificity,  │
│                                                                         │ and stable-counter test cases                        │
├─────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│                                                                         │ New — unit tests for recording rule:                 │
│ test/promql/tests/recording/cluster_upgrade_recording_rules_test.yaml   │ alertstate="firing" → signal=1; alertstate="pending" │
│                                                                         │  → no output                                         │
└─────────────────────────────────────────────────────────────────────────┴──────────────────────────────────────────────────────┘

---
Test results

promtool test rules:
  cluster_capacity_test.yaml                  SUCCESS
  cluster_upgrade_ongoing_alert_test.yaml     SUCCESS
  cluster_upgrade_recording_rules_test.yaml   SUCCESS

Validated scenarios:
- Leader changes > 2, no upgrade in progress → alert fires ✅
- Leader changes > 2, upgrade ongoing on same cluster → suppressed ✅
- Leader changes > 2, upgrade ongoing on different cluster → alert fires ✅
- Counter stable (no leader changes) → no alert ✅

---

[SPRE-5878]: https://redhat.atlassian.net/browse/SPRE-5878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ