### PR TITLE
fix(SPRE-5950): replace KonfluxAlert instant check with count_over_time 10-min window

### DIFF
--- a/docs/ALERTS.md
+++ b/docs/ALERTS.md
@@ -100,7 +100,7 @@ How `konflux_up` signals are created:
 
 In both cases, the metric must be forwarded to RHOBS via infra-deployments before alerts can consume it.
 
-Alerts built on `konflux_up` follow the pattern `konflux_up{namespace="...", check="...", service="..."} != 1`. A meta-alert (`KonfluxAlert`) also monitors for missing `konflux_up` signals by comparing against an `offset 1h` window and notifies o11y if a signal disappears.
+Alerts built on `konflux_up` follow the pattern `konflux_up{namespace="...", check="...", service="..."} != 1`. A meta-alert (`KonfluxAlert`) also monitors for missing `konflux_up` signals by checking whether the metric was present in the last hour but absent for the last 10 minutes, and notifies o11y if a signal disappears.
 
 ### Converting between alert types
 

--- a/rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml
@@ -10,14 +10,17 @@ spec:
     interval: 1m
     rules:
     - alert: KonfluxAlert
-      expr: (konflux_up offset 1h) unless on(service, check, source_cluster) konflux_up
-      for: 30m
+      expr: |
+        (sum by (service, check, source_cluster) (count_over_time(konflux_up[1h])) > 0)
+        unless on(service, check, source_cluster)
+        (sum by (service, check, source_cluster) (count_over_time(konflux_up[10m])) > 0)
+      for: 5m
       labels:
         severity: warning
       annotations:
         summary: Availability metric 'konflux_up' is missing.
         description: >-
-          Availability metric 'konflux_up' is missing some entries for check {{ $labels.check }}
-          on service {{ $labels.service }} and cluster {{ $labels.source_cluster }} when compared
-          to previous hour.
+          Availability metric 'konflux_up' has not reported for check {{ $labels.check }}
+          on service {{ $labels.service }} and cluster {{ $labels.source_cluster }}
+          in the last 10 minutes, but was present in the last hour.
         alert_routing_key: 'o11y'

--- a/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
+++ b/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
@@ -4,18 +4,26 @@ rule_files:
   - prometheus.availability_metric_konflux_alerts.yaml
 
 tests:
+  # Test 1: Metric disappears after 59 minutes - should alert
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", source_cluster="stone-stg-rh01"}'
-        values: '1x59 _x61'
+        values: '1x59 _x41'
       - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", source_cluster="stone-stg-m01"}'
-        values: '1x120'
+        values: '1x100'
 
     alert_rule_test:
-      - eval_time: 70m
+      # At 65m: metric absent for only 6 minutes. count_over_time[10m] still has samples. No alert.
+      - eval_time: 65m
         alertname: KonfluxAlert
 
-      - eval_time: 105m
+      # At 72m: count_over_time[10m] no longer includes the last sample (T=58m),
+      # so the expression is true, but for:5m pending period has not fully elapsed. No alert.
+      - eval_time: 72m
+        alertname: KonfluxAlert
+
+      # At 80m: metric absent for 21 minutes. Well past 10m window + 5m for. Alert fires.
+      - eval_time: 80m
         alertname: KonfluxAlert
         exp_alerts:
           - exp_labels:
@@ -27,27 +35,29 @@ tests:
               summary: >-
                 Availability metric 'konflux_up' is missing.
               description: >-
-                Availability metric 'konflux_up' is missing some entries for check
-                prometheus-appstudio-ds on service grafana and cluster stone-stg-rh01 when
-                compared to previous hour.
+                Availability metric 'konflux_up' has not reported for check
+                prometheus-appstudio-ds on service grafana and cluster stone-stg-rh01
+                in the last 10 minutes, but was present in the last hour.
               alert_routing_key: 'o11y'
 
+  # Test 2: Metric disappears too early (outside 1h lookback) - should NOT alert
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", source_cluster="stone-stg-rh01"}'
-        values: '1x30 _x90'
+        values: '1x5 _x115'
 
     alert_rule_test:
-      - eval_time: 120m
+      - eval_time: 100m
         alertname: KonfluxAlert
 
+  # Test 3: Pod label change (pod restart) - should NOT alert
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", source_cluster="stone-stg-rh01", pod="grafana-pod1"}'
-        values: '_x59 1x61'
+        values: '_x59 1x41'
       - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", source_cluster="stone-stg-rh01", pod="grafana-pod2"}'
-        values: '1x59 _x61'
+        values: '1x59 _x41'
 
     alert_rule_test:
-      - eval_time: 120m
+      - eval_time: 80m
         alertname: KonfluxAlert


### PR DESCRIPTION
### Description

[SPRE-5950](https://issues.redhat.com/browse/SPRE-5950)

Replace the KonfluxAlert expression with a time-window approach that reduces false positives during RHOBS pipeline disruptions.

**Old expression:**
```yaml
expr: (konflux_up offset 1h) unless on(service, check, source_cluster) konflux_up
for: 30m
```

**New expression:**
```yaml
expr: >-
  (sum by (service, check, source_cluster) (count_over_time(konflux_up[1h])) > 0)
  unless on(service, check, source_cluster)
  (sum by (service, check, source_cluster) (count_over_time(konflux_up[10m])) > 0)
for: 5m
```

**Why:** The old expression fires when `konflux_up` is momentarily absent at a single point in time. During pipeline disruptions (SSO outages, RHOBS ingestion issues), all checks disappear simultaneously, producing 800+ alerts for a single platform event.

The new expression checks whether a check reported at least once in the last 10 minutes. The `sum by (service, check, source_cluster)` wrapper normalizes volatile labels (like `pod` or `instance`) to prevent fan-out during pod restarts. This absorbs brief gaps while detecting genuine outages within 15 minutes total (10-min window + 5-min `for` clause).

**Detection time improvement:** 30 minutes -> 15 minutes.

Also updated `docs/ALERTS.md` line 103 to reflect the new expression mechanism.

### Pre-Submission Checklist

- [x] Alert rule updated
- [x] Label normalization with `sum by` to prevent fan-out
- [x] Unit tests updated and passing (including boundary test at 72m for `for` clause)
- [x] Full test suite passing (`ALL DONE OK`)
- [x] Documentation updated (`docs/ALERTS.md`)

[SPRE-5950]: https://redhat.atlassian.net/browse/SPRE-5950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