### PR TITLE
PVO11Y-5483: Implement 5 Prometheus monitoring alerts

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.availability_alert.yaml
+++ b/rhobs/alerting/data_plane/prometheus.availability_alert.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-prometheus-availability-alert
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: prometheus_availability_alert
+    interval: 1m
+    rules:
+    - alert: PrometheusUnavailable
+      expr: |
+        up{
+          namespace=~"openshift-monitoring|openshift-user-workload-monitoring|appstudio-monitoring",
+          job=~"prometheus.*"
+        } == 0
+      for: 2m
+      labels:
+        severity: critical
+        component: prometheus
+        slo: "true"
+      annotations:
+        summary: "Prometheus instance {{ $labels.pod }} is unavailable on cluster {{ $labels.source_cluster }}"
+        description: "Prometheus instance {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} has been unavailable for more than 2 minutes."
+        alert_team_handle: "<!subteam^S06LGCC3C2V>"
+        team: o11y
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-unavailable.md

--- a/rhobs/alerting/data_plane/prometheus.federation_delay_alert.yaml
+++ b/rhobs/alerting/data_plane/prometheus.federation_delay_alert.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-prometheus-federation-delay-alert
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: prometheus_federation_delay_alert
+    interval: 1m
+    rules:
+    - alert: PrometheusFederationDelayHigh
+      expr: |
+        (time() - prometheus_remote_storage_queue_highest_sent_timestamp_seconds{
+          namespace=~"openshift-monitoring|openshift-user-workload-monitoring|appstudio-monitoring",
+          job=~"prometheus.*"
+        }) > 300
+      for: 5m
+      labels:
+        severity: warning
+        component: prometheus
+        slo: "false"
+      annotations:
+        summary: "Prometheus federation delay high for {{ $labels.pod }} on cluster {{ $labels.source_cluster }}"
+        description: "Prometheus instance {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} has a federation delay of {{ $value | humanizeDuration }}. Data is not being sent to RHOBS in a timely manner, which may delay alerting."
+        alert_routing_key: o11y
+        team: o11y
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-federation-delay.md

--- a/rhobs/alerting/data_plane/prometheus.memory_usage_alert.yaml
+++ b/rhobs/alerting/data_plane/prometheus.memory_usage_alert.yaml
@@ -1,0 +1,41 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-prometheus-memory-usage-alert
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: prometheus_memory_usage_alert
+    interval: 1m
+    rules:
+    - alert: PrometheusMemoryUsageHigh
+      expr: |
+        (
+          sum by (source_cluster, namespace, pod) (
+            node_namespace_pod_container:container_memory_working_set_bytes{
+              namespace=~"openshift-monitoring|openshift-user-workload-monitoring|appstudio-monitoring",
+              container="prometheus"
+            }
+          )
+          /
+          on (source_cluster, namespace, pod)
+          sum by (source_cluster, namespace, pod) (
+            cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{
+              namespace=~"openshift-monitoring|openshift-user-workload-monitoring|appstudio-monitoring",
+              container="prometheus",
+              resource="memory"
+            }
+          )
+        ) > 0.80
+      for: 5m
+      labels:
+        severity: warning
+        component: prometheus
+        slo: "false"
+      annotations:
+        summary: "Prometheus pod {{ $labels.pod }} has high memory usage on cluster {{ $labels.source_cluster }}"
+        description: "Prometheus pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is using {{ $value | humanizePercentage }} of its memory limit. High memory usage can lead to OOM kills and monitoring gaps."
+        alert_routing_key: o11y
+        team: o11y
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-memory-usage.md

