### PR TITLE
Spre 6282 pulp release pipeline alerts

### DIFF
--- a/dashboards/grafana-dashboard-pulp-release-pipeline.configmap.yaml
+++ b/dashboards/grafana-dashboard-pulp-release-pipeline.configmap.yaml
@@ -368,7 +368,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum by (source_cluster, namespace, pod, container) (kube_pod_container_status_terminated_reason{source_cluster=~\"$cluster\", reason=\"OOMKilled\", pod=~\".*(push-rpms-to-pulp|push-rpm-data-to-pyxis|upload-src-rpm-sbom-attestation).*\"}) > 0",
+              "expr": "sum by (source_cluster, namespace, pod, container) (max_over_time(kube_pod_container_status_terminated_reason{source_cluster=~\"$cluster\", reason=\"OOMKilled\", pod=~\".*(push-rpms-to-pulp|push-rpm-data-to-pyxis|upload-src-rpm-sbom-attestation).*\"}[$__range])) > 0",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",

--- a/dashboards/grafana-dashboard-pulp-release-pipeline.configmap.yaml
+++ b/dashboards/grafana-dashboard-pulp-release-pipeline.configmap.yaml
@@ -455,7 +455,7 @@ data:
       },
       "timepicker": {},
       "timezone": "UTC",
-      "title": "Pulp Release Pipeline",
+      "title": "Pulp Release Pipeline OOMKills",
       "uid": "pulp-release-pipeline",
       "version": 0
     }

--- a/dashboards/grafana-dashboard-pulp-release-pipeline.configmap.yaml
+++ b/dashboards/grafana-dashboard-pulp-release-pipeline.configmap.yaml
@@ -126,7 +126,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "(sum(kube_pod_container_status_terminated_reason{source_cluster=~\"$cluster\", reason=\"OOMKilled\", pod=~\".*(push-rpms-to-pulp|push-rpm-data-to-pyxis|upload-src-rpm-sbom-attestation).*\"}) or vector(0))",
+              "expr": "count(count by (source_cluster, namespace, pod) (max_over_time(kube_pod_container_status_terminated_reason{source_cluster=~\"$cluster\", reason=\"OOMKilled\", pod=~\".*(push-rpms-to-pulp|push-rpm-data-to-pyxis|upload-src-rpm-sbom-attestation).*\"}[$__range]) > 0)) or vector(0)",
               "legendFormat": "OOMKilled",
               "range": true,
               "refId": "A"

