### PR TITLE
SPRE-5505: Add cert-manager alerting rules and tests

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
@@ -28,6 +28,8 @@ spec:
         - alert: CertManagerCertificateExpiringSoon
           expr: |
             (certmanager_certificate_expiration_timestamp_seconds - time()) / 86400 < 21
+            and
+            (certmanager_certificate_expiration_timestamp_seconds - time()) >= 0
           for: 30m
           labels:
             severity: warning
@@ -37,13 +39,15 @@ spec:
             summary: >-
               Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} expires in less than 21 days on cluster {{ $labels.source_cluster }}.
             description: >-
-              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} on cluster {{ $labels.source_cluster }} expires in {{ $value | humanize }} days. Investigate why cert-manager has not renewed it.
+              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} on cluster {{ $labels.source_cluster }} expires in {{ printf "%.0f" $value }} days. Investigate why cert-manager has not renewed it.
             alert_routing_key: spreandinfra
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
 
         - alert: CertManagerCertificateExpiryCritical
           expr: |
             (certmanager_certificate_expiration_timestamp_seconds - time()) / 86400 < 7
+            and
+            (certmanager_certificate_expiration_timestamp_seconds - time()) >= 0
           for: 15m
           labels:
             severity: critical
@@ -53,7 +57,7 @@ spec:
             summary: >-
               Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} expires in less than 7 days on cluster {{ $labels.source_cluster }}.
             description: >-
-              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} on cluster {{ $labels.source_cluster }} expires in {{ $value | humanize }} days. Immediate action required — renewal has likely failed.
+              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} on cluster {{ $labels.source_cluster }} expires in {{ printf "%.0f" $value }} days. Immediate action required — renewal has likely failed.
             alert_routing_key: spreandinfra
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
 

--- a/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
@@ -1,0 +1,74 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-cert-manager-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+    - name: cert-manager-alerts
+      interval: 1m
+      rules:
+        - alert: CertManagerCertificateNotReady
+          expr: |
+            certmanager_certificate_ready_status{condition="True"} == 0
+          for: 15m
+          labels:
+            severity: warning
+            slo: "false"
+            component: cert-manager
+          annotations:
+            summary: >-
+              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} is not ready on cluster {{ $labels.source_cluster }}.
+            description: >-
+              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} has been in a non-ready state for more than 15 minutes on cluster {{ $labels.source_cluster }}.
+            alert_routing_key: spreandinfra
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
+
+        - alert: CertManagerCertificateExpiringSoon
+          expr: |
+            (certmanager_certificate_expiration_timestamp_seconds - time()) / 86400 < 21
+          for: 30m
+          labels:
+            severity: warning
+            slo: "false"
+            component: cert-manager
+          annotations:
+            summary: >-
+              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} expires in less than 21 days on cluster {{ $labels.source_cluster }}.
+            description: >-
+              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} on cluster {{ $labels.source_cluster }} expires in {{ $value | humanize }} days. Investigate why cert-manager has not renewed it.
+            alert_routing_key: spreandinfra
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
+
+        - alert: CertManagerCertificateExpiryCritical
+          expr: |
+            (certmanager_certificate_expiration_timestamp_seconds - time()) / 86400 < 7
+          for: 15m
+          labels:
+            severity: critical
+            slo: "false"
+            component: cert-manager
+          annotations:
+            summary: >-
+              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} expires in less than 7 days on cluster {{ $labels.source_cluster }}.
+            description: >-
+              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} on cluster {{ $labels.source_cluster }} expires in {{ $value | humanize }} days. Immediate action required — renewal has likely failed.
+            alert_routing_key: spreandinfra
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
+
+        - alert: CertManagerClusterIssuerNotReady
+          expr: |
+            certmanager_clusterissuer_ready_status{condition="True"} == 0
+          for: 10m
+          labels:
+            severity: critical
+            slo: "false"
+            component: cert-manager
+          annotations:
+            summary: >-
+              ClusterIssuer {{ $labels.name }} is not ready on cluster {{ $labels.source_cluster }}.
+            description: >-
+              ClusterIssuer {{ $labels.name }} has been in a non-ready state for more than 10 minutes on cluster {{ $labels.source_cluster }}. No new certificates can be issued by this issuer.
+            alert_routing_key: spreandinfra
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md

