### PR TITLE
SPRE-6549: Add cert-manager alerts for Issuer health and controller sync errors

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
@@ -78,3 +78,52 @@ spec:
             alert_team_handle: >-
               <!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-CertManagerClusterIssuerNotReady.md
+
+        - alert: CertManagerIssuerNotReady
+          expr: |
+            certmanager_issuer_ready_status{condition="True"} == 0
+          for: 10m
+          labels:
+            severity: warning
+            slo: "false"
+            component: cert-manager
+          annotations:
+            summary: >-
+              Issuer {{ $labels.name }} in namespace {{ $labels.exported_namespace }} is not ready on cluster {{ $labels.source_cluster }}.
+            description: >-
+              Issuer {{ $labels.name }} in namespace {{ $labels.exported_namespace }} has been in a non-ready state for more than 10 minutes on cluster {{ $labels.source_cluster }}. Certificates referencing this issuer will not be renewed.
+            alert_routing_key: spreandinfra
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
+
+        - alert: CertManagerCertificateExpired
+          expr: |
+            (certmanager_certificate_expiration_timestamp_seconds - time()) < 0
+          for: 5m
+          labels:
+            severity: critical
+            slo: "true"
+            component: cert-manager
+          annotations:
+            summary: >-
+              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} has expired on cluster {{ $labels.source_cluster }}.
+            description: >-
+              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} on cluster {{ $labels.source_cluster }} has expired. Services using this certificate will fail TLS handshakes. Immediate action required.
+            alert_team_handle: >-
+              <!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-CertManagerCertificateExpiryCritical.md
+
+        - alert: CertManagerControllerSyncErrors
+          expr: |
+            increase(certmanager_controller_sync_error_count[15m]) > 5
+          for: 15m
+          labels:
+            severity: warning
+            slo: "false"
+            component: cert-manager
+          annotations:
+            summary: >-
+              cert-manager controller is experiencing sync errors on cluster {{ $labels.source_cluster }}.
+            description: >-
+              cert-manager controller has logged more than 5 sync errors in the last 15 minutes on cluster {{ $labels.source_cluster }}. Certificate issuance or renewal may be failing.
+            alert_routing_key: spreandinfra
+            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md

--- a/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
@@ -95,23 +95,6 @@ spec:
             alert_routing_key: spreandinfra
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
 
-        - alert: CertManagerCertificateExpired
-          expr: |
-            (certmanager_certificate_expiration_timestamp_seconds - time()) < 0
-          for: 5m
-          labels:
-            severity: critical
-            slo: "true"
-            component: cert-manager
-          annotations:
-            summary: >-
-              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} has expired on cluster {{ $labels.source_cluster }}.
-            description: >-
-              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} on cluster {{ $labels.source_cluster }} has expired. Services using this certificate will fail TLS handshakes. Immediate action required.
-            alert_team_handle: >-
-              <!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>
-            runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-CertManagerCertificateExpiryCritical.md
-
         - alert: CertManagerControllerSyncErrors
           expr: |
             increase(certmanager_controller_sync_error_count[15m]) > 5

--- a/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
@@ -115,7 +115,7 @@ spec:
         - alert: CertManagerControllerSyncErrors
           expr: |
             increase(certmanager_controller_sync_error_count[15m]) > 5
-          for: 15m
+          for: 5m
           labels:
             severity: warning
             slo: "false"
@@ -124,6 +124,6 @@ spec:
             summary: >-
               cert-manager controller is experiencing sync errors on cluster {{ $labels.source_cluster }}.
             description: >-
-              cert-manager controller has logged more than 5 sync errors in the last 15 minutes on cluster {{ $labels.source_cluster }}. Certificate issuance or renewal may be failing.
+              cert-manager controller has logged more than 5 sync errors in the last 15 minutes on cluster {{ $labels.source_cluster }}. This condition has persisted for at least 5 minutes. Certificate issuance or renewal may be failing.
             alert_routing_key: spreandinfra
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md

--- a/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.cert_manager_alerts.yaml
@@ -46,8 +46,6 @@ spec:
         - alert: CertManagerCertificateExpiryCritical
           expr: |
             (certmanager_certificate_expiration_timestamp_seconds - time()) / 86400 < 7
-            and
-            (certmanager_certificate_expiration_timestamp_seconds - time()) >= 0
           for: 15m
           labels:
             severity: critical
@@ -55,9 +53,9 @@ spec:
             component: cert-manager
           annotations:
             summary: >-