--- a/dashboards/grafana-dashboard-pulp-release-pipeline.configmap.yaml
+++ b/dashboards/grafana-dashboard-pulp-release-pipeline.configmap.yaml
@@ -1,0 +1,1129 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-pulp-release-pipeline
+  labels:
+    grafana_dashboard: "true"
+  annotations:
+    grafana-folder: /grafana-dashboard-definitions/RHTAP/Release-Service
+data:
+  pulp-release-pipeline-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [
+        {
+          "asDropdown": false,
+          "icon": "external link",
+          "includeVars": false,
+          "keepTime": false,
+          "tags": [],
+          "targetBlank": true,
+          "title": "RPM Release Pipeline Troubleshooting SOP",
+          "tooltip": "",
+          "type": "link",
+          "url": "https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/sre/rpm-release-pipeline-troubleshooting.md"
+        }
+      ],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "panels": [],
+          "title": "Overview",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Total push-rpms-to-pulp TaskRuns in the selected time range",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 1
+          },
+          "id": 2,
+          "options": {
+            "colorMode": "background_solid",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\"}[$__range])) or vector(0)",
+              "legendFormat": "Total",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total TaskRuns",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Failed push-rpms-to-pulp TaskRuns in the selected time range",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "0"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 5
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 6,
+            "y": 1
+          },
+          "id": 3,
+          "options": {
+            "colorMode": "background_solid",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\", status=\"failed\"}[$__range])) or vector(0)",
+              "legendFormat": "Failed",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Failed TaskRuns",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Failure rate of push-rpms-to-pulp TaskRuns over the last hour",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "noValue": "0%",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 12,
+            "y": 1
+          },
+          "id": 4,
+          "options": {
+            "colorMode": "background_solid",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "(\n  sum(rate(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\", status=\"failed\"}[1h]))\n  /\n  sum(rate(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\"}[1h]))\n) * 100",
+              "legendFormat": "Failure Rate",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Failure Rate (1h)",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "OOMKilled containers in push-rpms-to-pulp pods",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "0"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 18,
+            "y": 1
+          },
+          "id": 5,
+          "options": {
+            "colorMode": "background_solid",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(\n  count by (source_cluster, namespace, pod) (\n    max_over_time(\n      kube_pod_container_status_terminated_reason{source_cluster=~\"$cluster\", reason=\"OOMKilled\", pod=~\".*push-rpms-to-pulp.*\"}[$__range]\n    ) > 0\n  )\n) or vector(0)",
+              "legendFormat": "OOMKilled",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "OOMKilled Pods",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 6
+          },
+          "id": 10,
+          "panels": [],
+          "title": "TaskRun Activity",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Rate of push-rpms-to-pulp TaskRuns per minute, by status and cluster",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "TaskRuns / min",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/failed/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/success/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 7
+          },
+          "id": 11,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": true,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (source_cluster, status) (rate(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\"}[5m])) * 60",
+              "legendFormat": "{{source_cluster}} — {{status}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "TaskRun Rate by Status & Cluster",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Failure rate percentage over time (alert threshold at 20%)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "red",
+                "mode": "fixed"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Failure %",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 17
+          },
+          "id": 12,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "(\n  sum by (source_cluster) (rate(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\", status=\"failed\"}[1h]))\n  /\n  sum by (source_cluster) (rate(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\"}[1h]))\n) * 100",
+              "legendFormat": "{{source_cluster}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Failure Rate Over Time (Alert Threshold: 20%)",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 27
+          },
+          "id": 20,
+          "panels": [],
+          "title": "OOMKilled Events",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "OOMKilled events in push-rpms-to-pulp pods over time",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "red",
+                "mode": "fixed"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "OOMKilled Count",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "bars",
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 28
+          },
+          "id": 21,
+          "options": {
+            "legend": {
+              "calcs": [
+                "sum",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": true,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (source_cluster, namespace) (\n  kube_pod_container_status_terminated_reason{source_cluster=~\"$cluster\", reason=\"OOMKilled\", pod=~\".*push-rpms-to-pulp.*\"}\n)",
+              "legendFormat": "{{namespace}} ({{source_cluster}})",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "OOMKilled Events Over Time",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Details of OOMKilled push-rpms-to-pulp pods",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": true,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "source_cluster"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Cluster"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 180
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "namespace"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Namespace"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 220
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "pod"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Pod"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "container"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Container"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 200
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 38
+          },
+          "id": 22,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": true,
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (source_cluster, namespace, pod, container) (\n  max_over_time(\n    kube_pod_container_status_terminated_reason{source_cluster=~\"$cluster\", reason=\"OOMKilled\", pod=~\".*push-rpms-to-pulp.*\"}[$__range]\n  )\n) > 0",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "title": "OOMKilled Pulp Release Pods",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": [
+                    "source_cluster",
+                    "namespace",
+                    "pod",
+                    "container"
+                  ]
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 46
+          },
+          "id": 30,
+          "panels": [],
+          "title": "Cluster Breakdown",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "TaskRun volume per cluster over time",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "bars",
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 47
+          },
+          "id": 31,
+          "options": {
+            "legend": {
+              "calcs": [
+                "sum",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Total",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": true,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (source_cluster) (increase(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\"}[$__interval]))",
+              "legendFormat": "{{source_cluster}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "TaskRun Volume by Cluster",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Failed TaskRuns per cluster over time",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "bars",
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 47
+          },
+          "id": 32,
+          "options": {
+            "legend": {
+              "calcs": [
+                "sum",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Total",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": true,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (source_cluster) (increase(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\", status=\"failed\"}[$__interval]))",
+              "legendFormat": "{{source_cluster}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Failed TaskRuns by Cluster",
+          "type": "timeseries"
+        }
+      ],
+      "preload": false,
+      "refresh": "5m",
+      "schemaVersion": 39,
+      "tags": [
+        "pulp",
+        "release-service",
+        "tekton",
+        "spre"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "text": "rhtap-observatorium-production",
+              "value": "P22466E8E7855F1E0"
+            },
+            "description": "Datasource to fetch metrics from",
+            "label": "Datasource",
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "/^rhtap-observatorium-/",
+            "type": "datasource"
+          },
+          {
+            "current": {
+              "text": "All",
+              "value": [
+                "$__all"
+              ]
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(tekton_pipelines_controller_taskrun_total{pipeline=\"push-rpms-to-pulp\"}, source_cluster)",
+            "description": "Select clusters",
+            "includeAll": true,
+            "label": "Cluster",
+            "multi": true,
+            "name": "cluster",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values(tekton_pipelines_controller_taskrun_total{pipeline=\"push-rpms-to-pulp\"}, source_cluster)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-24h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "UTC",
+      "title": "Pulp Release Pipeline",
+      "uid": "pulp-release-pipeline",
+      "version": 0
+    }

--- a/dashboards/grafana-dashboard-pulp-release-pipeline.configmap.yaml
+++ b/dashboards/grafana-dashboard-pulp-release-pipeline.configmap.yaml
@@ -62,19 +62,34 @@ data:
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Total push-rpms-to-pulp TaskRuns in the selected time range",
+          "description": "OOMKilled containers in RPM release pipeline pods",
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "thresholds"
               },
-              "mappings": [],
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "0"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
               "noValue": "0",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
                   }
                 ]
               }
@@ -83,240 +98,8 @@ data:
           },
           "gridPos": {
             "h": 5,
-            "w": 6,
+            "w": 8,
             "x": 0,
-            "y": 1
-          },
-          "id": 2,
-          "options": {
-            "colorMode": "background_solid",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "sum(increase(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\"}[$__range])) or vector(0)",
-              "legendFormat": "Total",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Total TaskRuns",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "description": "Failed push-rpms-to-pulp TaskRuns in the selected time range",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "options": {
-                    "0": {
-                      "color": "green",
-                      "index": 0,
-                      "text": "0"
-                    }
-                  },
-                  "type": "value"
-                }
-              ],
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 1
-                  },
-                  {
-                    "color": "red",
-                    "value": 5
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 6,
-            "x": 6,
-            "y": 1
-          },
-          "id": 3,
-          "options": {
-            "colorMode": "background_solid",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "sum(increase(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\", status=\"failed\"}[$__range])) or vector(0)",
-              "legendFormat": "Failed",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Failed TaskRuns",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "description": "Failure rate of push-rpms-to-pulp TaskRuns over the last hour",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "noValue": "0%",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 10
-                  },
-                  {
-                    "color": "red",
-                    "value": 20
-                  }
-                ]
-              },
-              "unit": "percent"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 6,
-            "x": 12,
-            "y": 1
-          },
-          "id": 4,
-          "options": {
-            "colorMode": "background_solid",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "(\n  sum(rate(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\", status=\"failed\"}[1h]))\n  /\n  sum(rate(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\"}[1h]))\n) * 100",
-              "legendFormat": "Failure Rate",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Failure Rate (1h)",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "description": "OOMKilled containers in push-rpms-to-pulp pods",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "options": {
-                    "0": {
-                      "color": "green",
-                      "index": 0,
-                      "text": "0"
-                    }
-                  },
-                  "type": "value"
-                }
-              ],
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 6,
-            "x": 18,
             "y": 1
           },
           "id": 5,
