### PR TITLE
PWVSProbeAlert adding avg_over_time 

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.probe_alerts.yaml
@@ -102,7 +102,6 @@ spec:
           alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
           runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/static_host_probe_alerts.md
 
-
       - alert: PPCStaticHostProbeAlert
         expr: |
           konflux_up{
@@ -122,14 +121,13 @@ spec:
           alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
           runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/static_host_probe_alerts.md
 
-
       - alert: PWVSProbeAlert
         expr: |
           konflux_up{
           check="probe-pwvs",
           service=~".*pwvs"
           } != 1
-        for: 15m
+        for: 20m
         labels:
           severity: critical
           slo: "true"

--- a/rhobs/recording/probes_recording_rules.yaml
+++ b/rhobs/recording/probes_recording_rules.yaml
@@ -63,14 +63,14 @@ spec:
             )
 
     - name: probes_pwvs_availability
-      interval: 10m
+      interval: 5m
       rules:
         - record: konflux_up
           expr: |
             clamp_max(
               label_replace(
                 label_replace(
-                    sum by (job,target,source_cluster) (probe_success{job=~".*pwvs"}) / count by (job,target,source_cluster) (probe_success{job=~".*pwvs"}) >= bool 0.7
+                    avg by (job,target,source_cluster) (avg_over_time(probe_success{job=~".*pwvs"}[10m])) >= bool 0.7
                   , "check", "probe-pwvs", "",""
                 ), "service", "$1", "job", "(.*)"
               ), 1

--- a/rhobs/recording/probes_recording_rules.yaml
+++ b/rhobs/recording/probes_recording_rules.yaml
@@ -63,16 +63,14 @@ spec:
             )
 
     - name: probes_pwvs_availability
-      # Reduced interval from 10m to 5m to prevent metric lock-in during edge cases
-      # and ensure state updates occur twice as fast for genuine outages.
-      interval: 5m
+      interval: 10m
       rules:
         - record: konflux_up
           expr: |
             clamp_max(
               label_replace(
                 label_replace(
-                    avg by (job,target,source_cluster) (avg_over_time(probe_success{job=~".*pwvs"}[10m])) >= bool 0.7
+                    sum by (job,target,source_cluster) (avg_over_time(probe_success{job=~".*pwvs"}[10m])) / count by (job,target,source_cluster) (avg_over_time(probe_success{job=~".*pwvs"}[10m])) >= bool 0.7
                   , "check", "probe-pwvs", "",""
                 ), "service", "$1", "job", "(.*)"
               ), 1

--- a/rhobs/recording/probes_recording_rules.yaml
+++ b/rhobs/recording/probes_recording_rules.yaml
@@ -63,6 +63,8 @@ spec:
             )
 
     - name: probes_pwvs_availability
+      # Reduced interval from 10m to 5m to prevent metric lock-in during edge cases
+      # and ensure state updates occur twice as fast for genuine outages.
       interval: 5m
       rules:
         - record: konflux_up

--- a/test/promql/tests/data_plane/probe_test.yaml
+++ b/test/promql/tests/data_plane/probe_test.yaml
@@ -230,12 +230,12 @@ tests:
       # 10m average is 0.8. Since 0.8 >= 0.7, konflux_up should remain 1.
       - series: probe_success{job="pwvs", target="net01", source_cluster="cluster01"}
         values: 1x8 0x2 1x5
-      
+
       # Target 2 (Failing-sample): 10m lookback at eval_time 12m contains 7 failures.
       # 10m average drops to 0.3. Since 0.3 < 0.7, konflux_up should drop to 0.
       - series: probe_success{job="pwvs", target="net02", source_cluster="cluster01"}
         values: 1x6 0x9
