### PR TITLE
feat(PVO11Y-5368): Add and adjust panels for the new UX SLO metrics

### DIFF
--- a/dashboards/grafana-dashboard-konflux-tenant-ux-metrics.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-tenant-ux-metrics.configmap.yaml
@@ -46,6 +46,183 @@ data:
                 "type": "prometheus",
                 "uid": "${Datasource}"
               },
+              "description": "Per-component breach status for this tenant. Each cell shows 1 (breaching, red) or 0 (healthy, green). Empty cells mean no data for that domain.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "color-background",
+                      "mode": "basic"
+                    },
+                    "inspect": false
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "color": "green",
+                          "index": 0,
+                          "text": "OK"
+                        },
+                        "1": {
+                          "color": "red",
+                          "index": 1,
+                          "text": "BREACH"
+                        }
+                      },
+                      "type": "value"
+                    },
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "color": "transparent",
+                          "index": 2,
+                          "text": ""
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "noValue": "",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent"
+                      },
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Component"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 250
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "auto"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 1
+              },
+              "id": 60,
+              "options": {
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
+                  "fields": "",
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
+                },
+                "showHeader": true,
+                "sortBy": []
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "max by (application, component) (konflux_build_duration_slo_breach{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "Build"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "max by (application, component) (konflux_integration_duration_slo_breach{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "Integration"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "max by (application, component) (konflux_release_cr_duration_slo_breach{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "Release"
+                }
+              ],
+              "title": "Component Breach Status",
+              "transformations": [
+                {
+                  "id": "merge",
+                  "options": {}
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {
+                      "Time": true,
+                      "application": true
+                    },
+                    "renameByName": {
+                      "component": "Component",
+                      "Value #Build": "Build",
+                      "Value #Integration": "Integration",
+                      "Value #Release": "Release"
+                    }
+                  }
+                },
+                {
+                  "id": "sortBy",
+                  "options": {
+                    "fields": {},
+                    "sort": [
+                      {
+                        "desc": true,
+                        "field": "Build"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {

--- a/dashboards/grafana-dashboard-konflux-ux-slo.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ux-slo.configmap.yaml
@@ -49,7 +49,7 @@ data:
             "type": "prometheus",
             "uid": "${Datasource}"
           },
-          "description": "Number of priority classes with saturation_7d > 5% per cluster. Any value > 0 means the cluster is in breach.",
+          "description": "Composite cluster UX SLO: 1 if either >= 5% of tenants are breaching or kueue saturation exceeds 5%.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -74,7 +74,7 @@ data:
           },
           "gridPos": {
             "h": 6,
-            "w": 6,
+            "w": 5,
             "x": 0,
             "y": 1
           },
@@ -103,13 +103,81 @@ data:
                 "type": "prometheus",
                 "uid": "${Datasource}"
               },
-              "expr": "sum by (source_cluster) (\n  konflux_cluster:kueue_admission_wait_time_seconds:saturation_7d{\n    source_cluster=~\"$Cluster\"\n  } > bool 0.05\n)",
+              "expr": "konflux:cluster_ux_slo_breach{source_cluster=~\"$Cluster\"}",
               "instant": true,
               "legendFormat": "{{source_cluster}}",
               "refId": "A"
             }
           ],
-          "title": "Cluster Breach (priority classes > 5%)",
+          "title": "Cluster UX SLO Breach",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Datasource}"
+          },
+          "description": "1 if >= 5% of tenants on a cluster are breaching their duration SLO in any domain.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 5,
+            "y": 1
+          },
+          "id": 105,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.11",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "expr": "konflux:aggregate_performance_slo_breach{source_cluster=~\"$Cluster\"}",
+              "instant": true,
+              "legendFormat": "{{source_cluster}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Aggregate Tenant Breach",
           "type": "stat"
         },
         {
@@ -149,8 +217,8 @@ data:
           },
           "gridPos": {
             "h": 6,
-            "w": 6,
-            "x": 6,
+            "w": 5,
+            "x": 10,
             "y": 1
           },
           "id": 102,