@@ -343,7 +126,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(\n  count by (source_cluster, namespace, pod) (\n    max_over_time(\n      kube_pod_container_status_terminated_reason{source_cluster=~\"$cluster\", reason=\"OOMKilled\", pod=~\".*push-rpms-to-pulp.*\"}[$__range]\n    ) > 0\n  )\n) or vector(0)",
+              "expr": "(sum(kube_pod_container_status_terminated_reason{source_cluster=~\"$cluster\", reason=\"OOMKilled\", pod=~\".*(push-rpms-to-pulp|push-rpm-data-to-pyxis|upload-src-rpm-sbom-attestation).*\"}) or vector(0))",
               "legendFormat": "OOMKilled",
               "range": true,
               "refId": "A"
@@ -360,250 +143,6 @@ data:
             "x": 0,
             "y": 6
           },
-          "id": 10,
-          "panels": [],
-          "title": "TaskRun Activity",
-          "type": "row"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "description": "Rate of push-rpms-to-pulp TaskRuns per minute, by status and cluster",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "TaskRuns / min",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 15,
-                "gradientMode": "opacity",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "smooth",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              }
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byRegexp",
-                  "options": "/failed/"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "red",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byRegexp",
-                  "options": "/success/"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "green",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 24,
-            "x": 0,
-            "y": 7
-          },
-          "id": 11,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean",
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": true,
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "sum by (source_cluster, status) (rate(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\"}[5m])) * 60",
-              "legendFormat": "{{source_cluster}} — {{status}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "TaskRun Rate by Status & Cluster",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "description": "Failure rate percentage over time (alert threshold at 20%)",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "red",
-                "mode": "fixed"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "Failure %",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "opacity",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "smooth",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "line"
-                }
-              },
-              "mappings": [],
-              "max": 100,
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 20
-                  }
-                ]
-              },
-              "unit": "percent"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 24,
-            "x": 0,
-            "y": 17
-          },
-          "id": 12,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean",
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "(\n  sum by (source_cluster) (rate(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\", status=\"failed\"}[1h]))\n  /\n  sum by (source_cluster) (rate(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\"}[1h]))\n) * 100",
-              "legendFormat": "{{source_cluster}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Failure Rate Over Time (Alert Threshold: 20%)",
-          "type": "timeseries"
-        },
-        {
-          "collapsed": false,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 27
-          },
           "id": 20,
           "panels": [],
           "title": "OOMKilled Events",