--- a/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
@@ -60,7 +60,7 @@ spec:
               Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} on cluster {{ $labels.source_cluster }} expires in {{ printf "%.0f" $value }} days. Immediate action required — renewal has likely failed.
             alert_team_handle: >-
               <!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>
-            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-CertManagerCertificateExpiryCritical.md
 
         - alert: CertManagerClusterIssuerNotReady
           expr: |
@@ -77,4 +77,4 @@ spec:
               ClusterIssuer {{ $labels.name }} has been in a non-ready state for more than 10 minutes on cluster {{ $labels.source_cluster }}. No new certificates can be issued by this issuer.
             alert_team_handle: >-
               <!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>
-            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-CertManagerClusterIssuerNotReady.md

--- a/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
@@ -51,14 +51,15 @@ spec:
           for: 15m
           labels:
             severity: critical
-            slo: "false"
+            slo: "true"
             component: cert-manager
           annotations:
             summary: >-
               Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} expires in less than 7 days on cluster {{ $labels.source_cluster }}.
             description: >-
               Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} on cluster {{ $labels.source_cluster }} expires in {{ printf "%.0f" $value }} days. Immediate action required — renewal has likely failed.
-            alert_routing_key: spreandinfra
+            alert_team_handle: >-
+              <!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
 
         - alert: CertManagerClusterIssuerNotReady
@@ -67,12 +68,13 @@ spec:
           for: 10m
           labels:
             severity: critical
-            slo: "false"
+            slo: "true"
             component: cert-manager
           annotations:
             summary: >-
               ClusterIssuer {{ $labels.name }} is not ready on cluster {{ $labels.source_cluster }}.
             description: >-
               ClusterIssuer {{ $labels.name }} has been in a non-ready state for more than 10 minutes on cluster {{ $labels.source_cluster }}. No new certificates can be issued by this issuer.
-            alert_routing_key: spreandinfra
+            alert_team_handle: >-
+              <!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md