@@ -178,7 +246,7 @@ data:
                 "type": "prometheus",
                 "uid": "${Datasource}"
               },
-              "expr": "sum by (source_cluster) (\n  konflux_build_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  } == bool 1\n)\n/\ncount by (source_cluster) (\n  konflux_build_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  }\n)",
+              "expr": "konflux:tenant_performance_slo_breach_percentage{domain=\"build\", source_cluster=~\"$Cluster\"}",
               "instant": true,
               "legendFormat": "{{source_cluster}}",
               "refId": "A"
@@ -224,8 +292,8 @@ data:
           },
           "gridPos": {
             "h": 6,
-            "w": 6,
-            "x": 12,
+            "w": 5,
+            "x": 15,
             "y": 1
           },
           "id": 103,
@@ -253,7 +321,7 @@ data:
                 "type": "prometheus",
                 "uid": "${Datasource}"
               },
-              "expr": "sum by (source_cluster) (\n  konflux_integration_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  } == bool 1\n)\n/\ncount by (source_cluster) (\n  konflux_integration_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  }\n)",
+              "expr": "konflux:tenant_performance_slo_breach_percentage{domain=\"integration\", source_cluster=~\"$Cluster\"}",
               "instant": true,
               "legendFormat": "{{source_cluster}}",
               "refId": "A"
@@ -299,8 +367,8 @@ data:
           },
           "gridPos": {
             "h": 6,
-            "w": 6,
-            "x": 18,
+            "w": 4,
+            "x": 20,
             "y": 1
           },
           "id": 104,
@@ -328,7 +396,7 @@ data:
                 "type": "prometheus",
                 "uid": "${Datasource}"
               },
-              "expr": "sum by (source_cluster) (\n  konflux_release_cr_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  } == bool 1\n)\n/\ncount by (source_cluster) (\n  konflux_release_cr_duration_slo_breach{\n    source_cluster=~\"$Cluster\"\n  }\n)",
+              "expr": "konflux:tenant_performance_slo_breach_percentage{domain=\"release_cr\", source_cluster=~\"$Cluster\"}",
               "instant": true,
               "legendFormat": "{{source_cluster}}",
               "refId": "A"
@@ -592,47 +660,152 @@ data:
                 "type": "prometheus",
                 "uid": "${Datasource}"
               },
-              "description": "Tenants in breach of build duration SLO on this cluster.",
+              "description": "Per-tenant breach summary. Shows the fraction of components breaching in each domain. Yellow at >= 1%, red at >= 5%.",
               "fieldConfig": {
                 "defaults": {
                   "color": {
                     "mode": "thresholds"
                   },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "inspect": false
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "color": "transparent",
+                          "index": 0,
+                          "text": ""
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "noValue": "",
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "transparent"
+                      },
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 0.01
                       },
                       {
                         "color": "red",
-                        "value": 1
+                        "value": 0.05
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Tenant"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 250
+                      },
+                      {
+                        "id": "unit",
+                        "value": "string"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "text"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Build"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "gauge",
+                          "valueDisplayMode": "color"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Integration"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "gauge",
+                          "valueDisplayMode": "color"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Release"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "gauge",
+                          "valueDisplayMode": "color"
+                        }
                       }
                     ]
                   }
-                },
-                "overrides": []
+                ]
               },
               "gridPos": {
-                "h": 6,
-                "w": 8,
+                "h": 10,
+                "w": 24,
                 "x": 0,
                 "y": 30
               },
               "id": 11,
               "options": {
-                "colorMode": "background",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "horizontal",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
                   "fields": "",
-                  "values": false
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
                 },
