### PR TITLE
feat(KFLUXVNGD-1096): add Caddy UI proxy HTTP error alerts

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml
@@ -161,3 +161,105 @@ spec:
         alert_team_handle: <!subteam^S04HY632621>
         team: konflux-ui
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/konflux-ui/sre/upstream-502.md
+
+  # Konflux UI proxy (Caddy) HTTP error-rate alerts.
+  # Built from caddy_http_request_errors:* recording rules / raw _count (see each expr).
+  # proxy: caddy disambiguates Alertmanager identity from nginx twins during rollout.
+  - name: konflux-ui-caddy-http-error-rate
+    interval: 1m
+    rules:
+    - alert: KonfluxUIHttpHighErrorRate
+      expr: |
+        sum by (job, source_cluster) (caddy_http_request_errors:rate5m)
+        >
+        sum by (job, source_cluster) (
+          (caddy_http_request_errors:rate24h_avg)
+          +
+          3 * (caddy_http_request_errors:rate24h_stddev)
+        )
+      for: 5m
+      labels:
+        severity: warning
+        slo: "false"
+        component: konflux-ui
+        proxy: caddy
+      annotations:
+        summary: >-
+          Konflux UI HTTP endpoints are experiencing a high error rate in cluster {{ $labels.source_cluster }}
+        description: >
+          The Konflux UI HTTP endpoints have been experiencing a high error rate for 5min in cluster {{ $labels.source_cluster }}
+        alert_routing_key: konflux-ui
+        team: konflux-ui
+        runbook_url: null
+
+  - name: konflux-ui-caddy-5xx-http-error-rate
+    interval: 1m
+    rules:
+    - alert: KonfluxUIHttpHigh5xxErrorRate
+      expr: |
+        sum by (job, source_cluster) (caddy_http_request_errors:rate5m{status=~"5.."})
+        >
+        sum by (job, source_cluster) (
+          (caddy_http_request_errors:rate24h_avg{status=~"5.."})
+          +
+          3 * (caddy_http_request_errors:rate24h_stddev{status=~"5.."})
+        )
+      for: 5m
+      labels:
+        severity: warning
+        slo: "false"
+        component: konflux-ui
+        proxy: caddy
+      annotations:
+        summary: >-
+          Konflux UI HTTP endpoints are experiencing a high 5xx error rate in cluster {{ $labels.source_cluster }}
+        description: >
+          The Konflux UI HTTP endpoints have been experiencing a high 5xx error rate for 5min in cluster {{ $labels.source_cluster }}
+        alert_routing_key: <!subteam^S06V06A36F5>
+        team: spre
+        runbook_url: null
+
+  - name: konflux-ui-caddy-upstream-502
+    interval: 1m
+    rules:
+    - alert: KonfluxUIUpstream502
+      expr: |
+        # Uses raw caddy_http_request_duration_seconds_count (not
+        # caddy_http_request_errors:rate5m): this alert needs a 2m rate window aligned
+        # with for: 2m. The :rate5m recording rule is for the anomaly alerts above.
+        # Restrict to namespace="konflux-ui" so other namespaces cannot contribute.
+        # Caddy increments _count once per middleware handler for the same request —
+        # max without (handler, method, server) collapses that to one request-level rate
+        # before summing across series.
+        # rate[2m] matches the for: 2m pending period intentionally: a wider window (e.g. [5m])
+        # would allow a brief burst to keep the rate positive long enough to satisfy the
+        # pending period without sustained errors actually occurring.
+        # threshold of 0.05/s (~1 error per 20s) filters brief rolling-deploy bursts
+        # while catching sustained upstream failures within the 2m pending period.
+        sum by (source_cluster) (
+          max without (handler, method, server) (
+            rate(
+              caddy_http_request_duration_seconds_count{
+                namespace="konflux-ui",
+                code="502"
+              }[2m]
+            )
+          )
+        ) > 0.05
+      for: 2m
+      labels:
+        severity: critical
+        slo: "true"
+        component: konflux-ui
+        proxy: caddy
+      annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L225
+        summary: >-
+          Konflux UI proxy returning 502 errors in cluster {{ $labels.source_cluster }}
+        description: >
+          The Konflux UI proxy has been returning 502 errors for 2min in cluster
+          {{ $labels.source_cluster }}, indicating an upstream backend (e.g. namespace-lister)
+          is down or unreachable.
+        alert_team_handle: <!subteam^S04HY632621>
+        team: konflux-ui
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/konflux-ui/sre/upstream-502.md