@@ -614,7 +153,7 @@ data:
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "OOMKilled events in push-rpms-to-pulp pods over time",
+          "description": "OOMKilled events in RPM release pipeline pods over time",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -670,7 +209,7 @@ data:
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 28
+            "y": 7
           },
           "id": 21,
           "options": {
@@ -696,7 +235,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum by (source_cluster, namespace) (\n  kube_pod_container_status_terminated_reason{source_cluster=~\"$cluster\", reason=\"OOMKilled\", pod=~\".*push-rpms-to-pulp.*\"}\n)",
+              "expr": "sum by (source_cluster, namespace) (\n  kube_pod_container_status_terminated_reason{source_cluster=~\"$cluster\", reason=\"OOMKilled\", pod=~\".*(push-rpms-to-pulp|push-rpm-data-to-pyxis|upload-src-rpm-sbom-attestation).*\"}\n)",
               "legendFormat": "{{namespace}} ({{source_cluster}})",
               "range": true,
               "refId": "A"
@@ -710,7 +249,7 @@ data:
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Details of OOMKilled push-rpms-to-pulp pods",
+          "description": "Details of OOMKilled RPM release pipeline pods",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -805,7 +344,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 38
+            "y": 17
           },
           "id": 22,
           "options": {
@@ -829,14 +368,14 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum by (source_cluster, namespace, pod, container) (\n  max_over_time(\n    kube_pod_container_status_terminated_reason{source_cluster=~\"$cluster\", reason=\"OOMKilled\", pod=~\".*push-rpms-to-pulp.*\"}[$__range]\n  )\n) > 0",
+              "expr": "sum by (source_cluster, namespace, pod, container) (kube_pod_container_status_terminated_reason{source_cluster=~\"$cluster\", reason=\"OOMKilled\", pod=~\".*(push-rpms-to-pulp|push-rpm-data-to-pyxis|upload-src-rpm-sbom-attestation).*\"}) > 0",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "OOMKilled Pulp Release Pods",
+          "title": "OOMKilled RPM Release Pods",
           "transformations": [
             {
               "id": "filterFieldsByName",
@@ -853,213 +392,6 @@ data:
             }
           ],
           "type": "table"
-        },
-        {
-          "collapsed": false,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 46
-          },
-          "id": 30,
-          "panels": [],
-          "title": "Cluster Breakdown",
-          "type": "row"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "description": "TaskRun volume per cluster over time",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "bars",
-                "fillOpacity": 80,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "normal"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 0,
-            "y": 47
-          },
-          "id": 31,
-          "options": {
-            "legend": {
-              "calcs": [
-                "sum",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true,
-              "sortBy": "Total",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "hideZeros": true,
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "sum by (source_cluster) (increase(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\"}[$__interval]))",
-              "legendFormat": "{{source_cluster}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "TaskRun Volume by Cluster",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "description": "Failed TaskRuns per cluster over time",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "bars",
-                "fillOpacity": 80,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "normal"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 12,
-            "y": 47
-          },
-          "id": 32,
-          "options": {
-            "legend": {
-              "calcs": [
-                "sum",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true,
-              "sortBy": "Total",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "hideZeros": true,
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "sum by (source_cluster) (increase(tekton_pipelines_controller_taskrun_total{source_cluster=~\"$cluster\", pipeline=\"push-rpms-to-pulp\", status=\"failed\"}[$__interval]))",
-              "legendFormat": "{{source_cluster}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Failed TaskRuns by Cluster",
-          "type": "timeseries"
         }
       ],
       "preload": false,
@@ -1098,7 +430,7 @@ data:
               "type": "prometheus",
               "uid": "${datasource}"
             },
-            "definition": "label_values(tekton_pipelines_controller_taskrun_total{pipeline=\"push-rpms-to-pulp\"}, source_cluster)",
+            "definition": "label_values(kube_pod_container_status_terminated_reason{namespace=~\".*-tenant\"}, source_cluster)",
             "description": "Select clusters",
             "includeAll": true,
             "label": "Cluster",
@@ -1107,7 +439,7 @@ data:
             "options": [],
             "query": {
               "qryType": 1,
-              "query": "label_values(tekton_pipelines_controller_taskrun_total{pipeline=\"push-rpms-to-pulp\"}, source_cluster)",
+              "query": "label_values(kube_pod_container_status_terminated_reason{namespace=~\".*-tenant\"}, source_cluster)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 1,

--- a/dashboards/grafana-dashboard-pulp-release-pipeline.configmap.yaml
+++ b/dashboards/grafana-dashboard-pulp-release-pipeline.configmap.yaml
@@ -235,7 +235,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum by (source_cluster, namespace) (\n  kube_pod_container_status_terminated_reason{source_cluster=~\"$cluster\", reason=\"OOMKilled\", pod=~\".*(push-rpms-to-pulp|push-rpm-data-to-pyxis|upload-src-rpm-sbom-attestation).*\"}\n)",
+              "expr": "sum by (source_cluster, namespace) (\n  increase(kube_pod_container_status_terminated_reason{source_cluster=~\"$cluster\", reason=\"OOMKilled\", pod=~\".*(push-rpms-to-pulp|push-rpm-data-to-pyxis|upload-src-rpm-sbom-attestation).*\"}[10m])\n)",
               "legendFormat": "{{namespace}} ({{source_cluster}})",
               "range": true,
               "refId": "A"

--- a/rhobs/alerting/data_plane/prometheus.pulp_release_pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pulp_release_pipeline_alerts.yaml
@@ -1,0 +1,70 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-pulp-release-pipeline-alerting
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: pulp_release_pipeline_alerts
+    interval: 1m
+
+    rules:
+    - alert: PushRpmsToPulpTaskFailureRate
+      expr: |
+        (
+          sum by (source_cluster) (rate(tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp",status="failed"}[1h]))
+          /
+          sum by (source_cluster) (rate(tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp"}[1h]))
+        ) > 0.2
+      for: 15m
+      labels:
+        severity: high
+        slo: "false"
+        component: release-service
+      annotations:
+        summary: >-
+          Pulp RPM release task failure rate exceeds 20% on {{ $labels.source_cluster }}
+        description: >-
+          More than 20% of push-rpms-to-pulp TaskRuns have failed over the last hour
+          on cluster {{ $labels.source_cluster }}.
+        alert_routing_key: release-service
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/sre/rpm-release-pipeline-troubleshooting.md
+        team: release
+
+    - alert: ReleaseTaskOOMKilled
+      expr: |
+        increase(kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace=~".*-tenant",pod=~".*push-rpms-to-pulp.*"}[1h]) > 0
+      for: 5m
+      labels:
+        severity: high
+        slo: "false"
+        component: release-service
+      annotations:
+        summary: >-
+          Pulp release task OOMKilled in {{ $labels.namespace }} on {{ $labels.source_cluster }}
+        description: >-
+          A push-rpms-to-pulp container was OOMKilled in namespace {{ $labels.namespace }}
+          on cluster {{ $labels.source_cluster }}.
+        alert_routing_key: release-service
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/sre/rpm-release-pipeline-troubleshooting.md
+        team: release
+
+    - alert: PulpReleaseBurst
+      expr: |
+        sum by (source_cluster) (rate(tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp"}[15m])) * 60
+        > 10
+      for: 10m
+      labels:
+        severity: warning
+        slo: "false"
+        component: release-service
+      annotations:
+        summary: >-
+          Unusual burst of Pulp release tasks on {{ $labels.source_cluster }}
+        description: >-
+          More than 10 push-rpms-to-pulp TaskRuns per minute sustained over 10 minutes
+          on cluster {{ $labels.source_cluster }}. May indicate a noisy neighbor or runaway automation.
+        alert_routing_key: release-service
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/sre/rpm-release-pipeline-troubleshooting.md
+        team: release

--- a/rhobs/alerting/data_plane/prometheus.pulp_release_pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pulp_release_pipeline_alerts.yaml
@@ -10,31 +10,9 @@ spec:
     interval: 1m
 
     rules:
-    - alert: PushRpmsToPulpTaskFailureRate
-      expr: |
-        (
-          sum by (source_cluster) (rate(tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp",status="failed"}[1h]))
-          /
-          sum by (source_cluster) (rate(tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp"}[1h]))
-        ) > 0.2
-      for: 15m
-      labels:
-        severity: high
-        slo: "false"
-        component: release-service
-      annotations:
-        summary: >-
-          Pulp RPM release task failure rate exceeds 20% on {{ $labels.source_cluster }}
-        description: >-
-          More than 20% of push-rpms-to-pulp TaskRuns have failed over the last hour
-          on cluster {{ $labels.source_cluster }}.
-        alert_routing_key: release-service
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/sre/rpm-release-pipeline-troubleshooting.md
-        team: release
-
     - alert: ReleaseTaskOOMKilled
       expr: |
-        increase(kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace=~".*-tenant",pod=~".*push-rpms-to-pulp.*"}[1h]) > 0
+        increase(kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace=~".*-tenant",pod=~".*(push-rpms-to-pulp|push-rpm-data-to-pyxis|upload-src-rpm-sbom-attestation).*"}[1h]) > 0
       for: 5m
       labels:
         severity: high
@@ -42,29 +20,11 @@ spec:
         component: release-service
       annotations:
         summary: >-
-          Pulp release task OOMKilled in {{ $labels.namespace }} on {{ $labels.source_cluster }}
+          RPM release task OOMKilled in {{ $labels.namespace }} on {{ $labels.source_cluster }}
         description: >-
-          A push-rpms-to-pulp container was OOMKilled in namespace {{ $labels.namespace }}
+          An RPM release pipeline container (push-rpms-to-pulp, push-rpm-data-to-pyxis, or
+          upload-src-rpm-sbom-attestation) was OOMKilled in namespace {{ $labels.namespace }}
           on cluster {{ $labels.source_cluster }}.
-        alert_routing_key: release-service
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/sre/rpm-release-pipeline-troubleshooting.md
-        team: release
-
-    - alert: PulpReleaseBurst
-      expr: |
-        sum by (source_cluster) (rate(tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp"}[15m])) * 60
-        > 10
-      for: 10m
-      labels:
-        severity: warning
-        slo: "false"
-        component: release-service
-      annotations:
-        summary: >-
-          Unusual burst of Pulp release tasks on {{ $labels.source_cluster }}
-        description: >-
-          More than 10 push-rpms-to-pulp TaskRuns per minute sustained over 10 minutes
-          on cluster {{ $labels.source_cluster }}. May indicate a noisy neighbor or runaway automation.
         alert_routing_key: release-service
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/sre/rpm-release-pipeline-troubleshooting.md
         team: release

--- a/rhobs/alerting/data_plane/prometheus.pulp_release_pipeline_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pulp_release_pipeline_alerts.yaml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: ReleaseTaskOOMKilled
       expr: |
-        increase(kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace=~".*-tenant",pod=~".*(push-rpms-to-pulp|push-rpm-data-to-pyxis|upload-src-rpm-sbom-attestation).*"}[1h]) > 0
+        count by (source_cluster,namespace,container,pod) (kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace=~".*-tenant",pod=~".*(push-rpms-to-pulp|push-rpm-data-to-pyxis|upload-src-rpm-sbom-attestation).*"}) >= 1
       for: 5m
       labels:
         severity: high

--- a/test/promql/tests/data_plane/pulp_release_pipeline_alerts_test.yaml
+++ b/test/promql/tests/data_plane/pulp_release_pipeline_alerts_test.yaml
@@ -1,0 +1,122 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.pulp_release_pipeline_alerts.yaml
+
+tests:
+
+  # --- PushRpmsToPulpTaskFailureRate ---
+
+  - name: PushRpmsToPulpTaskFailureRate fires when failure rate exceeds 20%
+    interval: 1m
+    input_series:
+      - series: 'tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp",status="failed",source_cluster="stone-prod-p02"}'
+        values: '0+5x90'
+      - series: 'tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp",status="success",source_cluster="stone-prod-p02"}'
+        values: '0+10x90'
+    alert_rule_test:
+      - eval_time: 80m
+        alertname: PushRpmsToPulpTaskFailureRate
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              slo: "false"
+              source_cluster: stone-prod-p02
+              component: release-service
+            exp_annotations:
+              summary: >-
+                Pulp RPM release task failure rate exceeds 20% on stone-prod-p02
+              description: >-
+                More than 20% of push-rpms-to-pulp TaskRuns have failed over the last hour
+                on cluster stone-prod-p02.
+              alert_routing_key: release-service
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/sre/rpm-release-pipeline-troubleshooting.md
+              team: release
+
+  - name: PushRpmsToPulpTaskFailureRate does not fire when failure rate is below 20%
+    interval: 1m
+    input_series:
+      - series: 'tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp",status="failed",source_cluster="stone-prod-p02"}'
+        values: '0+1x90'
+      - series: 'tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp",status="success",source_cluster="stone-prod-p02"}'
+        values: '0+10x90'
+    alert_rule_test:
+      - eval_time: 80m
+        alertname: PushRpmsToPulpTaskFailureRate
+        exp_alerts: []
+
+  # --- ReleaseTaskOOMKilled ---
+
+  - name: ReleaseTaskOOMKilled fires on OOMKilled event
+    interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace="tenant01-tenant",pod="pipeline-push-rpms-to-pulp-run-abc-step",container="step-push",source_cluster="stone-prod-p02"}'
+        values: '0 0 0 0 0 1 1 1 1 1 1 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: ReleaseTaskOOMKilled
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              slo: "false"
+              reason: OOMKilled
+              namespace: tenant01-tenant
+              pod: pipeline-push-rpms-to-pulp-run-abc-step
+              container: step-push
+              source_cluster: stone-prod-p02
+              component: release-service
+            exp_annotations:
+              summary: >-
+                Pulp release task OOMKilled in tenant01-tenant on stone-prod-p02
+              description: >-
+                A push-rpms-to-pulp container was OOMKilled in namespace tenant01-tenant
+                on cluster stone-prod-p02.
+              alert_routing_key: release-service
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/sre/rpm-release-pipeline-troubleshooting.md
+              team: release
+
+  - name: ReleaseTaskOOMKilled does not fire for non-pulp pods
+    interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace="tenant01-tenant",pod="pipeline-build-run-xyz-step",container="step-build",source_cluster="stone-prod-p02"}'
+        values: '0 0 0 0 0 1 1 1 1 1 1 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: ReleaseTaskOOMKilled
+        exp_alerts: []
+
+  # --- PulpReleaseBurst ---
+
+  - name: PulpReleaseBurst fires on sustained high rate
+    interval: 1m
+    input_series:
+      - series: 'tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp",status="success",source_cluster="stone-prod-p02"}'
+        values: '0+15x40'
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: PulpReleaseBurst
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              slo: "false"
+              source_cluster: stone-prod-p02
+              component: release-service
+            exp_annotations:
+              summary: >-
+                Unusual burst of Pulp release tasks on stone-prod-p02
+              description: >-
+                More than 10 push-rpms-to-pulp TaskRuns per minute sustained over 10 minutes
+                on cluster stone-prod-p02. May indicate a noisy neighbor or runaway automation.
+              alert_routing_key: release-service
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/sre/rpm-release-pipeline-troubleshooting.md
+              team: release
+
+  - name: PulpReleaseBurst does not fire on normal rate
+    interval: 1m
+    input_series:
+      - series: 'tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp",status="success",source_cluster="stone-prod-p02"}'
+        values: '0+1x40'
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: PulpReleaseBurst
+        exp_alerts: []

--- a/test/promql/tests/data_plane/pulp_release_pipeline_alerts_test.yaml
+++ b/test/promql/tests/data_plane/pulp_release_pipeline_alerts_test.yaml
@@ -5,49 +5,9 @@ rule_files:
 
 tests:
 
-  # --- PushRpmsToPulpTaskFailureRate ---
-
-  - name: PushRpmsToPulpTaskFailureRate fires when failure rate exceeds 20%
-    interval: 1m
-    input_series:
-      - series: 'tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp",status="failed",source_cluster="stone-prod-p02"}'
-        values: '0+5x90'
-      - series: 'tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp",status="success",source_cluster="stone-prod-p02"}'
-        values: '0+10x90'
-    alert_rule_test:
-      - eval_time: 80m
-        alertname: PushRpmsToPulpTaskFailureRate
-        exp_alerts:
-          - exp_labels:
-              severity: high
-              slo: "false"
-              source_cluster: stone-prod-p02
-              component: release-service
-            exp_annotations:
-              summary: >-
-                Pulp RPM release task failure rate exceeds 20% on stone-prod-p02
-              description: >-
-                More than 20% of push-rpms-to-pulp TaskRuns have failed over the last hour
-                on cluster stone-prod-p02.
-              alert_routing_key: release-service
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/sre/rpm-release-pipeline-troubleshooting.md
-              team: release
-
-  - name: PushRpmsToPulpTaskFailureRate does not fire when failure rate is below 20%
-    interval: 1m
-    input_series:
-      - series: 'tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp",status="failed",source_cluster="stone-prod-p02"}'
-        values: '0+1x90'
-      - series: 'tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp",status="success",source_cluster="stone-prod-p02"}'
-        values: '0+10x90'
-    alert_rule_test:
-      - eval_time: 80m
-        alertname: PushRpmsToPulpTaskFailureRate
-        exp_alerts: []
-
   # --- ReleaseTaskOOMKilled ---
 
-  - name: ReleaseTaskOOMKilled fires on OOMKilled event
+  - name: ReleaseTaskOOMKilled fires on push-rpms-to-pulp OOMKilled
     interval: 1m
     input_series:
       - series: 'kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace="tenant01-tenant",pod="pipeline-push-rpms-to-pulp-run-abc-step",container="step-push",source_cluster="stone-prod-p02"}'
@@ -67,15 +27,74 @@ tests:
               component: release-service
             exp_annotations:
               summary: >-
-                Pulp release task OOMKilled in tenant01-tenant on stone-prod-p02
+                RPM release task OOMKilled in tenant01-tenant on stone-prod-p02
               description: >-
-                A push-rpms-to-pulp container was OOMKilled in namespace tenant01-tenant
+                An RPM release pipeline container (push-rpms-to-pulp, push-rpm-data-to-pyxis, or
+                upload-src-rpm-sbom-attestation) was OOMKilled in namespace tenant01-tenant
                 on cluster stone-prod-p02.
               alert_routing_key: release-service
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/sre/rpm-release-pipeline-troubleshooting.md
               team: release
 
-  - name: ReleaseTaskOOMKilled does not fire for non-pulp pods
+  - name: ReleaseTaskOOMKilled fires on push-rpm-data-to-pyxis OOMKilled
+    interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace="tenant01-tenant",pod="pipeline-push-rpm-data-to-pyxis-run-def-step",container="step-push",source_cluster="stone-prod-p02"}'
+        values: '0 0 0 0 0 1 1 1 1 1 1 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: ReleaseTaskOOMKilled
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              slo: "false"
+              reason: OOMKilled
+              namespace: tenant01-tenant
+              pod: pipeline-push-rpm-data-to-pyxis-run-def-step
+              container: step-push
+              source_cluster: stone-prod-p02
+              component: release-service
+            exp_annotations:
+              summary: >-
+                RPM release task OOMKilled in tenant01-tenant on stone-prod-p02
+              description: >-
+                An RPM release pipeline container (push-rpms-to-pulp, push-rpm-data-to-pyxis, or
+                upload-src-rpm-sbom-attestation) was OOMKilled in namespace tenant01-tenant
+                on cluster stone-prod-p02.
+              alert_routing_key: release-service
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/sre/rpm-release-pipeline-troubleshooting.md
+              team: release
+
+  - name: ReleaseTaskOOMKilled fires on upload-src-rpm-sbom-attestation OOMKilled
+    interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace="tenant01-tenant",pod="pipeline-upload-src-rpm-sbom-attestation-run-ghi-step",container="step-upload",source_cluster="stone-prod-p02"}'
+        values: '0 0 0 0 0 1 1 1 1 1 1 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: ReleaseTaskOOMKilled
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              slo: "false"
+              reason: OOMKilled
+              namespace: tenant01-tenant
+              pod: pipeline-upload-src-rpm-sbom-attestation-run-ghi-step
+              container: step-upload
+              source_cluster: stone-prod-p02
+              component: release-service
+            exp_annotations:
+              summary: >-
+                RPM release task OOMKilled in tenant01-tenant on stone-prod-p02
+              description: >-
+                An RPM release pipeline container (push-rpms-to-pulp, push-rpm-data-to-pyxis, or
+                upload-src-rpm-sbom-attestation) was OOMKilled in namespace tenant01-tenant
+                on cluster stone-prod-p02.
+              alert_routing_key: release-service
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/sre/rpm-release-pipeline-troubleshooting.md
+              team: release
+
+  - name: ReleaseTaskOOMKilled does not fire for non-release-pipeline pods
     interval: 1m
     input_series:
       - series: 'kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace="tenant01-tenant",pod="pipeline-build-run-xyz-step",container="step-build",source_cluster="stone-prod-p02"}'
@@ -83,40 +102,4 @@ tests:
     alert_rule_test:
       - eval_time: 15m
         alertname: ReleaseTaskOOMKilled
-        exp_alerts: []
-
-  # --- PulpReleaseBurst ---
-
-  - name: PulpReleaseBurst fires on sustained high rate
-    interval: 1m
-    input_series:
-      - series: 'tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp",status="success",source_cluster="stone-prod-p02"}'
-        values: '0+15x40'
-    alert_rule_test:
-      - eval_time: 30m
-        alertname: PulpReleaseBurst
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              slo: "false"
-              source_cluster: stone-prod-p02
-              component: release-service
-            exp_annotations:
-              summary: >-
-                Unusual burst of Pulp release tasks on stone-prod-p02
-              description: >-
-                More than 10 push-rpms-to-pulp TaskRuns per minute sustained over 10 minutes
-                on cluster stone-prod-p02. May indicate a noisy neighbor or runaway automation.
-              alert_routing_key: release-service
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/sre/rpm-release-pipeline-troubleshooting.md
-              team: release
-
-  - name: PulpReleaseBurst does not fire on normal rate
-    interval: 1m
-    input_series:
-      - series: 'tekton_pipelines_controller_taskrun_total{pipeline="push-rpms-to-pulp",status="success",source_cluster="stone-prod-p02"}'
-        values: '0+1x40'
-    alert_rule_test:
-      - eval_time: 30m
-        alertname: PulpReleaseBurst
         exp_alerts: []

--- a/test/promql/tests/data_plane/pulp_release_pipeline_alerts_test.yaml
+++ b/test/promql/tests/data_plane/pulp_release_pipeline_alerts_test.yaml
@@ -11,15 +11,14 @@ tests:
     interval: 1m
     input_series:
       - series: 'kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace="tenant01-tenant",pod="pipeline-push-rpms-to-pulp-run-abc-step",container="step-push",source_cluster="stone-prod-p02"}'
-        values: '0 0 0 0 0 1 1 1 1 1 1 1 1 1 1'
+        values: '1x15'
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 5m
         alertname: ReleaseTaskOOMKilled
         exp_alerts:
           - exp_labels:
               severity: high
               slo: "false"
-              reason: OOMKilled
               namespace: tenant01-tenant
               pod: pipeline-push-rpms-to-pulp-run-abc-step
               container: step-push
@@ -40,15 +39,14 @@ tests:
     interval: 1m
     input_series:
       - series: 'kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace="tenant01-tenant",pod="pipeline-push-rpm-data-to-pyxis-run-def-step",container="step-push",source_cluster="stone-prod-p02"}'
-        values: '0 0 0 0 0 1 1 1 1 1 1 1 1 1 1'
+        values: '1x15'
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 5m
         alertname: ReleaseTaskOOMKilled
         exp_alerts:
           - exp_labels:
               severity: high
               slo: "false"
-              reason: OOMKilled
               namespace: tenant01-tenant
               pod: pipeline-push-rpm-data-to-pyxis-run-def-step
               container: step-push
@@ -69,15 +67,14 @@ tests:
     interval: 1m
     input_series:
       - series: 'kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace="tenant01-tenant",pod="pipeline-upload-src-rpm-sbom-attestation-run-ghi-step",container="step-upload",source_cluster="stone-prod-p02"}'
-        values: '0 0 0 0 0 1 1 1 1 1 1 1 1 1 1'
+        values: '1x15'
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 5m
         alertname: ReleaseTaskOOMKilled
         exp_alerts:
           - exp_labels:
               severity: high
               slo: "false"
-              reason: OOMKilled
               namespace: tenant01-tenant
               pod: pipeline-upload-src-rpm-sbom-attestation-run-ghi-step
               container: step-upload
@@ -98,8 +95,8 @@ tests:
     interval: 1m
     input_series:
       - series: 'kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace="tenant01-tenant",pod="pipeline-build-run-xyz-step",container="step-build",source_cluster="stone-prod-p02"}'
-        values: '0 0 0 0 0 1 1 1 1 1 1 1 1 1 1'
+        values: '1x15'
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 5m
         alertname: ReleaseTaskOOMKilled
         exp_alerts: []


### PR DESCRIPTION
## Summary

- Add `ReleaseTaskOOMKilled` PrometheusRule alert for OOMKilled RPM release pipeline containers (`push-rpms-to-pulp`, `push-rpm-data-to-pyxis`, `upload-src-rpm-sbom-attestation`)
- Add Grafana dashboard (`pulp-release-pipeline`) with OOMKilled stat, event timeline, and pod detail table
- 4 unit tests (3 positive per task, 1 negative)

**Scope reduction:** `PushRpmsToPulpTaskFailureRate` and `PulpReleaseBurst` alerts were removed — Tekton v5.0.5 stripped `pipeline` and `task` labels from `tekton_pipelines_controller_taskrun_total`, confirmed absent in production RHOBS. Non-OOM failure detection relies on Splunk until labels are restored upstream. See [Jira comment](https://redhat.atlassian.net/browse/SPRE-6282?focusedId=18291755) for details.

## Test plan

- [x] `selective-check-and-test.sh` passes (promtool, yamllint, pint, unit tests)
- [x] Dashboard validated in staging Grafana — stat shows "0" (green), timeseries and table render correctly
- [ ] Delete staging test dashboard before merge
- [ ] Update app-interface saas file commit SHA after merge