-                "textMode": "auto"
+                "showHeader": true,
+                "sortBy": []
               },
               "targets": [
                 {
@@ -640,31 +813,127 @@ data:
                     "type": "prometheus",
                     "uid": "${Datasource}"
                   },
-                  "expr": "konflux_build_duration_slo_breach{source_cluster=\"$Cluster\", exported_namespace=~\"$Tenant\"}",
+                  "expr": "sum by (exported_namespace) (konflux_build_duration_slo_breach{source_cluster=\"$Cluster\", exported_namespace=~\"$Tenant\"} == bool 1)\n/\ncount by (exported_namespace) (konflux_build_duration_slo_breach{source_cluster=\"$Cluster\", exported_namespace=~\"$Tenant\"})",
+                  "format": "table",
                   "instant": true,
-                  "legendFormat": "{{exported_namespace}}",
-                  "refId": "A"
+                  "legendFormat": "",
+                  "refId": "Build"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "sum by (exported_namespace) (konflux_integration_duration_slo_breach{source_cluster=\"$Cluster\", exported_namespace=~\"$Tenant\"} == bool 1)\n/\ncount by (exported_namespace) (konflux_integration_duration_slo_breach{source_cluster=\"$Cluster\", exported_namespace=~\"$Tenant\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "Integration"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "sum by (exported_namespace) (konflux_release_cr_duration_slo_breach{source_cluster=\"$Cluster\", exported_namespace=~\"$Tenant\"} == bool 1)\n/\ncount by (exported_namespace) (konflux_release_cr_duration_slo_breach{source_cluster=\"$Cluster\", exported_namespace=~\"$Tenant\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "Release"
                 }
               ],
-              "title": "Build Duration SLO Breach",
-              "type": "stat"
+              "title": "Tenant Breach Summary",
+              "transformations": [
+                {
+                  "id": "merge",
+                  "options": {}
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {
+                      "Time": true
+                    },
+                    "renameByName": {
+                      "exported_namespace": "Tenant",
+                      "Value #Build": "Build",
+                      "Value #Integration": "Integration",
+                      "Value #Release": "Release"
+                    }
+                  }
+                },
+                {
+                  "id": "sortBy",
+                  "options": {
+                    "fields": {},
+                    "sort": [
+                      {
+                        "desc": true,
+                        "field": "Build"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "type": "table"
             },
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${Datasource}"
               },
-              "description": "Tenants in breach of integration duration SLO on this cluster.",
+              "description": "Per-component breach detail for the selected tenant. Each cell shows 1 (breaching, red) or 0 (healthy, green).",
               "fieldConfig": {
                 "defaults": {
                   "color": {
                     "mode": "thresholds"
                   },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "color-background",
+                      "mode": "basic"
+                    },
+                    "inspect": false
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "color": "green",
+                          "index": 0,
+                          "text": "OK"
+                        },
+                        "1": {
+                          "color": "red",
+                          "index": 1,
+                          "text": "BREACH"
+                        }
+                      },
+                      "type": "value"
+                    },
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "color": "transparent",
+                          "index": 2,
+                          "text": ""
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "noValue": "",
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "transparent"
+                      },
+                      {
+                        "color": "green",
+                        "value": 0
                       },
                       {
                         "color": "red",
@@ -673,90 +942,46 @@ data:
                     ]
                   }
                 },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 8,
-                "y": 30
-              },
-              "id": 12,
-              "options": {
-                "colorMode": "background",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "horizontal",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "textMode": "auto"
-              },
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${Datasource}"
-                  },
-                  "expr": "konflux_integration_duration_slo_breach{source_cluster=\"$Cluster\", exported_namespace=~\"$Tenant\"}",
-                  "instant": true,
-                  "legendFormat": "{{exported_namespace}}",
-                  "refId": "A"
-                }
-              ],
-              "title": "Integration Duration SLO Breach",
-              "type": "stat"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${Datasource}"
-              },
-              "description": "Tenants in breach of release CR duration SLO on this cluster.",
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Component"
+                    },
+                    "properties": [
                       {
-                        "color": "green"
+                        "id": "custom.width",
+                        "value": 250
                       },
                       {
-                        "color": "red",
-                        "value": 1
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "auto"
+                        }
                       }
                     ]
                   }