--- a/rhobs/alerting/data_plane/prometheus.remote_write_queue_alert.yaml
+++ b/rhobs/alerting/data_plane/prometheus.remote_write_queue_alert.yaml
@@ -1,0 +1,35 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-prometheus-remote-write-queue-alert
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: prometheus_remote_write_queue_alert
+    interval: 1m
+    rules:
+    - alert: PrometheusRemoteWriteQueueHigh
+      expr: |
+        (
+          prometheus_remote_storage_samples_pending{
+            namespace=~"openshift-monitoring|openshift-user-workload-monitoring|appstudio-monitoring",
+            job=~"prometheus.*"
+          }
+          /
+          prometheus_remote_storage_shard_capacity{
+            namespace=~"openshift-monitoring|openshift-user-workload-monitoring|appstudio-monitoring",
+            job=~"prometheus.*"
+          }
+        ) > 0.90
+      for: 5m
+      labels:
+        severity: warning
+        component: prometheus
+        slo: "false"
+      annotations:
+        summary: "Prometheus remote-write queue high for {{ $labels.pod }} on cluster {{ $labels.source_cluster }}"
+        description: "Prometheus instance {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} has a remote-write queue at {{ $value | humanizePercentage }} capacity. When the queue fills completely, samples will be dropped and data will be lost."
+        alert_routing_key: o11y
+        team: o11y
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-remote-write-queue.md

--- a/rhobs/alerting/data_plane/prometheus.tsdb_size_alert.yaml
+++ b/rhobs/alerting/data_plane/prometheus.tsdb_size_alert.yaml
@@ -1,0 +1,40 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-prometheus-tsdb-size-alert
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: prometheus_tsdb_size_alert
+    interval: 1m
+    rules:
+    - alert: PrometheusTSDBStorageHigh
+      expr: |
+        (
+          sum by (source_cluster, namespace, pod) (
+            prometheus_tsdb_storage_blocks_bytes{
+              namespace=~"openshift-monitoring|openshift-user-workload-monitoring|appstudio-monitoring",
+              job=~"prometheus.*"
+            }
+          )
+          /
+          on (source_cluster, namespace, pod)
+          sum by (source_cluster, namespace, pod) (
+            prometheus_tsdb_retention_limit_bytes{
+              namespace=~"openshift-monitoring|openshift-user-workload-monitoring|appstudio-monitoring",
+              job=~"prometheus.*"
+            }
+          )
+        ) > 0.85
+      for: 5m
+      labels:
+        severity: warning
+        component: prometheus
+        slo: "false"
+      annotations:
+        summary: "Prometheus TSDB storage high on {{ $labels.pod }} in cluster {{ $labels.source_cluster }}"
+        description: "Prometheus instance {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is using {{ $value | humanizePercentage }} of its TSDB retention limit. Note: Values above 100% can occur during normal compaction cycles and will typically resolve automatically."
+        alert_routing_key: o11y
+        team: o11y
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-tsdb-storage.md

--- a/test/promql/tests/data_plane/availability_alert_test.yaml
+++ b/test/promql/tests/data_plane/availability_alert_test.yaml
@@ -1,0 +1,71 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.availability_alert.yaml
+
+tests:
+  # Positive test: Alert fires when Prometheus is down for 2+ minutes
+  - interval: 1m
+    input_series:
+      - series: 'up{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '0x3'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: PrometheusUnavailable
+        exp_alerts:
+          - exp_labels:
+              component: prometheus
+              job: prometheus-k8s
+              namespace: openshift-monitoring
+              pod: prometheus-k8s-0
+              severity: critical
+              slo: "true"
+              source_cluster: cluster01
+            exp_annotations:
+              summary: 'Prometheus instance prometheus-k8s-0 is unavailable on cluster cluster01'
+              description: 'Prometheus instance prometheus-k8s-0 in namespace openshift-monitoring on cluster cluster01 has been unavailable for more than 2 minutes.'
+              alert_team_handle: "<!subteam^S06LGCC3C2V>"
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-unavailable.md
+
+  # Negative test: No alert when Prometheus is up
+  - interval: 1m
+    input_series:
+      - series: 'up{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '1x3'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: PrometheusUnavailable
+
+  # Duration test: No alert if down for only 1 minute
+  - interval: 1m
+    input_series:
+      - series: 'up{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '0x2 1x1'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: PrometheusUnavailable
+
+  # Multiple namespaces test: Alert works for user-workload-monitoring
+  - interval: 1m
+    input_series:
+      - series: 'up{job="prometheus-user-workload",namespace="openshift-user-workload-monitoring",pod="prometheus-user-workload-0",source_cluster="cluster02"}'
+        values: '0x3'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: PrometheusUnavailable
+        exp_alerts:
+          - exp_labels:
+              component: prometheus
+              job: prometheus-user-workload
+              namespace: openshift-user-workload-monitoring
+              pod: prometheus-user-workload-0
+              severity: critical
+              slo: "true"
+              source_cluster: cluster02
+            exp_annotations:
+              summary: 'Prometheus instance prometheus-user-workload-0 is unavailable on cluster cluster02'
+              description: 'Prometheus instance prometheus-user-workload-0 in namespace openshift-user-workload-monitoring on cluster cluster02 has been unavailable for more than 2 minutes.'
+              alert_team_handle: "<!subteam^S06LGCC3C2V>"
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-unavailable.md

