### PR TITLE
feat(PVO11Y-5332): Add tenant-level capacity panels

### DIFF
--- a/dashboards/grafana-dashboard-konflux-ux-metrics.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ux-metrics.configmap.yaml
@@ -6031,7 +6031,7 @@ data:
                   {
                     "matcher": {
                       "id": "byName",
-                      "options": "% of CPU CFS periods throttled"
+                      "options": "Usage"
                     },
                     "properties": [
                       {

--- a/dashboards/grafana-dashboard-konflux-ux-metrics.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ux-metrics.configmap.yaml
@@ -5689,7 +5689,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "PDCCF087A30F0737B"
+                    "uid": "${Datasource}"
                   },
                   "editorMode": "code",
                   "expr": "sort_desc(\n    topk(10, namespace:avg_container_cpu_cfs_throttled_periods:ratio{source_cluster=~\"${Cluster}\", namespace=~\".*-tenant\"})\n)",
@@ -5803,7 +5803,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "PDCCF087A30F0737B"
+                    "uid": "${Datasource}"
                   },
                   "editorMode": "code",
                   "exemplar": false,
@@ -5958,7 +5958,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "PDCCF087A30F0737B"
+                    "uid": "${Datasource}"
                   },
                   "editorMode": "code",
                   "expr": "sort_desc(\n    topk(10, namespace:container_memory_usage_bytes:sum{source_cluster=~\"${Cluster}\", namespace=~\".*-tenant\"})\n)",
@@ -6069,7 +6069,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "PDCCF087A30F0737B"
+                    "uid": "${Datasource}"
                   },
                   "editorMode": "code",
                   "exemplar": false,

--- a/dashboards/grafana-dashboard-konflux-ux-metrics.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ux-metrics.configmap.yaml
@@ -154,7 +154,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 0,
-                "y": 740
+                "y": 834
               },
               "id": 24,
               "options": {
@@ -327,7 +327,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 12,
-                "y": 740
+                "y": 834
               },
               "id": 25,
               "options": {
@@ -442,7 +442,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 0,
-                "y": 820
+                "y": 914
               },
               "id": 10,
               "options": {
@@ -521,7 +521,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 12,
-                "y": 820
+                "y": 914
               },
               "id": 17,
               "options": {
@@ -635,7 +635,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 0,
-                "y": 827
+                "y": 921
               },
               "id": 31,
               "options": {
@@ -781,7 +781,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 12,
-                "y": 827
+                "y": 921
               },
               "id": 33,
               "options": {
@@ -927,7 +927,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 0,
-                "y": 834
+                "y": 928
               },
               "id": 34,
               "options": {
@@ -1073,7 +1073,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 12,
-                "y": 834
+                "y": 928
               },
               "id": 35,
               "options": {
@@ -1152,6 +1152,7 @@ data:
                   "color": {
                     "mode": "thresholds"
                   },
+                  "decimals": 0,
                   "mappings": [],
                   "thresholds": {
                     "mode": "absolute",
@@ -1161,8 +1162,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "short",
-                  "decimals": 0
+                  "unit": "short"
                 },
                 "overrides": []
               },
@@ -1170,7 +1170,7 @@ data:
                 "h": 7,
                 "w": 6,
                 "x": 0,
-                "y": 841
+                "y": 935
               },
               "id": 101,
               "maxPerRow": 2,
@@ -1198,10 +1198,10 @@ data:
                   },
                   "editorMode": "code",
                   "expr": "sum(konflux_build_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"})",
-                  "legendFormat": "",
-                  "refId": "A",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Total Build Throughput (30d)",
@@ -1271,7 +1271,7 @@ data:
                 "h": 7,
                 "w": 18,
                 "x": 6,
-                "y": 841
+                "y": 935
               },
               "id": 102,
               "maxPerRow": 2,
@@ -1298,8 +1298,8 @@ data:
                   "editorMode": "code",
                   "expr": "sum by (exported_namespace) (konflux_build_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"})",
                   "legendFormat": "{{exported_namespace}}",
-                  "refId": "A",
-                  "range": true
+                  "range": true,
+                  "refId": "A"
                 }
               ],
               "title": "Build Volume by Tenant (30d rolling count)",
@@ -1315,6 +1315,7 @@ data:
                   "color": {
                     "mode": "thresholds"
                   },
