### PR TITLE
feat(KFLUXVNGD-1179): add KonfluxOperatorNotReady alert rule

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.konflux_operator_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.konflux_operator_alerts.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-konflux-operator-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: konflux-operator-availability
+    interval: 1m
+    rules:
+    - alert: KonfluxOperatorNotReady
+      expr: |
+        konflux_up{
+          service="konflux-operator",
+          check="konflux-ready"
+        } != 1
+      for: 10m
+      labels:
+        severity: warning
+        slo: "false"
+        component: konflux-operator
+      annotations:
+        summary: >-
+          Konflux operator is not ready in cluster {{ $labels.source_cluster }}
+        description: >-
+          The Konflux operator reports the platform is not ready for 10min
+          in cluster {{ $labels.source_cluster }}. One or more sub-component
+          readiness conditions are not True.
+        alert_routing_key: 'konflux-operator'
+        team: konflux-operator

--- a/test/promql/tests/data_plane/konflux_operator_alerts_test.yaml
+++ b/test/promql/tests/data_plane/konflux_operator_alerts_test.yaml
@@ -1,0 +1,55 @@
+---
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.konflux_operator_alerts.yaml
+
+tests:
+# Platform not ready — alert should fire after 10m
+- interval: 1m
+  input_series:
+    - series: 'konflux_up{service="konflux-operator", check="konflux-ready", source_cluster="c1"}'
+      values: '0 0 0 0 0 0 0 0 0 0'
+    - series: 'konflux_up{service="konflux-operator", check="konflux-ready", source_cluster="c2"}'
+      values: '1 1 1 1 1 1 1 1 1 1'
+
+  alert_rule_test:
+    - eval_time: 10m
+      alertname: KonfluxOperatorNotReady
+      exp_alerts:
+        - exp_labels:
+            severity: warning
+            slo: "false"
+            component: konflux-operator
+            service: konflux-operator
+            check: konflux-ready
+            source_cluster: c1
+          exp_annotations:
+            summary: >-
+              Konflux operator is not ready in cluster c1
+            description: >-
+              The Konflux operator reports the platform is not ready for 10min in cluster c1. One or more sub-component readiness conditions are not True.
+            alert_routing_key: 'konflux-operator'
+            team: konflux-operator
+
+# Platform healthy — no alert should fire
+- interval: 1m
+  input_series:
+    - series: 'konflux_up{service="konflux-operator", check="konflux-ready", source_cluster="c1"}'
+      values: '1 1 1 1 1 1 1 1 1 1'
+
+  alert_rule_test:
+    - eval_time: 10m
+      alertname: KonfluxOperatorNotReady
+      exp_alerts: []
+
+# Platform recovers before for duration — no alert should fire
+- interval: 1m
+  input_series:
+    - series: 'konflux_up{service="konflux-operator", check="konflux-ready", source_cluster="c1"}'
+      values: '0 0 0 0 0 0 0 1 1 1'
+
+  alert_rule_test:
+    - eval_time: 10m
+      alertname: KonfluxOperatorNotReady
+      exp_alerts: []


### PR DESCRIPTION
Add a PrometheusRule that fires when the Konflux operator's aggregated readiness gauge reports the platform is not ready for 10 minutes.

Expression: `konflux_up{service="konflux-operator", check="konflux-ready"} != 1`

This is a non-SLO alert (severity: warning) routed to the konflux-operator team via `alert_routing_key`. It can be promoted to SLO later once a runbook is in place.

The alert consumes the `konflux_up` gauge introduced in konflux-ci/konflux-ci PR #8703, which the operator emits with `service` and `check` constant labels to integrate with the existing `konflux_up` availability ecosystem.

Includes promtool unit tests covering three scenarios:
- Alert fires after 10m of not-ready on one cluster while another stays healthy
- No alert when the platform is healthy
- No alert when the platform recovers before the `for` duration elapses

Assisted-by: Cursor + Opus 4.6