--- a/test/promql/tests/data_plane/federation_delay_alert_test.yaml
+++ b/test/promql/tests/data_plane/federation_delay_alert_test.yaml
@@ -1,0 +1,76 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.federation_delay_alert.yaml
+
+tests:
+  # Positive test: Alert fires when delay >300s for 5+ minutes
+  # At eval_time 11m (660s from epoch), time() returns 660
+  # With timestamp at 0, delay is 660 - 0 = 660s > 300s (true)
+  # With for: 5m, alert fires at 11m (6m condition true + 5m duration)
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '0+0x15'  # Timestamp stays at 0 (very old), causing large delay
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: PrometheusFederationDelayHigh
+        exp_alerts:
+          - exp_labels:
+              component: prometheus
+              job: prometheus-k8s
+              namespace: openshift-monitoring
+              pod: prometheus-k8s-0
+              severity: warning
+              slo: "false"
+              source_cluster: cluster01
+            exp_annotations:
+              summary: 'Prometheus federation delay high for prometheus-k8s-0 on cluster cluster01'
+              description: 'Prometheus instance prometheus-k8s-0 in namespace openshift-monitoring on cluster cluster01 has a federation delay of 11m0s. Data is not being sent to RHOBS in a timely manner, which may delay alerting.'
+              alert_routing_key: o11y
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-federation-delay.md
+
+  # Negative test: No alert when delay is under threshold
+  # Incrementing timestamp keeps delay small
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '1+60x15'  # Incrementing timestamp, always recent (delay ~60s)
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: PrometheusFederationDelayHigh
+
+  # Duration test: No alert if delay only lasts 4 minutes
+  # High delay for 4 minutes, then recent timestamp
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '0+0x4 240+60x10'  # Old timestamps for 4min, then catch up
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PrometheusFederationDelayHigh
+
+  # Multiple namespaces test: user-workload-monitoring
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job="prometheus-user-workload",namespace="openshift-user-workload-monitoring",pod="prometheus-user-workload-0",source_cluster="cluster02"}'
+        values: '0+0x15'
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: PrometheusFederationDelayHigh
+        exp_alerts:
+          - exp_labels:
+              component: prometheus
+              job: prometheus-user-workload
+              namespace: openshift-user-workload-monitoring
+              pod: prometheus-user-workload-0
+              severity: warning
+              slo: "false"
+              source_cluster: cluster02
+            exp_annotations:
+              summary: 'Prometheus federation delay high for prometheus-user-workload-0 on cluster cluster02'
+              description: 'Prometheus instance prometheus-user-workload-0 in namespace openshift-user-workload-monitoring on cluster cluster02 has a federation delay of 11m0s. Data is not being sent to RHOBS in a timely manner, which may delay alerting.'
+              alert_routing_key: o11y
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-federation-delay.md