--- a/rhobs/recording/konflux_ui_availability_recording_rules.yaml
+++ b/rhobs/recording/konflux_ui_availability_recording_rules.yaml
@@ -44,10 +44,10 @@ spec:
         - record: nginx_otel_http_request_errors:rate24h_stddev
           expr: stddev_over_time(nginx_otel_http_request_errors:rate5m[24h])
 
-        # Caddy UI proxy HTTP 4xx/5xx rates (replaces nginx_otel_* once alerts switch).
-        # Source is histogram _count with code=; rename to status for alert parity.
+        # Konflux UI proxy (Caddy) HTTP 4xx/5xx rates from histogram _count.
+        # label_replace maps code → status for alert matchers (status=~"5..", etc.).
         # Caddy increments _count once per middleware handler for the same request —
-        # max without (handler, method, server) keeps a request-level rate (nginx-like),
+        # max without (handler, method, server) collapses that to one request-level rate,
         # then sum across pods/instances by (job, status, source_cluster).
         - record: caddy_http_request_errors:rate5m
           expr: |

--- a/test/promql/tests/data_plane/konflux_ui_alerts_test.yaml
+++ b/test/promql/tests/data_plane/konflux_ui_alerts_test.yaml
@@ -309,3 +309,229 @@ tests:
               alert_team_handle: <!subteam^S04HY632621>
               team: konflux-ui
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/konflux-ui/sre/upstream-502.md
+
+  # --- Caddy UI proxy HTTP error alerts ---
+
+  - interval: 1m
+    input_series:
+      # HTTP 5xx short spike (no alert)
+      - series: 'caddy_http_request_errors:rate5m{job="proxy", status="500", source_cluster="c_caddy_5xx_short"}'
+        values: '0x5 10x3 0x7'
+      - series: 'caddy_http_request_errors:rate24h_avg{job="proxy", status="500", source_cluster="c_caddy_5xx_short"}'
+        values: '1x15'
+      - series: 'caddy_http_request_errors:rate24h_stddev{job="proxy", status="500", source_cluster="c_caddy_5xx_short"}'
+        values: '1x15'
+      # HTTP 5xx long spike (alert)
+      - series: 'caddy_http_request_errors:rate5m{job="proxy", status="500", source_cluster="c_caddy_5xx_long"}'
+        values: '0x5 10x10'
+      - series: 'caddy_http_request_errors:rate24h_avg{job="proxy", status="500", source_cluster="c_caddy_5xx_long"}'
+        values: '1x15'
+      - series: 'caddy_http_request_errors:rate24h_stddev{job="proxy", status="500", source_cluster="c_caddy_5xx_long"}'
+        values: '1x15'
+      # Normal operation (no alert)
+      - series: 'caddy_http_request_errors:rate5m{job="proxy", status="500", source_cluster="c_caddy_5xx_ok"}'
+        values: '0x15'
+      - series: 'caddy_http_request_errors:rate24h_avg{job="proxy", status="500", source_cluster="c_caddy_5xx_ok"}'
+        values: '1x15'
+      - series: 'caddy_http_request_errors:rate24h_stddev{job="proxy", status="500", source_cluster="c_caddy_5xx_ok"}'
+        values: '1x15'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: KonfluxUIHttpHigh5xxErrorRate
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: konflux-ui
+              job: proxy
+              proxy: caddy
+              slo: "false"
+              source_cluster: c_caddy_5xx_long
+            exp_annotations:
+              summary: Konflux UI HTTP endpoints are experiencing a high 5xx error rate in cluster c_caddy_5xx_long
+              description: >
+                The Konflux UI HTTP endpoints have been experiencing a high 5xx error rate for 5min in cluster c_caddy_5xx_long
+              alert_routing_key: <!subteam^S06V06A36F5>
+              team: spre
+              runbook_url: null
+
+  - interval: 1m
+    input_series:
+      # Small spike, should not fire
+      - series: 'caddy_http_request_errors:rate5m{job="proxy", status="400", source_cluster="c_caddy_general_small_spike_4xx"}'
+        values: '0x3 5x2 0x10'
+      - series: 'caddy_http_request_errors:rate24h_avg{job="proxy", status="400", source_cluster="c_caddy_general_small_spike_4xx"}'
+        values: '1x15'
+      - series: 'caddy_http_request_errors:rate24h_stddev{job="proxy", status="400", source_cluster="c_caddy_general_small_spike_4xx"}'
+        values: '1x15'
+      - series: 'caddy_http_request_errors:rate5m{job="proxy", status="500", source_cluster="c_caddy_general_small_spike_5xx"}'
+        values: '0x3 5x2 0x10'
+      - series: 'caddy_http_request_errors:rate24h_avg{job="proxy", status="500", source_cluster="c_caddy_general_small_spike_5xx"}'
+        values: '1x15'
+      - series: 'caddy_http_request_errors:rate24h_stddev{job="proxy", status="500", source_cluster="c_caddy_general_small_spike_5xx"}'
+        values: '1x15'
+      # Big and long spike, should fire
+      - series: 'caddy_http_request_errors:rate5m{job="proxy", status="400", source_cluster="c_caddy_general_big_long_spike_4xx"}'
+        values: '0x5 100+100x10'
+      - series: 'caddy_http_request_errors:rate24h_avg{job="proxy", status="400", source_cluster="c_caddy_general_big_long_spike_4xx"}'
+        values: '1x15'
+      - series: 'caddy_http_request_errors:rate24h_stddev{job="proxy", status="400", source_cluster="c_caddy_general_big_long_spike_4xx"}'
+        values: '1x15'
+      - series: 'caddy_http_request_errors:rate5m{job="proxy", status="500", source_cluster="c_caddy_general_big_long_spike_5xx"}'
+        values: '0x5 100+100x10'
+      - series: 'caddy_http_request_errors:rate24h_avg{job="proxy", status="500", source_cluster="c_caddy_general_big_long_spike_5xx"}'
+        values: '1x15'
+      - series: 'caddy_http_request_errors:rate24h_stddev{job="proxy", status="500", source_cluster="c_caddy_general_big_long_spike_5xx"}'
+        values: '1x15'
+      # Big but short spike, should not fire
+      - series: 'caddy_http_request_errors:rate5m{job="proxy", status="400", source_cluster="c_caddy_general_big_short_spike_4xx"}'
+        values: '0x3 500x2 0x10'
+      - series: 'caddy_http_request_errors:rate24h_avg{job="proxy", status="400", source_cluster="c_caddy_general_big_short_spike_4xx"}'
+        values: '1x15'
+      - series: 'caddy_http_request_errors:rate24h_stddev{job="proxy", status="400", source_cluster="c_caddy_general_big_short_spike_4xx"}'
+        values: '1x15'
+      - series: 'caddy_http_request_errors:rate5m{job="proxy", status="500", source_cluster="c_caddy_general_big_short_spike_5xx"}'
+        values: '0x3 500x2 0x10'
+      - series: 'caddy_http_request_errors:rate24h_avg{job="proxy", status="500", source_cluster="c_caddy_general_big_short_spike_5xx"}'
+        values: '1x15'
+      - series: 'caddy_http_request_errors:rate24h_stddev{job="proxy", status="500", source_cluster="c_caddy_general_big_short_spike_5xx"}'
+        values: '1x15'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: KonfluxUIHttpHighErrorRate
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: KonfluxUIHttpHighErrorRate
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: konflux-ui
+              job: proxy
+              proxy: caddy
+              slo: "false"
+              source_cluster: c_caddy_general_big_long_spike_4xx
+            exp_annotations:
+              summary: Konflux UI HTTP endpoints are experiencing a high error rate in cluster c_caddy_general_big_long_spike_4xx
+              description: >
+                The Konflux UI HTTP endpoints have been experiencing a high error rate for 5min in cluster c_caddy_general_big_long_spike_4xx
+              alert_routing_key: konflux-ui
+              team: konflux-ui
+              runbook_url: null
+          - exp_labels:
+              severity: warning
+              component: konflux-ui
+              job: proxy
+              proxy: caddy
+              slo: "false"
+              source_cluster: c_caddy_general_big_long_spike_5xx
+            exp_annotations:
+              summary: Konflux UI HTTP endpoints are experiencing a high error rate in cluster c_caddy_general_big_long_spike_5xx
+              description: >
+                The Konflux UI HTTP endpoints have been experiencing a high error rate for 5min in cluster c_caddy_general_big_long_spike_5xx
+              alert_routing_key: konflux-ui
+              team: konflux-ui
+              runbook_url: null
+      - eval_time: 7m
+        alertname: KonfluxUIHttpHighErrorRate
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      # Small spike, should not fire
+      - series: 'caddy_http_request_errors:rate5m{job="proxy", status="503", source_cluster="c_caddy_5xx_small_spike"}'
+        values: '0x3 5x2 0x10'
+      - series: 'caddy_http_request_errors:rate24h_avg{job="proxy", status="503", source_cluster="c_caddy_5xx_small_spike"}'
+        values: '1x15'
+      - series: 'caddy_http_request_errors:rate24h_stddev{job="proxy", status="503", source_cluster="c_caddy_5xx_small_spike"}'
+        values: '1x15'
+      # Big and long spike, should fire
+      - series: 'caddy_http_request_errors:rate5m{job="proxy", status="503", source_cluster="c_caddy_5xx_big_long_spike"}'
+        values: '0x5 100+100x10'
+      - series: 'caddy_http_request_errors:rate24h_avg{job="proxy", status="503", source_cluster="c_caddy_5xx_big_long_spike"}'
+        values: '1x15'
+      - series: 'caddy_http_request_errors:rate24h_stddev{job="proxy", status="503", source_cluster="c_caddy_5xx_big_long_spike"}'
+        values: '1x15'
+      # Big but short spike, should not fire
+      - series: 'caddy_http_request_errors:rate5m{job="proxy", status="503", source_cluster="c_caddy_5xx_big_short_spike"}'
+        values: '0x3 500x2 0x10'
+      - series: 'caddy_http_request_errors:rate24h_avg{job="proxy", status="503", source_cluster="c_caddy_5xx_big_short_spike"}'
+        values: '1x15'
+      - series: 'caddy_http_request_errors:rate24h_stddev{job="proxy", status="503", source_cluster="c_caddy_5xx_big_short_spike"}'
+        values: '1x15'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: KonfluxUIHttpHigh5xxErrorRate
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: KonfluxUIHttpHigh5xxErrorRate
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: konflux-ui
+              job: proxy
+              proxy: caddy
+              slo: "false"
+              source_cluster: c_caddy_5xx_big_long_spike
+            exp_annotations:
+              summary: Konflux UI HTTP endpoints are experiencing a high 5xx error rate in cluster c_caddy_5xx_big_long_spike
+              description: >
+                The Konflux UI HTTP endpoints have been experiencing a high 5xx error rate for 5min in cluster c_caddy_5xx_big_long_spike
+              alert_routing_key: <!subteam^S06V06A36F5>
+              team: spre
+              runbook_url: null
+      - eval_time: 7m
+        alertname: KonfluxUIHttpHigh5xxErrorRate
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      # Sustained 502s on two middleware handlers — max without collapses to one rate; should fire
+      - series: 'caddy_http_request_duration_seconds_count{namespace="konflux-ui", code="502", handler="metrics", method="GET", server="srv0", source_cluster="c_caddy_upstream_502", job="proxy"}'
+        values: '0+10x10'
+      - series: 'caddy_http_request_duration_seconds_count{namespace="konflux-ui", code="502", handler="reverse_proxy", method="GET", server="srv0", source_cluster="c_caddy_upstream_502", job="proxy"}'
+        values: '0+10x10'
+      # Only 404s — should not fire
+      - series: 'caddy_http_request_duration_seconds_count{namespace="konflux-ui", code="404", handler="reverse_proxy", method="GET", server="srv0", source_cluster="c_caddy_upstream_ok", job="proxy"}'
+        values: '0+10x10'
+      # Brief 502 burst then flat — should not fire
+      - series: 'caddy_http_request_duration_seconds_count{namespace="konflux-ui", code="502", handler="reverse_proxy", method="GET", server="srv0", source_cluster="c_caddy_upstream_burst", job="proxy"}'
+        values: '0 1 2 2 2 2 2 2 2 2'
+
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: KonfluxUIUpstream502
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: konflux-ui
+              proxy: caddy
+              slo: "true"
+              source_cluster: c_caddy_upstream_502
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L225
+              summary: Konflux UI proxy returning 502 errors in cluster c_caddy_upstream_502
+              description: >
+                The Konflux UI proxy has been returning 502 errors for 2min in cluster
+                c_caddy_upstream_502, indicating an upstream backend (e.g. namespace-lister)
+                is down or unreachable.
+              alert_team_handle: <!subteam^S04HY632621>
+              team: konflux-ui
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/konflux-ui/sre/upstream-502.md
+      - eval_time: 5m
+        alertname: KonfluxUIUpstream502
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: konflux-ui
+              proxy: caddy
+              slo: "true"
+              source_cluster: c_caddy_upstream_502
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.konflux_ui_availability_alerts.yaml#L225
+              summary: Konflux UI proxy returning 502 errors in cluster c_caddy_upstream_502
+              description: >
+                The Konflux UI proxy has been returning 502 errors for 2min in cluster
+                c_caddy_upstream_502, indicating an upstream backend (e.g. namespace-lister)
+                is down or unreachable.
+              alert_team_handle: <!subteam^S04HY632621>
+              team: konflux-ui
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/konflux-ui/sre/upstream-502.md


### PR DESCRIPTION
Mirror the nginx error-rate and upstream-502 alerts on caddy_http_request_errors:* / raw _count so operator clusters are covered during the rollout.

Assisted-by: Cursor

### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [x] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [ ] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