--- a/test/promql/tests/data_plane/cert_manager_alerts_test.yaml
+++ b/test/promql/tests/data_plane/cert_manager_alerts_test.yaml
@@ -1,0 +1,156 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.cert_manager_alerts.yaml
+
+tests:
+  # --- CertManagerCertificateNotReady ---
+
+  # Positive: cert stays not-ready for 15m, should fire
+  - interval: 1m
+    input_series:
+      - series: 'certmanager_certificate_ready_status{condition="True", name="my-cert", exported_namespace="my-ns", source_cluster="stone-prod-p01", issuer_name="letsencrypt", issuer_kind="ClusterIssuer"}'
+        values: '0x20'
+
+    alert_rule_test:
+      - alertname: CertManagerCertificateNotReady
+        eval_time: 16m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: cert-manager
+              condition: "True"
+              name: my-cert
+              exported_namespace: my-ns
+              source_cluster: stone-prod-p01
+              issuer_name: letsencrypt
+              issuer_kind: ClusterIssuer
+            exp_annotations:
+              summary: "Certificate my-cert in namespace my-ns is not ready on cluster stone-prod-p01."
+              description: "Certificate my-cert in namespace my-ns has been in a non-ready state for more than 15 minutes on cluster stone-prod-p01."
+              alert_routing_key: spreandinfra
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
+
+  # Negative: cert is ready (value=1), should NOT fire
+  - interval: 1m
+    input_series:
+      - series: 'certmanager_certificate_ready_status{condition="True", name="healthy-cert", exported_namespace="my-ns", source_cluster="stone-prod-p01", issuer_name="letsencrypt", issuer_kind="ClusterIssuer"}'
+        values: '1x20'
+
+    alert_rule_test:
+      - alertname: CertManagerCertificateNotReady
+        eval_time: 16m
+        exp_alerts: []
+
+  # --- CertManagerCertificateExpiringSoon ---
+
+  # Positive: cert expiring in 15 days (< 21), should fire
+  - interval: 1m
+    input_series:
+      - series: 'certmanager_certificate_expiration_timestamp_seconds{name="expiring-cert", exported_namespace="my-ns", source_cluster="stone-prod-p01", issuer_name="letsencrypt", issuer_kind="ClusterIssuer"}'
+        values: '1296000+0x35'
+
+    alert_rule_test:
+      - alertname: CertManagerCertificateExpiringSoon
+        eval_time: 31m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: cert-manager
+              name: expiring-cert
+              exported_namespace: my-ns
+              source_cluster: stone-prod-p01
+              issuer_name: letsencrypt
+              issuer_kind: ClusterIssuer
+            exp_annotations:
+              summary: "Certificate expiring-cert in namespace my-ns expires in less than 21 days on cluster stone-prod-p01."
+              description: "Certificate expiring-cert in namespace my-ns on cluster stone-prod-p01 expires in 15 days. Investigate why cert-manager has not renewed it."
+              alert_routing_key: spreandinfra
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
+
+  # Negative: cert expiring in 60 days (> 21), should NOT fire
+  - interval: 1m
+    input_series:
+      - series: 'certmanager_certificate_expiration_timestamp_seconds{name="healthy-cert", exported_namespace="my-ns", source_cluster="stone-prod-p01", issuer_name="letsencrypt", issuer_kind="ClusterIssuer"}'
+        values: '5184000+0x35'
+
+    alert_rule_test:
+      - alertname: CertManagerCertificateExpiringSoon
+        eval_time: 31m
+        exp_alerts: []
+
+  # --- CertManagerCertificateExpiryCritical ---
+
+  # Positive: cert expiring in 3 days (< 7), should fire
+  - interval: 1m
+    input_series:
+      - series: 'certmanager_certificate_expiration_timestamp_seconds{name="critical-cert", exported_namespace="my-ns", source_cluster="stone-prod-p01", issuer_name="letsencrypt", issuer_kind="ClusterIssuer"}'
+        values: '259200+0x20'
+
+    alert_rule_test:
+      - alertname: CertManagerCertificateExpiryCritical
+        eval_time: 16m
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo: "false"
+              component: cert-manager
+              name: critical-cert
+              exported_namespace: my-ns
+              source_cluster: stone-prod-p01
+              issuer_name: letsencrypt
+              issuer_kind: ClusterIssuer
+            exp_annotations:
+              summary: "Certificate critical-cert in namespace my-ns expires in less than 7 days on cluster stone-prod-p01."
+              description: "Certificate critical-cert in namespace my-ns on cluster stone-prod-p01 expires in 3 days. Immediate action required — renewal has likely failed."
+              alert_routing_key: spreandinfra
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
+
+  # Negative: cert expiring in 15 days (> 7), should NOT fire for critical
+  - interval: 1m
+    input_series:
+      - series: 'certmanager_certificate_expiration_timestamp_seconds{name="warning-cert", exported_namespace="my-ns", source_cluster="stone-prod-p01", issuer_name="letsencrypt", issuer_kind="ClusterIssuer"}'
+        values: '1296000+0x20'
+
+    alert_rule_test:
+      - alertname: CertManagerCertificateExpiryCritical
+        eval_time: 16m
+        exp_alerts: []
+
+  # --- CertManagerClusterIssuerNotReady ---
+
+  # Positive: issuer not ready for 10m, should fire
+  - interval: 1m
+    input_series:
+      - series: 'certmanager_clusterissuer_ready_status{condition="True", name="letsencrypt-prod", source_cluster="stone-prod-p01"}'
+        values: '0x15'
+
+    alert_rule_test:
+      - alertname: CertManagerClusterIssuerNotReady
+        eval_time: 11m
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo: "false"
+              component: cert-manager
+              condition: "True"
+              name: letsencrypt-prod
+              source_cluster: stone-prod-p01
+            exp_annotations:
+              summary: "ClusterIssuer letsencrypt-prod is not ready on cluster stone-prod-p01."
+              description: "ClusterIssuer letsencrypt-prod has been in a non-ready state for more than 10 minutes on cluster stone-prod-p01. No new certificates can be issued by this issuer."
+              alert_routing_key: spreandinfra
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
+
+  # Negative: issuer is ready (value=1), should NOT fire
+  - interval: 1m
+    input_series:
+      - series: 'certmanager_clusterissuer_ready_status{condition="True", name="letsencrypt-prod", source_cluster="stone-prod-p01"}'
+        values: '1x15'
+
+    alert_rule_test:
+      - alertname: CertManagerClusterIssuerNotReady
+        eval_time: 11m
+        exp_alerts: []