+                  "decimals": 0,
                   "mappings": [],
                   "min": 0,
                   "thresholds": {
@@ -1329,8 +1330,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "short",
-                  "decimals": 0
+                  "unit": "short"
                 },
                 "overrides": []
               },
@@ -1338,7 +1338,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 848
+                "y": 942
               },
               "id": 103,
               "maxPerRow": 2,
@@ -1375,10 +1375,10 @@ data:
                   },
                   "editorMode": "code",
                   "expr": "topk(10, sum by (exported_namespace) (konflux_build_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"}))",
-                  "legendFormat": "{{exported_namespace}}",
-                  "refId": "A",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "{{exported_namespace}}",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Top 10 Tenants by Build Volume",
@@ -1394,6 +1394,7 @@ data:
                   "color": {
                     "mode": "thresholds"
                   },
+                  "decimals": 0,
                   "mappings": [],
                   "min": 0,
                   "thresholds": {
@@ -1408,8 +1409,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "short",
-                  "decimals": 0
+                  "unit": "short"
                 },
                 "overrides": []
               },
@@ -1417,7 +1417,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 848
+                "y": 942
               },
               "id": 104,
               "maxPerRow": 2,
@@ -1454,10 +1454,10 @@ data:
                   },
                   "editorMode": "code",
                   "expr": "topk(5, sum by (reason) (konflux_build_failure_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"}))",
-                  "legendFormat": "{{reason}}",
-                  "refId": "A",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "{{reason}}",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Top 5 Build Failure Reasons",
@@ -1527,7 +1527,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 856
+                "y": 950
               },
               "id": 105,
               "maxPerRow": 2,
@@ -1554,8 +1554,8 @@ data:
                   "editorMode": "code",
                   "expr": "sum by (exported_namespace) (konflux_build_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"}) / 30",
                   "legendFormat": "{{exported_namespace}}",
-                  "refId": "A",
-                  "range": true
+                  "range": true,
+                  "refId": "A"
                 }
               ],
               "title": "Build Daily Throughput Rate (total_count/30)",
@@ -1675,7 +1675,7 @@ data:
                 "h": 12,
                 "w": 12,
                 "x": 0,
-                "y": 191
+                "y": 285
               },
               "id": 38,
               "options": {
@@ -1848,7 +1848,7 @@ data:
                 "h": 12,
                 "w": 12,
                 "x": 12,
-                "y": 191
+                "y": 285
               },
               "id": 39,
               "options": {
@@ -1963,7 +1963,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 0,
-                "y": 203
+                "y": 297
               },
               "id": 40,
               "options": {
@@ -2042,7 +2042,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 12,
-                "y": 203
+                "y": 297
               },
               "id": 41,
               "options": {
@@ -2156,7 +2156,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 0,
-                "y": 210
+                "y": 304
               },
               "id": 42,
               "options": {
@@ -2302,7 +2302,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 12,
-                "y": 210
+                "y": 304
               },
               "id": 43,
               "options": {
@@ -2460,7 +2460,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 0,
-                "y": 217
+                "y": 311
               },
               "id": 76,
               "options": {
@@ -2621,7 +2621,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 12,
-                "y": 217
+                "y": 311
               },
               "id": 77,
               "options": {
@@ -2782,7 +2782,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 0,
-                "y": 224
+                "y": 318
               },
               "id": 44,
               "options": {
@@ -2943,7 +2943,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 12,
-                "y": 224
+                "y": 318
               },
               "id": 45,
               "options": {
@@ -3025,6 +3025,7 @@ data:
                   "color": {
                     "mode": "thresholds"
                   },
+                  "decimals": 0,
                   "mappings": [],
                   "thresholds": {
                     "mode": "absolute",
@@ -3034,8 +3035,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "short",
-                  "decimals": 0
+                  "unit": "short"
                 },
                 "overrides": []
               },
@@ -3043,7 +3043,7 @@ data:
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 231
+                "y": 325
               },
               "id": 106,
               "maxPerRow": 2,
@@ -3071,10 +3071,10 @@ data:
                   },
                   "editorMode": "code",
                   "expr": "sum(konflux_integration_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"})",
