### PR TITLE
SPRE-6607 fix(alerts): exclude konflux-ui from MultiClusterProbeAlert

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
@@ -49,7 +49,7 @@ spec:
         expr: |
           multicluster_probe_up{
           check="probe-multicluster",
-          service!~".*-vpn|.*static-host|.*pwvs|quay|api-server|openshift-ui"
+          service!~".*-vpn|.*static-host|.*pwvs|quay|api-server|openshift-ui|konflux-ui"
           } != 1
         for: 25m
         labels:

--- a/test/promql/tests/data_plane/probe_test.yaml
+++ b/test/promql/tests/data_plane/probe_test.yaml
@@ -114,6 +114,17 @@ tests:
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/exporters/blackbox/probe-alerts.md
 
+  # konflux-ui is a per-cluster service; a single-cluster outage must not fire the
+  # fleet-wide MultiClusterProbeAlert.
+  - interval: 1m
+    input_series:
+      - series: multicluster_probe_up{instance="instance01",job="konflux-ui",check="probe-multicluster",service="konflux-ui"}
+        values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+    alert_rule_test:
+      - eval_time: 39m
+        alertname: MultiClusterProbeAlert
+        exp_alerts: []
+
   - interval: 1m
     input_series:
       - series: multicluster_probe_up{instance="instance01",check="probe-multicluster",service="quay"}


### PR DESCRIPTION
- added konflux-ui to the exclusion list in MultiClusterProbeAlert
- added a unit test covering the new exclusion