-              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} expires in less than 7 days on cluster {{ $labels.source_cluster }}.
+              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} expires in less than 7 days or has already expired on cluster {{ $labels.source_cluster }}.
             description: >-
-              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} on cluster {{ $labels.source_cluster }} expires in {{ printf "%.0f" $value }} days. Immediate action required — renewal has likely failed.
+              Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} on cluster {{ $labels.source_cluster }} expires in {{ printf "%.0f" $value }} days. If the value is negative, the certificate has already expired. Immediate action required - renewal has likely failed.
             alert_team_handle: >-
               <!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>
             runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-CertManagerCertificateExpiryCritical.md

--- a/test/promql/tests/data_plane/cert_manager_alerts_test.yaml
+++ b/test/promql/tests/data_plane/cert_manager_alerts_test.yaml
@@ -154,3 +154,113 @@ tests:
       - alertname: CertManagerClusterIssuerNotReady
         eval_time: 11m
         exp_alerts: []
+
+  # --- CertManagerIssuerNotReady ---
+
+  # Positive: namespace issuer not ready for 10m, should fire
+  - interval: 1m
+    input_series:
+      - series: 'certmanager_issuer_ready_status{condition="True", name="selfsigned-issuer", exported_namespace="etcd-shield", source_cluster="stone-prod-p01"}'
+        values: '0x15'
+
+    alert_rule_test:
+      - alertname: CertManagerIssuerNotReady
+        eval_time: 11m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: cert-manager
+              condition: "True"
+              name: selfsigned-issuer
+              exported_namespace: etcd-shield
+              source_cluster: stone-prod-p01
+            exp_annotations:
+              summary: "Issuer selfsigned-issuer in namespace etcd-shield is not ready on cluster stone-prod-p01."
+              description: "Issuer selfsigned-issuer in namespace etcd-shield has been in a non-ready state for more than 10 minutes on cluster stone-prod-p01. Certificates referencing this issuer will not be renewed."
+              alert_routing_key: spreandinfra
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
+
+  # Negative: namespace issuer is ready, should NOT fire
+  - interval: 1m
+    input_series:
+      - series: 'certmanager_issuer_ready_status{condition="True", name="selfsigned-issuer", exported_namespace="etcd-shield", source_cluster="stone-prod-p01"}'
+        values: '1x15'
+
+    alert_rule_test:
+      - alertname: CertManagerIssuerNotReady
+        eval_time: 11m
+        exp_alerts: []
+
+  # --- CertManagerCertificateExpired ---
+
+  # Positive: cert expired (expiry timestamp in the past), should fire
+  - interval: 1m
+    input_series:
+      - series: 'certmanager_certificate_expiration_timestamp_seconds{name="expired-cert", exported_namespace="my-ns", source_cluster="stone-prod-p01", issuer_name="selfsigned-issuer", issuer_kind="Issuer"}'
+        values: '-86400+0x10'
+
+    alert_rule_test:
+      - alertname: CertManagerCertificateExpired
+        eval_time: 6m
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo: "true"
+              component: cert-manager
+              name: expired-cert
+              exported_namespace: my-ns
+              source_cluster: stone-prod-p01
+              issuer_name: selfsigned-issuer
+              issuer_kind: Issuer
+            exp_annotations:
+              summary: "Certificate expired-cert in namespace my-ns has expired on cluster stone-prod-p01."
+              description: "Certificate expired-cert in namespace my-ns on cluster stone-prod-p01 has expired. Services using this certificate will fail TLS handshakes. Immediate action required."
+              alert_team_handle: "<!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>"
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-CertManagerCertificateExpiryCritical.md
+
+  # Negative: cert not expired (60 days left), should NOT fire
+  - interval: 1m
+    input_series:
+      - series: 'certmanager_certificate_expiration_timestamp_seconds{name="valid-cert", exported_namespace="my-ns", source_cluster="stone-prod-p01", issuer_name="selfsigned-issuer", issuer_kind="Issuer"}'
+        values: '5184000+0x10'
+
+    alert_rule_test:
+      - alertname: CertManagerCertificateExpired
+        eval_time: 6m
+        exp_alerts: []
+
+  # --- CertManagerControllerSyncErrors ---
+
+  # Positive: more than 5 sync errors in 15m, should fire
+  - interval: 1m
+    input_series:
+      - series: 'certmanager_controller_sync_error_count{source_cluster="stone-prod-p01", controller="certificates-trigger"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31'
+
+    alert_rule_test:
+      - alertname: CertManagerControllerSyncErrors
+        eval_time: 30m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              component: cert-manager
+              source_cluster: stone-prod-p01
+              controller: certificates-trigger
+            exp_annotations:
+              summary: "cert-manager controller is experiencing sync errors on cluster stone-prod-p01."
+              description: "cert-manager controller has logged more than 5 sync errors in the last 15 minutes on cluster stone-prod-p01. Certificate issuance or renewal may be failing."
+              alert_routing_key: spreandinfra
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
+
+  # Negative: no sync errors, should NOT fire
+  - interval: 1m
+    input_series:
+      - series: 'certmanager_controller_sync_error_count{source_cluster="stone-prod-p01", controller="certificates-trigger"}'
+        values: '0x32'
+
+    alert_rule_test:
+      - alertname: CertManagerControllerSyncErrors
+        eval_time: 30m
+        exp_alerts: []