-                  "legendFormat": "",
-                  "refId": "A",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Total Integration Throughput (30d)",
@@ -3144,7 +3144,7 @@ data:
                 "h": 7,
                 "w": 18,
                 "x": 6,
-                "y": 231
+                "y": 325
               },
               "id": 107,
               "maxPerRow": 2,
@@ -3171,8 +3171,8 @@ data:
                   "editorMode": "code",
                   "expr": "sum by (exported_namespace) (konflux_integration_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"})",
                   "legendFormat": "{{exported_namespace}}",
-                  "refId": "A",
-                  "range": true
+                  "range": true,
+                  "refId": "A"
                 }
               ],
               "title": "Integration Test Volume by Tenant (30d rolling count)",
@@ -3188,6 +3188,7 @@ data:
                   "color": {
                     "mode": "thresholds"
                   },
+                  "decimals": 0,
                   "mappings": [],
                   "min": 0,
                   "thresholds": {
@@ -3202,8 +3203,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "short",
-                  "decimals": 0
+                  "unit": "short"
                 },
                 "overrides": []
               },
@@ -3211,7 +3211,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 238
+                "y": 332
               },
               "id": 108,
               "maxPerRow": 2,
@@ -3248,10 +3248,10 @@ data:
                   },
                   "editorMode": "code",
                   "expr": "topk(10, sum by (exported_namespace) (konflux_integration_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"}))",
-                  "legendFormat": "{{exported_namespace}}",
-                  "refId": "A",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "{{exported_namespace}}",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Top 10 Tenants by Integration Test Volume",
@@ -3267,6 +3267,7 @@ data:
                   "color": {
                     "mode": "thresholds"
                   },
+                  "decimals": 0,
                   "mappings": [],
                   "min": 0,
                   "thresholds": {
@@ -3281,8 +3282,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "short",
-                  "decimals": 0
+                  "unit": "short"
                 },
                 "overrides": []
               },
@@ -3290,7 +3290,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 238
+                "y": 332
               },
               "id": 109,
               "maxPerRow": 2,
@@ -3327,10 +3327,10 @@ data:
                   },
                   "editorMode": "code",
                   "expr": "topk(5, sum by (reason) (konflux_integration_failure_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"}))",
-                  "legendFormat": "{{reason}}",
-                  "refId": "A",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "{{reason}}",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Top 5 Integration Failure Reasons",
@@ -3400,7 +3400,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 246
+                "y": 340
               },
               "id": 110,
               "maxPerRow": 2,
@@ -3427,8 +3427,8 @@ data:
                   "editorMode": "code",
                   "expr": "sum by (exported_namespace) (konflux_integration_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"}) / 30",
                   "legendFormat": "{{exported_namespace}}",
-                  "refId": "A",
-                  "range": true
+                  "range": true,
+                  "refId": "A"
                 }
               ],
               "title": "Integration Daily Throughput Rate (total_count/30)",
@@ -3548,7 +3548,7 @@ data:
                 "h": 12,
                 "w": 12,
                 "x": 0,
-                "y": 272
+                "y": 366
               },
               "id": 46,
               "options": {
@@ -3724,7 +3724,7 @@ data:
                 "h": 12,
                 "w": 12,
                 "x": 12,
-                "y": 272
+                "y": 366
               },
               "id": 47,
               "options": {
@@ -3839,7 +3839,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 0,
-                "y": 284
+                "y": 378
               },
               "id": 48,
               "options": {
@@ -3918,7 +3918,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 12,
-                "y": 284
+                "y": 378
               },
               "id": 49,
               "options": {
@@ -4032,7 +4032,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 0,
-                "y": 291
+                "y": 385
               },
               "id": 50,
               "options": {
@@ -4178,7 +4178,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 12,
-                "y": 291
+                "y": 385
               },
               "id": 51,
               "options": {
@@ -4324,7 +4324,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 0,
-                "y": 298
+                "y": 392
               },
               "id": 52,
               "options": {
@@ -4458,7 +4458,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 12,
-                "y": 298
+                "y": 392
               },
               "id": 53,
               "options": {
@@ -4536,6 +4536,7 @@ data:
                   "color": {
                     "mode": "thresholds"
                   },
+                  "decimals": 0,
                   "mappings": [],
                   "thresholds": {
                     "mode": "absolute",
@@ -4545,8 +4546,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "short",
-                  "decimals": 0
+                  "unit": "short"
                 },
                 "overrides": []
               },
