### PR TITLE
fix(PVO11Y-5480): Change tenant UX SLO breach threshold from mean+1stddev to mean+2stddev

### DIFF
--- a/exporters/kaexporter/README.md
+++ b/exporters/kaexporter/README.md
@@ -42,13 +42,13 @@ If the file is specified but cannot be read or parsed, the exporter fails to sta
 
 #### Custom SLO thresholds
 
-The same config file supports a `customSLO` section for per-tenant, per-application, or per-component SLO threshold overrides. Values cascade from the most specific level upward: component overrides application, application overrides tenant, tenant overrides built-in defaults (k=1 stddev, 5% breach percentage).
+The same config file supports a `customSLO` section for per-tenant, per-application, or per-component SLO threshold overrides. Values cascade from the most specific level upward: component overrides application, application overrides tenant, tenant overrides built-in defaults (k=2 stddev, 5% breach percentage).
 
 At each level, domain-specific keys can be set:
 
 | Key | Description |
 |-----|-------------|
-| `build_duration_threshold_seconds` | Fixed build duration threshold in seconds. Replaces the computed mean + stddev. |
+| `build_duration_threshold_seconds` | Fixed build duration threshold in seconds. Replaces the computed mean + 2*stddev. |
 | `build_duration_breach_percentage` | Fraction of daily means that must exceed the threshold to trigger breach (default: 0.05). |
 | `integration_duration_threshold_seconds` | Fixed integration test duration threshold. |
 | `integration_duration_breach_percentage` | Integration breach percentage override. |
@@ -73,7 +73,7 @@ integration_duration_threshold_seconds:
 
 Match fields (`scenario`, `event_type`, `build_type`, `automated`) are compared against the metric's label set. Empty fields act as wildcards. Matches are evaluated in YAML order; the first match wins. When no match hits, `default` is used. When `default` is also absent, the value falls through to the parent hierarchy level or the built-in defaults.
 