-        
+
     promql_expr_test:
       - expr: |
           clamp_max(

--- a/test/promql/tests/data_plane/probe_test.yaml
+++ b/test/promql/tests/data_plane/probe_test.yaml
@@ -169,7 +169,6 @@ tests:
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/static_host_probe_alerts.md
 
-
   - interval: 1m
     input_series:
       - series: konflux_up{job="ppc-static-host", source_cluster="cluster01",check="probe-ppc",service="ppc-static-host"}
@@ -199,6 +198,11 @@ tests:
         values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 
     alert_rule_test:
+      # Boundary check at 33m (19m after drop): strictly less than for: 20m -> must NOT fire
+      - eval_time: 33m
+        alertname: PWVSProbeAlert
+        exp_alerts: []
+      # Fire check at 35m (21m after drop): exceeds for: 20m -> MUST fire
       - eval_time: 35m
         alertname: PWVSProbeAlert
         exp_alerts:
@@ -216,3 +220,37 @@ tests:
               summary: PWVS Probe alert pwvs.
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/sre/vpn_probe_alerts.md
+
+  # =========================================================================
+  # NEW TEST: PWVS Recording Rule - Smoothing and Threshold-Boundary Test
+  # =========================================================================
+  - interval: 1m
+    input_series:
+      # Target 1 (Smoothing): Fails for only 2 minutes out of 10.
+      # 10m average is 0.8. Since 0.8 >= 0.7, konflux_up should remain 1.
+      - series: probe_success{job="pwvs", target="net01", source_cluster="cluster01"}
+        values: 1x8 0x2 1x5
+
+      # Target 2 (Failing-sample): Fails for 4 minutes out of 10.
+      # 10m average drops to 0.6. Since 0.6 < 0.7, konflux_up should drop to 0.
+      - series: probe_success{job="pwvs", target="net02", source_cluster="cluster01"}
+        values: 1x6 0x9
+
+    promql_expr_test:
+      - expr: |
+          clamp_max(
+            label_replace(
+              label_replace(
+                  avg by (job,target,source_cluster) (avg_over_time(probe_success{job=~".*pwvs"}[10m])) >= bool 0.7
+                , "check", "probe-pwvs", "",""
+              ), "service", "$1", "job", "(.*)"
+            ), 1
+          )
+        eval_time: 12m
+        exp_samples:
+          # Assert Target 1 stayed UP (absorbed the transient blip)
+          - labels: '{job="pwvs", target="net01", source_cluster="cluster01", check="probe-pwvs", service="pwvs"}'
+            value: 1
+          # Assert Target 2 went DOWN (caught the sustained outage)
+          - labels: '{job="pwvs", target="net02", source_cluster="cluster01", check="probe-pwvs", service="pwvs"}'
+            value: 0

--- a/test/promql/tests/data_plane/probe_test.yaml
+++ b/test/promql/tests/data_plane/probe_test.yaml
@@ -230,18 +230,18 @@ tests:
       # 10m average is 0.8. Since 0.8 >= 0.7, konflux_up should remain 1.
       - series: probe_success{job="pwvs", target="net01", source_cluster="cluster01"}
         values: 1x8 0x2 1x5
-
-      # Target 2 (Failing-sample): Fails for 4 minutes out of 10.
-      # 10m average drops to 0.6. Since 0.6 < 0.7, konflux_up should drop to 0.
+      
+      # Target 2 (Failing-sample): 10m lookback at eval_time 12m contains 7 failures.
+      # 10m average drops to 0.3. Since 0.3 < 0.7, konflux_up should drop to 0.
       - series: probe_success{job="pwvs", target="net02", source_cluster="cluster01"}
         values: 1x6 0x9
-
+        
     promql_expr_test:
       - expr: |
           clamp_max(
             label_replace(
               label_replace(
-                  avg by (job,target,source_cluster) (avg_over_time(probe_success{job=~".*pwvs"}[10m])) >= bool 0.7
+                  sum by (job,target,source_cluster) (avg_over_time(probe_success{job=~".*pwvs"}[10m])) / count by (job,target,source_cluster) (avg_over_time(probe_success{job=~".*pwvs"}[10m])) >= bool 0.7
                 , "check", "probe-pwvs", "",""
               ), "service", "$1", "job", "(.*)"
             ), 1


### PR DESCRIPTION
Description:
Resolves false-positive critical alerts triggered by PWVSProbeAlert. Analysis of recent incidents showed that momentary network jitter caused single-scrape probe failures, which immediately dropped the recorded konflux_up metric to 0. Due to the previous 10-minute rule evaluation interval, the metric remained locked at 0, leading to false critical alerts.

Ticket:
SPRE-5340
https://redhat.atlassian.net/browse/SPRE-5340


- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x ] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [ ] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

#