@@ -4554,7 +4554,7 @@ data:
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 305
+                "y": 399
               },
               "id": 111,
               "maxPerRow": 2,
@@ -4582,10 +4582,10 @@ data:
                   },
                   "editorMode": "code",
                   "expr": "sum(konflux_release_cr_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"})",
-                  "legendFormat": "",
-                  "refId": "A",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Total Release Throughput (30d)",
@@ -4601,6 +4601,7 @@ data:
                   "color": {
                     "mode": "thresholds"
                   },
+                  "decimals": 1,
                   "mappings": [],
                   "thresholds": {
                     "mode": "absolute",
@@ -4610,8 +4611,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "percentunit",
-                  "decimals": 1
+                  "unit": "percentunit"
                 },
                 "overrides": []
               },
@@ -4619,7 +4619,7 @@ data:
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 305
+                "y": 399
               },
               "id": 112,
               "maxPerRow": 2,
@@ -4647,10 +4647,10 @@ data:
                   },
                   "editorMode": "code",
                   "expr": "sum(\n    konflux_release_cr_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\", automated=\"true\"}\n    or\n    konflux_release_cr_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"} * 0\n)\n/\nsum(konflux_release_cr_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"})",
-                  "legendFormat": "",
-                  "refId": "A",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Release Automation Adoption %",
@@ -4675,7 +4675,7 @@ data:
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 305
+                "y": 399
               },
               "id": 113,
               "maxPerRow": 2,
@@ -4713,10 +4713,10 @@ data:
                   },
                   "editorMode": "code",
                   "expr": "sum by (automated) (konflux_release_cr_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"})",
-                  "legendFormat": "{{automated}}",
-                  "refId": "A",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "{{automated}}",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Automated vs. Manual Releases",
@@ -4786,7 +4786,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 311
+                "y": 405
               },
               "id": 114,
               "maxPerRow": 2,
@@ -4813,8 +4813,8 @@ data:
                   "editorMode": "code",
                   "expr": "sum by (exported_namespace) (konflux_release_cr_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"})",
                   "legendFormat": "{{exported_namespace}}",
-                  "refId": "A",
-                  "range": true
+                  "range": true,
+                  "refId": "A"
                 }
               ],
               "title": "Release Volume by Tenant (30d rolling count)",
@@ -4830,6 +4830,7 @@ data:
                   "color": {
                     "mode": "thresholds"
                   },
+                  "decimals": 0,
                   "mappings": [],
                   "min": 0,
                   "thresholds": {
@@ -4844,8 +4845,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "short",
-                  "decimals": 0
+                  "unit": "short"
                 },
                 "overrides": []
               },
@@ -4853,7 +4853,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 318
+                "y": 412
               },
               "id": 115,
               "maxPerRow": 2,
@@ -4890,10 +4890,10 @@ data:
                   },
                   "editorMode": "code",
                   "expr": "topk(10, sum by (exported_namespace) (konflux_release_cr_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"}))",
-                  "legendFormat": "{{exported_namespace}}",
-                  "refId": "A",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "{{exported_namespace}}",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Top 10 Tenants by Release Volume",
@@ -4909,6 +4909,7 @@ data:
                   "color": {
                     "mode": "thresholds"
                   },
+                  "decimals": 0,
                   "mappings": [],
                   "min": 0,
                   "thresholds": {
@@ -4923,8 +4924,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "short",
-                  "decimals": 0
+                  "unit": "short"
                 },
                 "overrides": []
               },
@@ -4932,7 +4932,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 318
+                "y": 412
               },
               "id": 116,
               "maxPerRow": 2,
@@ -4969,10 +4969,10 @@ data:
                   },
                   "editorMode": "code",
                   "expr": "topk(5, sum by (reason) (konflux_release_cr_failure_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"}))",
-                  "legendFormat": "{{reason}}",
-                  "refId": "A",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "{{reason}}",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Top 5 Release Failure Reasons",
@@ -5042,7 +5042,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 326
+                "y": 420
               },
               "id": 117,
               "maxPerRow": 2,