--- a/test/promql/tests/data_plane/memory_usage_alert_test.yaml
+++ b/test/promql/tests/data_plane/memory_usage_alert_test.yaml
@@ -1,0 +1,113 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.memory_usage_alert.yaml
+
+tests:
+  # Positive test: Alert fires at 81% for 5+ minutes
+  - interval: 1m
+    input_series:
+      - series: 'node_namespace_pod_container:container_memory_working_set_bytes{namespace="openshift-monitoring",pod="prometheus-k8s-0",container="prometheus",source_cluster="cluster01"}'
+        values: '0.81+0x10'
+      - series: 'cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace="openshift-monitoring",pod="prometheus-k8s-0",container="prometheus",resource="memory",source_cluster="cluster01"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusMemoryUsageHigh
+        exp_alerts:
+          - exp_labels:
+              component: prometheus
+              namespace: openshift-monitoring
+              pod: prometheus-k8s-0
+              severity: warning
+              slo: "false"
+              source_cluster: cluster01
+            exp_annotations:
+              summary: 'Prometheus pod prometheus-k8s-0 has high memory usage on cluster cluster01'
+              description: 'Prometheus pod prometheus-k8s-0 in namespace openshift-monitoring on cluster cluster01 is using 81% of its memory limit. High memory usage can lead to OOM kills and monitoring gaps.'
+              alert_routing_key: o11y
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-memory-usage.md
+
+  # Negative test: No alert at 79%
+  - interval: 1m
+    input_series:
+      - series: 'node_namespace_pod_container:container_memory_working_set_bytes{namespace="openshift-monitoring",pod="prometheus-k8s-0",container="prometheus",source_cluster="cluster01"}'
+        values: '0.79+0x10'
+      - series: 'cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace="openshift-monitoring",pod="prometheus-k8s-0",container="prometheus",resource="memory",source_cluster="cluster01"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusMemoryUsageHigh
+
+  # Edge case: No alert when exactly at 80% (expression uses > not >=)
+  - interval: 1m
+    input_series:
+      - series: 'node_namespace_pod_container:container_memory_working_set_bytes{namespace="openshift-monitoring",pod="prometheus-k8s-0",container="prometheus",source_cluster="cluster01"}'
+        values: '0.80+0x10'
+      - series: 'cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace="openshift-monitoring",pod="prometheus-k8s-0",container="prometheus",resource="memory",source_cluster="cluster01"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusMemoryUsageHigh
+
+  # Duration test: No alert if high usage lasts only 4 minutes
+  - interval: 1m
+    input_series:
+      - series: 'node_namespace_pod_container:container_memory_working_set_bytes{namespace="openshift-monitoring",pod="prometheus-k8s-0",container="prometheus",source_cluster="cluster01"}'
+        values: '0.85+0x4 0.75+0x6'
+      - series: 'cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace="openshift-monitoring",pod="prometheus-k8s-0",container="prometheus",resource="memory",source_cluster="cluster01"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: PrometheusMemoryUsageHigh
+
+  # Multiple namespaces test: user-workload-monitoring
+  - interval: 1m
+    input_series:
+      - series: 'node_namespace_pod_container:container_memory_working_set_bytes{namespace="openshift-user-workload-monitoring",pod="prometheus-user-workload-0",container="prometheus",source_cluster="cluster02"}'
+        values: '0.85+0x10'
+      - series: 'cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace="openshift-user-workload-monitoring",pod="prometheus-user-workload-0",container="prometheus",resource="memory",source_cluster="cluster02"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusMemoryUsageHigh
+        exp_alerts:
+          - exp_labels:
+              component: prometheus
+              namespace: openshift-user-workload-monitoring
+              pod: prometheus-user-workload-0
+              severity: warning
+              slo: "false"
+              source_cluster: cluster02
+            exp_annotations:
+              summary: 'Prometheus pod prometheus-user-workload-0 has high memory usage on cluster cluster02'
+              description: 'Prometheus pod prometheus-user-workload-0 in namespace openshift-user-workload-monitoring on cluster cluster02 is using 85% of its memory limit. High memory usage can lead to OOM kills and monitoring gaps.'
+              alert_routing_key: o11y
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-memory-usage.md
+
+  # appstudio-monitoring namespace test
+  - interval: 1m
+    input_series:
+      - series: 'node_namespace_pod_container:container_memory_working_set_bytes{namespace="appstudio-monitoring",pod="prometheus-appstudio-0",container="prometheus",source_cluster="cluster03"}'
+        values: '0.90+0x10'
+      - series: 'cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace="appstudio-monitoring",pod="prometheus-appstudio-0",container="prometheus",resource="memory",source_cluster="cluster03"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusMemoryUsageHigh
+        exp_alerts:
+          - exp_labels:
+              component: prometheus
+              namespace: appstudio-monitoring
+              pod: prometheus-appstudio-0
+              severity: warning
+              slo: "false"
+              source_cluster: cluster03
+            exp_annotations:
+              summary: 'Prometheus pod prometheus-appstudio-0 has high memory usage on cluster cluster03'
+              description: 'Prometheus pod prometheus-appstudio-0 in namespace appstudio-monitoring on cluster cluster03 is using 90% of its memory limit. High memory usage can lead to OOM kills and monitoring gaps.'
+              alert_routing_key: o11y
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-memory-usage.md