--- a/test/promql/tests/data_plane/cert_manager_alerts_test.yaml
+++ b/test/promql/tests/data_plane/cert_manager_alerts_test.yaml
@@ -95,7 +95,7 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: critical
-              slo: "false"
+              slo: "true"
               component: cert-manager
               name: critical-cert
               exported_namespace: my-ns
@@ -105,7 +105,7 @@ tests:
             exp_annotations:
               summary: "Certificate critical-cert in namespace my-ns expires in less than 7 days on cluster stone-prod-p01."
               description: "Certificate critical-cert in namespace my-ns on cluster stone-prod-p01 expires in 3 days. Immediate action required — renewal has likely failed."
-              alert_routing_key: spreandinfra
+              alert_team_handle: "<!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>"
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
 
   # Negative: cert expiring in 15 days (> 7), should NOT fire for critical
@@ -133,7 +133,7 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: critical
-              slo: "false"
+              slo: "true"
               component: cert-manager
               condition: "True"
               name: letsencrypt-prod
@@ -141,7 +141,7 @@ tests:
             exp_annotations:
               summary: "ClusterIssuer letsencrypt-prod is not ready on cluster stone-prod-p01."
               description: "ClusterIssuer letsencrypt-prod has been in a non-ready state for more than 10 minutes on cluster stone-prod-p01. No new certificates can be issued by this issuer."
-              alert_routing_key: spreandinfra
+              alert_team_handle: "<!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>"
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
 
   # Negative: issuer is ready (value=1), should NOT fire

--- a/test/promql/tests/data_plane/cert_manager_alerts_test.yaml
+++ b/test/promql/tests/data_plane/cert_manager_alerts_test.yaml
@@ -106,7 +106,7 @@ tests:
               summary: "Certificate critical-cert in namespace my-ns expires in less than 7 days on cluster stone-prod-p01."
               description: "Certificate critical-cert in namespace my-ns on cluster stone-prod-p01 expires in 3 days. Immediate action required — renewal has likely failed."
               alert_team_handle: "<!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>"
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-CertManagerCertificateExpiryCritical.md
 
   # Negative: cert expiring in 15 days (> 7), should NOT fire for critical
   - interval: 1m
@@ -142,7 +142,7 @@ tests:
               summary: "ClusterIssuer letsencrypt-prod is not ready on cluster stone-prod-p01."
               description: "ClusterIssuer letsencrypt-prod has been in a non-ready state for more than 10 minutes on cluster stone-prod-p01. No new certificates can be issued by this issuer."
               alert_team_handle: "<!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>"
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-CertManagerClusterIssuerNotReady.md
 
   # Negative: issuer is ready (value=1), should NOT fire
   - interval: 1m


### PR DESCRIPTION
Add PrometheusRule alerts for cert-manager visibility across Konflux clusters.

## Alerts
- **CertManagerCertificateNotReady** (warning, 15m) — certificate in non-ready state
- **CertManagerCertificateExpiringSoon** (warning, 30m) — certificate expiring within 21 days
- **CertManagerCertificateExpiryCritical** (critical, 15m) — certificate expiring within 7 days
- **CertManagerClusterIssuerNotReady** (critical, 10m) — ClusterIssuer not ready

All non-SLO, routed to `spreandinfra`. Includes positive and negative promtool unit tests for each alert.

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
https://redhat.atlassian.net/browse/SPRE-5505