@@ -5069,8 +5069,8 @@ data:
                   "editorMode": "code",
                   "expr": "sum by (exported_namespace) (konflux_release_cr_total_count_30d{source_cluster=~\"${Cluster}\", exported_namespace!~\"${omit_tenant}\"}) / 30",
                   "legendFormat": "{{exported_namespace}}",
-                  "refId": "A",
-                  "range": true
+                  "range": true,
+                  "refId": "A"
                 }
               ],
               "title": "Release Daily Throughput Rate (total_count/30)",
@@ -5087,6 +5087,1532 @@ data:
             "w": 24,
             "x": 0,
             "y": 3
+          },
+          "id": 118,
+          "panels": [
+            {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 4
+              },
+              "id": 125,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "# CPU Metrics",
+                "mode": "markdown"
+              },
+              "pluginVersion": "11.6.11",
+              "title": "",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "description": "",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 6
+              },
+              "id": 119,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "pluginVersion": "11.6.11",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "topk(10, namespace:container_cpu_usage:sum{source_cluster=~\"${Cluster}\", namespace=~\".*-tenant\"})",
+                  "instant": false,
+                  "legendFormat": "{{namespace}} - {{source_cluster}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU Usage (100% for a single core) - Top-10 Tenants",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "inspect": false
+                  },
+                  "mappings": [],
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.8
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Tenant"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 300
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Cluster"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 200
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Usage (100% for a single cpu core)"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "auto"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 12,
+                "w": 24,
+                "x": 0,
+                "y": 12
+              },
+              "id": 120,
+              "options": {
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
+                  "fields": "",
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
+                },
+                "frameIndex": 0,
+                "showHeader": true
+              },
+              "pluginVersion": "11.6.11",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "editorMode": "code",
+                  "exemplar": false,
+                  "expr": "sort_desc(\n    topk(10, namespace:container_cpu_usage:sum{source_cluster=~\"${Cluster}\", namespace=~\".*-tenant\"})\n)",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "__auto",
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU Usage - Top-10 Tenants",
+              "transformations": [
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "include": {
+                      "names": [
+                        "namespace",
+                        "source_cluster",
+                        "Value"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {},
+                    "includeByName": {},
+                    "indexByName": {},
+                    "renameByName": {
+                      "Value": "Usage (100% for a single cpu core)",
+                      "namespace": "Tenant",
+                      "source_cluster": "Cluster"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "description": "",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 24
+              },
+              "id": 121,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "pluginVersion": "11.6.11",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sort_desc(\n    topk(10, namespace:konflux_tenant_resourcequota_utilization:ratio{resource=\"requests.cpu\", source_cluster=~\"${Cluster}\", namespace=~\".*-tenant\"})\n)",
+                  "instant": false,
+                  "legendFormat": "{{namespace}} - {{source_cluster}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "ResourceQuota Usage - requests.cpu - Top-10 Tenants",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "inspect": false
+                  },
+                  "mappings": [],
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.8
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Tenant"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 300
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Cluster"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 200
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Usage"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge",
+                          "valueDisplayMode": "color"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 12,
+                "w": 24,
+                "x": 0,
+                "y": 30
+              },
+              "id": 122,
+              "options": {
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
+                  "fields": "",
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
+                },
+                "frameIndex": 0,
+                "showHeader": true
+              },
+              "pluginVersion": "11.6.11",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "editorMode": "code",
+                  "exemplar": false,
+                  "expr": "sort_desc(\n    topk(10, namespace:konflux_tenant_resourcequota_utilization:ratio{resource=\"requests.cpu\", source_cluster=~\"${Cluster}\", namespace=~\".*-tenant\"})\n)",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "__auto",
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "ResourceQuota Usage - requests.cpu - Top-10 Tenants",
+              "transformations": [
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "include": {
+                      "names": [
+                        "namespace",
+                        "source_cluster",
+                        "Value"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {},
+                    "includeByName": {},
+                    "indexByName": {},
+                    "renameByName": {
+                      "Value": "Usage",
+                      "namespace": "Tenant",
+                      "source_cluster": "Cluster"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "description": "",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 42
+              },
+              "id": 123,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "pluginVersion": "11.6.11",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "PDCCF087A30F0737B"
+                  },
+                  "editorMode": "code",
+                  "expr": "sort_desc(\n    topk(10, namespace:avg_container_cpu_cfs_throttled_periods:ratio{source_cluster=~\"${Cluster}\", namespace=~\".*-tenant\"})\n)",
+                  "legendFormat": "{{namespace}} - {{source_cluster}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "10-min Average % of CPU CFS Periods Throttled - Top-10 Tenants",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "inspect": false
+                  },
+                  "mappings": [],
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.0001
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Tenant"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 300
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Cluster"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 200
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "% of CPU CFS periods throttled"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge",
+                          "valueDisplayMode": "color"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 12,
+                "w": 24,
+                "x": 0,
+                "y": 48
+              },
+              "id": 124,
+              "options": {
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
+                  "fields": "",
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
+                },
+                "frameIndex": 0,
+                "showHeader": true
+              },
+              "pluginVersion": "11.6.11",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "PDCCF087A30F0737B"
+                  },
+                  "editorMode": "code",
+                  "exemplar": false,
+                  "expr": "sort_desc(\n    topk(10, namespace:avg_container_cpu_cfs_throttled_periods:ratio{source_cluster=~\"${Cluster}\", namespace=~\".*-tenant\"})\n)",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "legendFormat": "__auto",
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "10-min Average % of CPU CFS Periods Throttled - Top-10 Tenants",
+              "transformations": [
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "include": {
+                      "names": [
+                        "namespace",
+                        "source_cluster",
+                        "Value"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {},
+                    "includeByName": {},
+                    "indexByName": {},
+                    "renameByName": {
+                      "Value": "% of CPU CFS periods throttled",
+                      "namespace": "Tenant",
+                      "source_cluster": "Cluster"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 60
+              },
+              "id": 126,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "# Memory Metrics",
+                "mode": "markdown"
+              },
+              "pluginVersion": "11.6.11",
+              "title": "",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "description": "Note: This may include more than 10 tenants since it is Top-10 for a given point in time",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 62
+              },
+              "id": 127,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "pluginVersion": "11.6.11",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "PDCCF087A30F0737B"
+                  },
+                  "editorMode": "code",
+                  "expr": "sort_desc(\n    topk(10, namespace:container_memory_usage_bytes:sum{source_cluster=~\"${Cluster}\", namespace=~\".*-tenant\"})\n)",
+                  "legendFormat": "{{namespace}} - {{source_cluster}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory Usage - Top-10 Tenants",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "inspect": false
+                  },
+                  "mappings": [],
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.0001
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Tenant"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 300
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Cluster"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 200
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "% of CPU CFS periods throttled"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "auto"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 12,
+                "w": 24,
+                "x": 0,
+                "y": 68
+              },
+              "id": 128,
+              "options": {
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
+                  "fields": "",
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
+                },
+                "frameIndex": 0,
+                "showHeader": true
+              },
+              "pluginVersion": "11.6.11",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "PDCCF087A30F0737B"
+                  },
+                  "editorMode": "code",
+                  "exemplar": false,
+                  "expr": "sort_desc(\n    topk(10, namespace:container_memory_usage_bytes:sum{source_cluster=~\"${Cluster}\", namespace=~\".*-tenant\"})\n)",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "legendFormat": "__auto",
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory Usage - Top-10 Tenants",
+              "transformations": [
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "include": {
+                      "names": [
+                        "namespace",
+                        "source_cluster",
+                        "Value"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {},
+                    "includeByName": {},
+                    "indexByName": {},
+                    "renameByName": {
+                      "Value": "Usage",
+                      "namespace": "Tenant",
+                      "source_cluster": "Cluster"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "description": "Note: This may include more than 10 tenants since it is Top-10 for a given point in time",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 80
+              },
+              "id": 129,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "pluginVersion": "11.6.11",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sort_desc(\n    topk(10, namespace:konflux_tenant_resourcequota_utilization:ratio{resource=\"requests.memory\", source_cluster=~\"${Cluster}\", namespace=~\".*-tenant\"})\n)",
+                  "instant": false,
+                  "legendFormat": "{{namespace}} - {{source_cluster}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "ResourceQuota Usage - requests.memory - Top-10 Tenants",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "description": "Note: This may include more than 10 tenants since it is Top-10 for a given point in time",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 80
+              },
+              "id": 130,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "pluginVersion": "11.6.11",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sort_desc(\n    topk(10, namespace:konflux_tenant_resourcequota_utilization:ratio{resource=\"limits.memory\", source_cluster=~\"${Cluster}\", namespace=~\".*-tenant\"})\n)",
+                  "instant": false,
+                  "legendFormat": "{{namespace}} - {{source_cluster}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "ResourceQuota Usage - limits.memory - Top-10 Tenants",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "inspect": false
+                  },
+                  "mappings": [],
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.8
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Tenant"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 300
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Cluster"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 200
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Usage"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge",
+                          "valueDisplayMode": "color"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 12,
+                "w": 12,
+                "x": 0,
+                "y": 86
+              },
+              "id": 131,
+              "options": {
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
+                  "fields": "",
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
+                },
+                "frameIndex": 0,
+                "showHeader": true
+              },
+              "pluginVersion": "11.6.11",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "editorMode": "code",
+                  "exemplar": false,
+                  "expr": "sort_desc(\n    topk(10, namespace:konflux_tenant_resourcequota_utilization:ratio{resource=\"requests.memory\", source_cluster=~\"${Cluster}\", namespace=~\".*-tenant\"})\n)",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "__auto",
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "ResourceQuota Usage - requests.memory - Top-10 Tenants",
+              "transformations": [
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "include": {
+                      "names": [
+                        "namespace",
+                        "source_cluster",
+                        "Value"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {},
+                    "includeByName": {},
+                    "indexByName": {},
+                    "renameByName": {
+                      "Value": "Usage",
+                      "namespace": "Tenant",
+                      "source_cluster": "Cluster"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "inspect": false
+                  },
+                  "mappings": [],
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.8
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Tenant"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 300
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Cluster"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 200
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Usage"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge",
+                          "valueDisplayMode": "color"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 12,
+                "w": 12,
+                "x": 12,
+                "y": 86
+              },
+              "id": 132,
+              "options": {
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
+                  "fields": "",
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
+                },
+                "frameIndex": 0,
+                "showHeader": true
+              },
+              "pluginVersion": "11.6.11",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${Datasource}"
+                  },
+                  "editorMode": "code",
+                  "exemplar": false,
+                  "expr": "sort_desc(\n    topk(10, namespace:konflux_tenant_resourcequota_utilization:ratio{resource=\"limits.memory\", source_cluster=~\"${Cluster}\", namespace=~\".*-tenant\"})\n)",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "__auto",
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "ResourceQuota Usage - limits.memory - Top-10 Tenants",
+              "transformations": [
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "include": {
+                      "names": [
+                        "namespace",
+                        "source_cluster",
+                        "Value"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {},
+                    "includeByName": {},
+                    "indexByName": {},
+                    "renameByName": {
+                      "Value": "Usage",
+                      "namespace": "Tenant",
+                      "source_cluster": "Cluster"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            }
+          ],
+          "title": "Tenant-Level Metrics - Capacity",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 4
           },
           "id": 2,
           "panels": [
@@ -5122,7 +6648,7 @@ data:
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 2205
+                "y": 2299
               },
               "id": 4,
               "maxPerRow": 2,
@@ -5199,7 +6725,7 @@ data:
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 2205
+                "y": 2299
               },
               "id": 5,
               "maxPerRow": 2,
@@ -5308,7 +6834,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 2211
+                "y": 2305
               },
               "id": 1,
               "maxPerRow": 2,
@@ -5438,7 +6964,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 2218
+                "y": 2312
               },
               "id": 6,
               "maxPerRow": 2,
@@ -5599,7 +7125,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 2225
+                "y": 2319
               },
               "id": 7,
               "maxPerRow": 2,
@@ -5750,5 +7276,5 @@ data:
       "timezone": "UTC",
       "title": "Konflux Tenant-Level UX Metrics - General",
       "uid": "konflux-ux-metrics",
-      "version": 1
+      "version": 2
     }


### PR DESCRIPTION
### Description

Add new row and panels for viewing tenant-level capacity metrics in the Konflux Tenant-Level UX Metrics dashboard

Preview of these changes can be viewed at https://grafana.stage.devshift.net/d/konflux-ux-metrics-pacho/konflux-tenant-level-ux-metrics-general-pacho

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [ ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [x] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [x] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [x] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