--- a/test/promql/tests/data_plane/remote_write_queue_alert_test.yaml
+++ b/test/promql/tests/data_plane/remote_write_queue_alert_test.yaml
@@ -1,0 +1,127 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.remote_write_queue_alert.yaml
+
+tests:
+  # Positive test: Alert fires at 91% for 5+ minutes
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_samples_pending{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '0.91+0x10'
+      - series: 'prometheus_remote_storage_shard_capacity{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusRemoteWriteQueueHigh
+        exp_alerts:
+          - exp_labels:
+              component: prometheus
+              job: prometheus-k8s
+              namespace: openshift-monitoring
+              pod: prometheus-k8s-0
+              severity: warning
+              slo: "false"
+              source_cluster: cluster01
+            exp_annotations:
+              summary: 'Prometheus remote-write queue high for prometheus-k8s-0 on cluster cluster01'
+              description: 'Prometheus instance prometheus-k8s-0 in namespace openshift-monitoring on cluster cluster01 has a remote-write queue at 91% capacity. When the queue fills completely, samples will be dropped and data will be lost.'
+              alert_routing_key: o11y
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-remote-write-queue.md
+
+  # Negative test: No alert at 89%
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_samples_pending{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '0.89+0x10'
+      - series: 'prometheus_remote_storage_shard_capacity{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusRemoteWriteQueueHigh
+
+  # Edge case: No alert when exactly at 90% (expression uses > not >=)
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_samples_pending{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '0.90+0x10'
+      - series: 'prometheus_remote_storage_shard_capacity{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusRemoteWriteQueueHigh
+
+  # Duration test: No alert if high usage only 4 minutes
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_samples_pending{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '0.91+0x4 0.10+0x6'
+      - series: 'prometheus_remote_storage_shard_capacity{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: PrometheusRemoteWriteQueueHigh
+
+  # Normal operation test: No alert at 5% (healthy)
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_samples_pending{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '0.05+0x10'
+      - series: 'prometheus_remote_storage_shard_capacity{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusRemoteWriteQueueHigh
+
+  # Edge case: Queue at 100% (full saturation)
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_samples_pending{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '1.0+0x10'
+      - series: 'prometheus_remote_storage_shard_capacity{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusRemoteWriteQueueHigh
+        exp_alerts:
+          - exp_labels:
+              component: prometheus
+              job: prometheus-k8s
+              namespace: openshift-monitoring
+              pod: prometheus-k8s-0
+              severity: warning
+              slo: "false"
+              source_cluster: cluster01
+            exp_annotations:
+              summary: 'Prometheus remote-write queue high for prometheus-k8s-0 on cluster cluster01'
+              description: 'Prometheus instance prometheus-k8s-0 in namespace openshift-monitoring on cluster cluster01 has a remote-write queue at 100% capacity. When the queue fills completely, samples will be dropped and data will be lost.'
+              alert_routing_key: o11y
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-remote-write-queue.md
+
+  # Multiple namespaces test: user-workload-monitoring
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_samples_pending{job="prometheus-user-workload",namespace="openshift-user-workload-monitoring",pod="prometheus-user-workload-0",source_cluster="cluster02"}'
+        values: '0.96+0x10'
+      - series: 'prometheus_remote_storage_shard_capacity{job="prometheus-user-workload",namespace="openshift-user-workload-monitoring",pod="prometheus-user-workload-0",source_cluster="cluster02"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusRemoteWriteQueueHigh
+        exp_alerts:
+          - exp_labels:
+              component: prometheus
+              job: prometheus-user-workload
+              namespace: openshift-user-workload-monitoring
+              pod: prometheus-user-workload-0
+              severity: warning
+              slo: "false"
+              source_cluster: cluster02
+            exp_annotations:
+              summary: 'Prometheus remote-write queue high for prometheus-user-workload-0 on cluster cluster02'
+              description: 'Prometheus instance prometheus-user-workload-0 in namespace openshift-user-workload-monitoring on cluster cluster02 has a remote-write queue at 96% capacity. When the queue fills completely, samples will be dropped and data will be lost.'
+              alert_routing_key: o11y
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-remote-write-queue.md

--- a/test/promql/tests/data_plane/tsdb_size_alert_test.yaml
+++ b/test/promql/tests/data_plane/tsdb_size_alert_test.yaml
@@ -1,0 +1,113 @@
+evaluation_interval: 1m
+
+rule_files:
+  - prometheus.tsdb_size_alert.yaml
+
+tests:
+  # Positive test: Alert fires when TSDB at 86% for 5+ minutes
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_tsdb_storage_blocks_bytes{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '0.86+0x10'
+      - series: 'prometheus_tsdb_retention_limit_bytes{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusTSDBStorageHigh
+        exp_alerts:
+          - exp_labels:
+              component: prometheus
+              namespace: openshift-monitoring
+              pod: prometheus-k8s-0
+              severity: warning
+              slo: "false"
+              source_cluster: cluster01
+            exp_annotations:
+              summary: 'Prometheus TSDB storage high on prometheus-k8s-0 in cluster cluster01'
+              description: 'Prometheus instance prometheus-k8s-0 in namespace openshift-monitoring on cluster cluster01 is using 86% of its TSDB retention limit. Note: Values above 100% can occur during normal compaction cycles and will typically resolve automatically.'
+              alert_routing_key: o11y
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-tsdb-storage.md
+
+  # Negative test: No alert when TSDB at 84%
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_tsdb_storage_blocks_bytes{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '0.84+0x10'
+      - series: 'prometheus_tsdb_retention_limit_bytes{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusTSDBStorageHigh
+
+  # Edge case: No alert when exactly at 85% (expression uses > not >=)
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_tsdb_storage_blocks_bytes{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '0.85+0x10'
+      - series: 'prometheus_tsdb_retention_limit_bytes{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusTSDBStorageHigh
+
+  # Duration test: No alert if high usage lasts only 4 minutes
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_tsdb_storage_blocks_bytes{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '0.86+0x4 0.84+0x6'
+      - series: 'prometheus_tsdb_retention_limit_bytes{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: PrometheusTSDBStorageHigh
+
+  # Above 100% test: Alert fires even when TSDB exceeds retention limit (e.g., 105% during compaction)
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_tsdb_storage_blocks_bytes{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '1.05+0x10'
+      - series: 'prometheus_tsdb_retention_limit_bytes{job="prometheus-k8s",namespace="openshift-monitoring",pod="prometheus-k8s-0",source_cluster="cluster01"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusTSDBStorageHigh
+        exp_alerts:
+          - exp_labels:
+              component: prometheus
+              namespace: openshift-monitoring
+              pod: prometheus-k8s-0
+              severity: warning
+              slo: "false"
+              source_cluster: cluster01
+            exp_annotations:
+              summary: 'Prometheus TSDB storage high on prometheus-k8s-0 in cluster cluster01'
+              description: 'Prometheus instance prometheus-k8s-0 in namespace openshift-monitoring on cluster cluster01 is using 105% of its TSDB retention limit. Note: Values above 100% can occur during normal compaction cycles and will typically resolve automatically.'
+              alert_routing_key: o11y
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-tsdb-storage.md
+
+  # Namespace coverage test: user-workload-monitoring
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_tsdb_storage_blocks_bytes{job="prometheus-user-workload",namespace="openshift-user-workload-monitoring",pod="prometheus-user-workload-0",source_cluster="cluster02"}'
+        values: '0.90+0x10'
+      - series: 'prometheus_tsdb_retention_limit_bytes{job="prometheus-user-workload",namespace="openshift-user-workload-monitoring",pod="prometheus-user-workload-0",source_cluster="cluster02"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusTSDBStorageHigh
+        exp_alerts:
+          - exp_labels:
+              component: prometheus
+              namespace: openshift-user-workload-monitoring
+              pod: prometheus-user-workload-0
+              severity: warning
+              slo: "false"
+              source_cluster: cluster02
+            exp_annotations:
+              summary: 'Prometheus TSDB storage high on prometheus-user-workload-0 in cluster cluster02'
+              description: 'Prometheus instance prometheus-user-workload-0 in namespace openshift-user-workload-monitoring on cluster cluster02 is using 90% of its TSDB retention limit. Note: Values above 100% can occur during normal compaction cycles and will typically resolve automatically.'
+              alert_routing_key: o11y
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-prometheus-tsdb-storage.md


### PR DESCRIPTION
## Summary

Implement 5 monitoring alerts for Prometheus stack health based on PVO11Y-4996 spike assessment. These alerts provide early warning for failure modes including storage exhaustion, memory pressure, unavailability, federation delays, and remote-write queue saturation.

## Alerts Implemented

### Phase 1: Metrics Already Available

1. **PrometheusUnavailable** - Detects when Prometheus instances are down (up==0)
   - Severity: warning, SLO: true
   - Duration: 2m
   - Immediate impact on monitoring coverage

2. **PrometheusMemoryUsageHigh** - Warns when memory usage > 80% of limit
   - Severity: warning, SLO: false
   - Duration: 5m
   - Prevents OOM kills

3. **PrometheusTSDBStorageHigh** - Warns when TSDB > 85% of retention limit
   - Severity: warning, SLO: false
   - Duration: 5m
   - Note: Values can exceed 100% during normal compaction cycles
   - **Dependency**: Requires infra-deployments staging PR #13650 to be deployed

### Phase 2: Requires Federation Deployment

4. **PrometheusFederationDelayHigh** - Detects federation delays > 5 minutes
   - Severity: warning, SLO: false
   - Duration: 5m
   - Indicates remote-write issues or network problems
   - **Dependency**: Requires infra-deployments staging PR #13650 to be deployed

5. **PrometheusRemoteWriteQueueHigh** - Warns when remote-write queue > 90%
   - Severity: warning, SLO: false
   - Duration: 5m
   - Prevents data loss when queue fills
   - **Dependency**: Requires infra-deployments staging PR #13650 to be deployed

## Files Created

**Alert Rules**:
- `rhobs/alerting/data_plane/prometheus.availability_alert.yaml`
- `rhobs/alerting/data_plane/prometheus.memory_usage_alert.yaml`
- `rhobs/alerting/data_plane/prometheus.tsdb_size_alert.yaml`
- `rhobs/alerting/data_plane/prometheus.federation_delay_alert.yaml`
- `rhobs/alerting/data_plane/prometheus.remote_write_queue_alert.yaml`

**Test Files**:
- `test/promql/tests/data_plane/availability_alert_test.yaml`
- `test/promql/tests/data_plane/memory_usage_alert_test.yaml`
- `test/promql/tests/data_plane/tsdb_size_alert_test.yaml`
- `test/promql/tests/data_plane/federation_delay_alert_test.yaml`
- `test/promql/tests/data_plane/remote_write_queue_alert_test.yaml`

Each test file includes:
- Positive test: Alert fires above threshold for required duration
- Negative test: No alert below threshold
- Edge case: No alert at exact threshold (> vs >=)
- Duration test: No alert if condition lasts shorter than `for:` duration
- Multiple namespace coverage

## Common Configuration

All alerts share:
- **Component**: `prometheus`
- **Team**: `o11y`
- **Alert routing key**: `o11y`
- **Namespaces monitored**: openshift-monitoring, openshift-user-workload-monitoring, appstudio-monitoring
- **Job filter**: `job=~"prometheus.*"`

## Dependencies

**Metrics Federation** (infra-deployments):
- ✅ Alert #2 (Memory): Metrics already federated
- ✅ Alert #3 (Availability): `up` metric already federated
- ⏳ Alert #1 (TSDB): Requires infra-deployments PR [#13650](https://github.com/redhat-appstudio/infra-deployments/pull/13650) (staging)
- ⏳ Alert #4 (Federation delay): Requires infra-deployments PR #13650
- ⏳ Alert #5 (Remote-write queue): Requires infra-deployments PR #13650

**Required metrics**:
- `prometheus_tsdb_storage_blocks_bytes` (already federated)
- `prometheus_tsdb_retention_limit_bytes` (added in infra-deployments PR #13650)
- `node_namespace_pod_container:container_memory_working_set_bytes` (already federated)
- `cluster:namespace:pod_memory:active:kube_pod_container_resource_limits` (already federated)
- `up` (already federated)
- `prometheus_remote_storage_queue_highest_sent_timestamp_seconds` (added in PR #13650)
- `prometheus_remote_storage_samples_pending` (added in PR #13650)
- `prometheus_remote_storage_shard_capacity` (added in PR #13650)

## Validation

**Local validation**: Alert rules follow existing patterns from:
- `prometheus.cluster_capacity_alerts.yaml` - Percentage-based capacity alerts
- `prometheus.prometheus_pod_high_memory_usage_alert.yaml` - Prometheus-specific patterns

**Test coverage**: Each alert has comprehensive unit tests covering:
- Threshold behavior (above, below, exact)
- Duration requirements
- Multiple namespace coverage
- Edge cases (100% for TSDB, queue saturation)

## Still Needed (Before Ready for Review)

- [ ] **Runbooks**: Create 5 runbooks in GitLab SOP
  - `alert-rule-prometheus-tsdb-storage.md`
  - `alert-rule-prometheus-memory-usage.md`
  - `alert-rule-prometheus-unavailable.md`
  - `alert-rule-prometheus-federation-delay.md`
  - `alert-rule-prometheus-remote-write-queue.md`

- [ ] **Alert-to-SOP Mapping**: Update mapping documentation

- [ ] **Staging Validation**: After infra-deployments PR #13650 is deployed:
  - Query RHOBS staging to verify metrics are federated
  - Verify all alerts evaluate correctly
  - Check alert routing to o11y team

- [ ] **Documentation**: Add alert threshold rationale to runbooks

## Testing Plan

**After infra-deployments deployment**:
1. Query RHOBS staging for new metrics:
   ```promql
   prometheus_tsdb_retention_limit_bytes{namespace="openshift-monitoring"}
   prometheus_remote_storage_samples_pending{namespace="openshift-monitoring"}
   prometheus_remote_storage_shard_capacity{namespace="openshift-monitoring"}
   prometheus_remote_storage_queue_highest_sent_timestamp_seconds{namespace="openshift-monitoring"}
   ```
2. Verify all alerts appear in RHOBS after deployment
3. Monitor for false positives over 2-4 weeks
4. Validate alert routing to o11y team via Slack

## References

- **Jira Task**: [PVO11Y-5483](https://redhat.atlassian.net/browse/PVO11Y-5483)
- **Spike**: [PVO11Y-4996](https://redhat.atlassian.net/browse/PVO11Y-4996) - Metric availability assessment
- **Epic**: [PVO11Y-5090](https://redhat.atlassian.net/browse/PVO11Y-5090) - Prometheus server monitoring and alerting
- **Failure Mode Analysis**: [PVO11Y-4768](https://redhat.atlassian.net/browse/PVO11Y-4768)
- **infra-deployments PR**: [#13650](https://github.com/redhat-appstudio/infra-deployments/pull/13650)

[PVO11Y-5483]: https://redhat.atlassian.net/browse/PVO11Y-5483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