-When `duration_threshold_seconds` is set, the breach evaluation uses that fixed value directly instead of computing `mean + stddev`. When omitted, the statistical baseline is used. Breach percentages must be in the range (0, 1]. Thresholds must be > 0. Invalid values are logged as warnings at startup and ignored -- the exporter starts normally and the affected overrides fall back to built-in defaults.
+When `duration_threshold_seconds` is set, the breach evaluation uses that fixed value directly instead of computing `mean + 2*stddev`. When omitted, the statistical baseline is used. Breach percentages must be in the range (0, 1]. Thresholds must be > 0. Invalid values are logged as warnings at startup and ignored -- the exporter starts normally and the affected overrides fall back to built-in defaults.
 
 ```yaml
 excludeNamespaces:
@@ -156,7 +156,7 @@ All metrics are **Gauges** over a rolling 30-day window of daily aggregated buck
 - **Total count** (`total_count_30d`): Count of all completed workloads (successful + failed) in the rolling window
 - **Success count** (`success_count_30d`): Count of successful workloads in the rolling window. Enables correct volume-weighted aggregation across dimensions: `sum(success_count) / sum(total_count)`.
 - **Failure count** (`failure_count_30d`): Count of failed workloads, broken down by failure reason. Useful for root cause analysis.
-- **Duration SLO breach** (`duration_slo_breach`): 1 if the component's duration SLO is breached, 0 otherwise. Not emitted when data is insufficient (success_count < 10 or days_with_data < 3). By default, a component is in breach when >=5% of its daily mean durations over the past 30 days exceed the 30-day mean + 1 standard deviation. Thresholds and breach percentages can be overridden per tenant/application/component via the config file (see [Custom SLO thresholds](#custom-slo-thresholds)).
+- **Duration SLO breach** (`duration_slo_breach`): 1 if the component's duration SLO is breached, 0 otherwise. Not emitted when data is insufficient (success_count < 10 or days_with_data < 3). By default, a component is in breach when >=5% of its daily mean durations over the past 30 days exceed the 30-day mean + 2 standard deviations. Thresholds and breach percentages can be overridden per tenant/application/component via the config file (see [Custom SLO thresholds](#custom-slo-thresholds)).
 
 **Derived metrics** (can be computed from the above):
 - **Success rate**: `success_count_30d / total_count_30d` (or 0 when total_count_30d == 0)

--- a/exporters/kaexporter/metrics_test.go
+++ b/exporters/kaexporter/metrics_test.go
@@ -863,6 +863,36 @@ func TestBuildDurationSLOBreach(t *testing.T) {
 		}
 	})
 
+	t.Run("no breach for moderate variance that exceeds mean+1*stddev but not mean+2*stddev", func(t *testing.T) {
+		store := NewStore()
+		now := time.Now().UTC()
+		labels := buildLabelShort
+
+		// 15 days at 300s, 5 days at 450s.
+		// mean = (15*300 + 5*450) / 20 = 337.5
+		// stddev ~= 64.95
+		// mean + 1*stddev ~= 402.5  -> 5 days (450s) exceed this -> 5/20 = 25% -> breach at k=1
+		// mean + 2*stddev ~= 467.4  -> 0 days exceed this -> 0/20 = 0% -> no breach at k=2
+		for i := 0; i < 15; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("normal-%d", i),
+				now.Add(-time.Duration((i+5)*24)*time.Hour), labels, 300.0, 10.0, true, "")
+		}
+		for i := 0; i < 5; i++ {
+			store.RecordObservation(metricBuildDuration, fmt.Sprintf("elevated-%d", i),
+				now.Add(-time.Duration(i*24)*time.Hour), labels, 450.0, 10.0, true, "")
+		}
+
+		buildSLO := newBuildSLO30d(nil)
+		buildSLO.updateGauges(store, nil)
+
+		m := &dto.Metric{}
+		buildSLO.durationSLOBreach.WithLabelValues("c", "ns", "app", "comp", "docker-builds", "push").Write(m) //nolint:errcheck
+		if m.GetGauge().GetValue() != 0 {
+			t.Errorf("expected breach=0 with k=2 (daily means between mean+1*stddev and mean+2*stddev should not breach), got %v",
+				m.GetGauge().GetValue())
+		}
+	})
+
 	t.Run("single day with data skips SLO evaluation", func(t *testing.T) {
 		store := NewStore()
 		now := time.Now().UTC()
@@ -1433,7 +1463,7 @@ func TestSLOBreachWithConfigOverrides(t *testing.T) {
 		store := NewStore()
 		now := time.Now().UTC()
 
-		// 17 days at 300s, 3 days at 600s -> with stddev, 3 days breach
+		// 17 days at 300s, 3 days at 600s -> with 2*stddev, 3 days breach
 		// 3/20 = 15% -> default 5% would trigger, but 20% override should not
 		for i := 0; i < 17; i++ {
 			store.RecordObservation(metricBuildDuration, fmt.Sprintf("norm-%d", i),
@@ -1649,20 +1679,20 @@ func TestSLOBreachWithMatchBasedConfig(t *testing.T) {
 		})
 	})
 
-	t.Run("unmatched scenario with no parent threshold falls to mean+stddev", func(t *testing.T) {
+	t.Run("unmatched scenario with no parent threshold falls to mean+2*stddev", func(t *testing.T) {
 		store := NewStore()
 
 		// ec-scan: 50s mean. Match sets fixed threshold=60, and 50 < 60 -> no breach.
-		// If it fell to mean+stddev instead, threshold would be ~50 (stddev~=0),
+		// If it fell to mean+2*stddev instead, threshold would be ~50 (stddev~=0),
 		// and daily means = 50, not > 50, also no breach -- so we need ec-scan
-		// to prove the match fires by using a threshold that differs from mean+stddev.
+		// to prove the match fires by using a threshold that differs from mean+2*stddev.
 		populateIntegrationData(store, "ec-scan", "push", 50.0, 20)
 
 		// other-scenario: consistent 300s with a few spikes.
-		// mean+stddev with consistent data -> stddev~=0, threshold~=300,
+		// mean+2*stddev with consistent data -> stddev~=0, threshold~=300,
 		// daily means = 300, not > 300 -> no breach under statistical baseline.
 		// BUT if a fixed threshold like ec-scan's 60 were applied, 300 >> 60 -> breach.
-		// So breach=0 here proves it's using mean+stddev, not the ec-scan match.
+		// So breach=0 here proves it's using mean+2*stddev, not the ec-scan match.
 		populateIntegrationData(store, "other-scenario", "push", 300.0, 20)
 
 		cfg := newSLOCfg().
@@ -1692,10 +1722,10 @@ func TestSLOBreachWithMatchBasedConfig(t *testing.T) {
 					t.Errorf("ec-scan: expected breach=0 (50s < 60s match threshold), got %v", m.GetGauge().GetValue())
 				}
 			case "other-scenario":
-				// 300s consistent -> mean+stddev threshold ~300, daily means not > 300 -> no breach
+				// 300s consistent -> mean+2*stddev threshold ~300, daily means not > 300 -> no breach
 				// If the ec-scan match (60) leaked here, 300 >> 60 would breach=1
 				if m.GetGauge().GetValue() != 0 {
-					t.Errorf("other-scenario: expected breach=0 (using mean+stddev, not ec-scan's 60s), got %v", m.GetGauge().GetValue())
+					t.Errorf("other-scenario: expected breach=0 (using mean+2*stddev, not ec-scan's 60s), got %v", m.GetGauge().GetValue())
 				}
 			}
 		})

--- a/exporters/kaexporter/rolling_store.go
+++ b/exporters/kaexporter/rolling_store.go
@@ -464,7 +464,7 @@ const (
 
 // SLO breach evaluation constants.
 const (
-	sloThresholdK         = 1.0  // threshold = mean + k*stddev
+	sloThresholdK         = 2.0  // threshold = mean + k*stddev
 	sloBreachPercentage   = 0.05 // fraction of daily means that must exceed threshold
 	minSuccessCountForSLO = 10   // minimum observations before evaluating SLO
 	minDaysWithDataForSLO = 3    // minimum days with successful observations before evaluating SLO


### PR DESCRIPTION


### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

Jira: [PVO11Y-5480](https://redhat.atlassian.net/browse/PVO11Y-5480)

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [X] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [X] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [X] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [X] **Pipeline Finished Successfully**

---

### Deployment Notice

- [X] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.


[PVO11Y-5480]: https://redhat.atlassian.net/browse/PVO11Y-5480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