-                },
-                "overrides": []
+                ]
               },
               "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 16,
-                "y": 30
+                "h": 10,
+                "w": 24,
+                "x": 0,
+                "y": 40
               },
-              "id": 13,
+              "id": 14,
               "options": {
-                "colorMode": "background",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "horizontal",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
                   "fields": "",
-                  "values": false
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
                 },
-                "textMode": "auto"
+                "showHeader": true,
+                "sortBy": []
               },
               "targets": [
                 {
@@ -764,14 +989,78 @@ data:
                     "type": "prometheus",
                     "uid": "${Datasource}"
                   },
-                  "expr": "konflux_release_cr_duration_slo_breach{source_cluster=\"$Cluster\", exported_namespace=~\"$Tenant\"}",
+                  "expr": "max by (exported_namespace, application, component) (konflux_build_duration_slo_breach{source_cluster=\"$Cluster\", exported_namespace=~\"$Tenant\"})",
+                  "format": "table",
                   "instant": true,
-                  "legendFormat": "{{exported_namespace}}",
-                  "refId": "A"
+                  "legendFormat": "",
+                  "refId": "Build"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "max by (exported_namespace, application, component) (konflux_integration_duration_slo_breach{source_cluster=\"$Cluster\", exported_namespace=~\"$Tenant\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "Integration"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "expr": "max by (exported_namespace, application, component) (konflux_release_cr_duration_slo_breach{source_cluster=\"$Cluster\", exported_namespace=~\"$Tenant\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "Release"
                 }
               ],
-              "title": "Release CR Duration SLO Breach",
-              "type": "stat"
+              "title": "Component Breach Detail - ${Tenant}",
+              "transformations": [
+                {
+                  "id": "merge",
+                  "options": {}
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {
+                      "Time": true,
+                      "application": true
+                    },
+                    "renameByName": {
+                      "exported_namespace": "Tenant",
+                      "component": "Component",
+                      "Value #Build": "Build",
+                      "Value #Integration": "Integration",
+                      "Value #Release": "Release"
+                    },
+                    "indexByName": {
+                      "exported_namespace": 0,
+                      "component": 1,
+                      "Value #Build": 2,
+                      "Value #Integration": 3,
+                      "Value #Release": 4
+                    }
+                  }
+                },
+                {
+                  "id": "sortBy",
+                  "options": {
+                    "fields": {},
+                    "sort": [
+                      {
+                        "desc": true,
+                        "field": "Build"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "type": "table"
             }
           ],
           "repeat": "Cluster",


### PR DESCRIPTION
### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

JIRA: [PVO11Y-5368](https://redhat.atlassian.net/browse/PVO11Y-5368)

Implementing new panels and adjusting already existing ones with new `slo_breach` metrics and recording rules we have created. 

https://grafana.stage.devshift.net/d/konflux-ux-slo-tbehal2/konflux-ux-slo-2?orgId=1&from=now-7d&to=now&timezone=UTC&var-Datasource=PDCCF087A30F0737B&var-Cluster=$__all&var-Tenant=$__all

https://grafana.stage.devshift.net/d/konflux-tenant-ux-metrics-tbehal/konflux-tenant-level-ux-metrics?orgId=1&from=now-6h&to=now&timezone=UTC&var-Datasource=PDCCF087A30F0737B&var-Cluster=$__all&var-Tenant=abardavi-test-tenant&var-omit_tenant=$__all


---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [X] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [X] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [X] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [X] **Pipeline Finished Successfully**

---

### Deployment Notice

- [X] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.


[PVO11Y-5368]: https://redhat.atlassian.net/browse/PVO11Y-5368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