--- a/test/promql/tests/data_plane/cert_manager_alerts_test.yaml
+++ b/test/promql/tests/data_plane/cert_manager_alerts_test.yaml
@@ -232,15 +232,15 @@ tests:
 
   # --- CertManagerControllerSyncErrors ---
 
-  # Positive: more than 5 sync errors in 15m, should fire
+  # Positive: more than 5 sync errors in 15m, should fire after 5m persistence
   - interval: 1m
     input_series:
       - series: 'certmanager_controller_sync_error_count{source_cluster="stone-prod-p01", controller="certificates-trigger"}'
-        values: '0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31'
+        values: '0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25'
 
     alert_rule_test:
       - alertname: CertManagerControllerSyncErrors
-        eval_time: 30m
+        eval_time: 20m
         exp_alerts:
           - exp_labels:
               severity: warning
@@ -250,7 +250,7 @@ tests:
               controller: certificates-trigger
             exp_annotations:
               summary: "cert-manager controller is experiencing sync errors on cluster stone-prod-p01."
-              description: "cert-manager controller has logged more than 5 sync errors in the last 15 minutes on cluster stone-prod-p01. Certificate issuance or renewal may be failing."
+              description: "cert-manager controller has logged more than 5 sync errors in the last 15 minutes on cluster stone-prod-p01. This condition has persisted for at least 5 minutes. Certificate issuance or renewal may be failing."
               alert_routing_key: spreandinfra
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-cert-manager.md
 
@@ -258,9 +258,9 @@ tests:
   - interval: 1m
     input_series:
       - series: 'certmanager_controller_sync_error_count{source_cluster="stone-prod-p01", controller="certificates-trigger"}'
-        values: '0x32'
+        values: '0x25'
 
     alert_rule_test:
       - alertname: CertManagerControllerSyncErrors
-        eval_time: 30m
+        eval_time: 20m
         exp_alerts: []

--- a/test/promql/tests/data_plane/cert_manager_alerts_test.yaml
+++ b/test/promql/tests/data_plane/cert_manager_alerts_test.yaml
@@ -103,8 +103,33 @@ tests:
               issuer_name: letsencrypt
               issuer_kind: ClusterIssuer
             exp_annotations:
-              summary: "Certificate critical-cert in namespace my-ns expires in less than 7 days on cluster stone-prod-p01."
-              description: "Certificate critical-cert in namespace my-ns on cluster stone-prod-p01 expires in 3 days. Immediate action required — renewal has likely failed."
+              summary: "Certificate critical-cert in namespace my-ns expires in less than 7 days or has already expired on cluster stone-prod-p01."
+              description: "Certificate critical-cert in namespace my-ns on cluster stone-prod-p01 expires in 3 days. If the value is negative, the certificate has already expired. Immediate action required - renewal has likely failed."
+              alert_team_handle: "<!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>"
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-CertManagerCertificateExpiryCritical.md
+
+  # Positive: cert already expired (negative value), should also fire
+  - interval: 1m
+    input_series:
+      - series: 'certmanager_certificate_expiration_timestamp_seconds{name="expired-cert", exported_namespace="my-ns", source_cluster="stone-prod-p01", issuer_name="selfsigned-issuer", issuer_kind="Issuer"}'
+        values: '-86400+0x20'
+
+    alert_rule_test:
+      - alertname: CertManagerCertificateExpiryCritical
+        eval_time: 16m
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo: "true"
+              component: cert-manager
+              name: expired-cert
+              exported_namespace: my-ns
+              source_cluster: stone-prod-p01
+              issuer_name: selfsigned-issuer
+              issuer_kind: Issuer
+            exp_annotations:
+              summary: "Certificate expired-cert in namespace my-ns expires in less than 7 days or has already expired on cluster stone-prod-p01."
+              description: "Certificate expired-cert in namespace my-ns on cluster stone-prod-p01 expires in -1 days. If the value is negative, the certificate has already expired. Immediate action required - renewal has likely failed."
               alert_team_handle: "<!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>"
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-CertManagerCertificateExpiryCritical.md
 

