### PR TITLE
fix(PVO11Y-5405): use max without(priority_class) in cluster_ux_slo_breach

### DIFF
--- a/rhobs/recording/ux_slo_aggregate_recording_rules.yaml
+++ b/rhobs/recording/ux_slo_aggregate_recording_rules.yaml
@@ -101,11 +101,11 @@ spec:
             (konflux:aggregate_performance_slo_breach == 1)
               or
             (
-              max by (source_cluster) (
+              max without (priority_class) (
                 konflux_cluster:kueue_admission_wait_time_seconds:saturation_7d >= bool 0.05
               ) == 1
             )
               or
             (konflux:aggregate_performance_slo_breach * 0)
               or
-            (max by (source_cluster) (konflux_cluster:kueue_admission_wait_time_seconds:saturation_7d) * 0)
+            (max without (priority_class) (konflux_cluster:kueue_admission_wait_time_seconds:saturation_7d) * 0)

--- a/test/promql/tests/recording/ux_slo_aggregate_recording_rules_test.yaml
+++ b/test/promql/tests/recording/ux_slo_aggregate_recording_rules_test.yaml
@@ -394,6 +394,27 @@ tests:
           - labels: 'konflux:cluster_ux_slo_breach{source_cluster="cluster-1"}'
             value: 1
 
+  - name: ClusterUxSloWithTenantIdLabelCollision
+    interval: 5m
+    input_series:
+      # Simulates RHOBS injecting tenant_id into all metrics.
+      # max by (source_cluster) drops tenant_id from kueue, causing label
+      # mismatch with aggregate (which keeps tenant_id). The or chain then
+      # produces two series for the same source_cluster that collide after
+      # rule labels are applied.
+      - series: 'konflux:aggregate_performance_slo_breach{source_cluster="cluster-1", tenant_id="rhobs-tenant"}'
+        values: "1x5"
+      - series: 'konflux_cluster:kueue_admission_wait_time_seconds:saturation_7d{priority_class="pre-merge-build", source_cluster="cluster-1", tenant_id="rhobs-tenant"}'
+        values: "0.03x5"
+    promql_expr_test:
+      # Should produce exactly ONE series. With max by (source_cluster), it
+      # produces TWO (one with tenant_id, one without) which is the bug.
+      - expr: konflux:cluster_ux_slo_breach
+        eval_time: 5m
+        exp_samples:
+          - labels: 'konflux:cluster_ux_slo_breach{source_cluster="cluster-1", tenant_id="rhobs-tenant"}'
+            value: 1
+
   - name: ClusterUxSloNoBreachWhenBothHealthy
     interval: 5m
     input_series:


### PR DESCRIPTION
### Description

RHOBS injects tenant_id into all metrics. max by (source_cluster) drops tenant_id from kueue metrics, causing label mismatch with aggregate metrics in the or chain. After RHOBS applies rule labels, both sides collide: "vector contains metrics with the same labelset after applying rule labels".

Switch to max without (priority_class) to preserve all labels except the one we need to collapse.


<img width="2370" height="869" alt="image" src="https://github.com/user-attachments/assets/20fdd52d-edd4-44b8-842e-bf456782b0e7" />


<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [X] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [x] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [x] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