--- a/test/promql/tests/data_plane/cert_manager_alerts_test.yaml
+++ b/test/promql/tests/data_plane/cert_manager_alerts_test.yaml
@@ -192,44 +192,6 @@ tests:
         eval_time: 11m
         exp_alerts: []
 
-  # --- CertManagerCertificateExpired ---
-
-  # Positive: cert expired (expiry timestamp in the past), should fire
-  - interval: 1m
-    input_series:
-      - series: 'certmanager_certificate_expiration_timestamp_seconds{name="expired-cert", exported_namespace="my-ns", source_cluster="stone-prod-p01", issuer_name="selfsigned-issuer", issuer_kind="Issuer"}'
-        values: '-86400+0x10'
-
-    alert_rule_test:
-      - alertname: CertManagerCertificateExpired
-        eval_time: 6m
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-              slo: "true"
-              component: cert-manager
-              name: expired-cert
-              exported_namespace: my-ns
-              source_cluster: stone-prod-p01
-              issuer_name: selfsigned-issuer
-              issuer_kind: Issuer
-            exp_annotations:
-              summary: "Certificate expired-cert in namespace my-ns has expired on cluster stone-prod-p01."
-              description: "Certificate expired-cert in namespace my-ns on cluster stone-prod-p01 has expired. Services using this certificate will fail TLS handshakes. Immediate action required."
-              alert_team_handle: "<!subteam^S07SW2EEW3D> <!subteam^S05Q1P4Q2TG>"
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/sre/alert-rule-CertManagerCertificateExpiryCritical.md
-
-  # Negative: cert not expired (60 days left), should NOT fire
-  - interval: 1m
-    input_series:
-      - series: 'certmanager_certificate_expiration_timestamp_seconds{name="valid-cert", exported_namespace="my-ns", source_cluster="stone-prod-p01", issuer_name="selfsigned-issuer", issuer_kind="Issuer"}'
-        values: '5184000+0x10'
-
-    alert_rule_test:
-      - alertname: CertManagerCertificateExpired
-        eval_time: 6m
-        exp_alerts: []
-
   # --- CertManagerControllerSyncErrors ---
 
   # Positive: more than 5 sync errors in 15m, should fire after 5m persistence


### PR DESCRIPTION
## Summary

JIRA: https://issues.redhat.com/browse/SPRE-6549

Adds two new Prometheus alerts to improve cert-manager monitoring coverage:

- **CertManagerIssuerNotReady** (warning) - monitors namespace-scoped Issuers. Needed as teams migrate from service-ca to per-namespace selfsigned-issuers.
- **CertManagerControllerSyncErrors** (warning) - detects cert-manager controller sync failures that may prevent certificate issuance or renewal. Uses a 15m increase window with 5m persistence.

Also modifies the existing **CertManagerCertificateExpiryCritical** alert: removed the `>= 0` guard from the expression so it now fires for both certificates expiring within 7 days AND certificates that have already expired. Previously, expired certificates were excluded by the `>= 0` condition, creating a monitoring gap. A separate CertManagerCertificateExpired alert was initially added to cover this gap but was replaced by this simpler fix to the existing alert.

## Metrics used

All metrics are confirmed in the federation endpoints-params allow-list:
- `certmanager_issuer_ready_status`
- `certmanager_controller_sync_error_count`

## Testing

- Positive and negative promtool test cases for both new alerts
- Added test case for expired certificate on CertManagerCertificateExpiryCritical
- `make check-and-test` passes

## Context

Part of the ongoing migration from OpenShift service-ca to cert-manager across Konflux clusters. As teams create per-namespace selfsigned-issuers, we need monitoring coverage for namespace-scoped Issuers (not just ClusterIssuers). SOPs for all alerts will be submitted separately to the sop repo.