### PR TITLE
fix(o11y): increase KonfluxAlert 'for' duration to 10m

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml
@@ -14,7 +14,7 @@ spec:
         (sum by (service, check, source_cluster) (count_over_time(konflux_up[1h])) > 0)
         unless on(service, check, source_cluster)
         (sum by (service, check, source_cluster) (count_over_time(konflux_up[10m])) > 0)
-      for: 5m
+      for: 10m
       labels:
         severity: warning
       annotations:

--- a/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
+++ b/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
@@ -17,13 +17,13 @@ tests:
       - eval_time: 65m
         alertname: KonfluxAlert
 
-      # At 72m: count_over_time[10m] no longer includes the last sample (T=58m),
-      # so the expression is true, but for:5m pending period has not fully elapsed. No alert.
-      - eval_time: 72m
+      # At 74m: count_over_time[10m] no longer includes the last sample (T=58m),
+      # but for:10m pending period has not fully elapsed (needs 10m). No alert.
+      - eval_time: 74m
         alertname: KonfluxAlert
 
-      # At 80m: metric absent for 21 minutes. Well past 10m window + 5m for. Alert fires.
-      - eval_time: 80m
+      # At 85m: metric absent for 26 minutes (15m expression true + 10m for period elapsed). Alert fires.
+      - eval_time: 85m
         alertname: KonfluxAlert
         exp_alerts:
           - exp_labels:
@@ -59,5 +59,5 @@ tests:
         values: '1x59 _x41'
 
     alert_rule_test:
-      - eval_time: 80m
+      - eval_time: 85m
         alertname: KonfluxAlert

--- a/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
+++ b/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
@@ -17,13 +17,16 @@ tests:
       - eval_time: 65m
         alertname: KonfluxAlert
 
-      # At 74m: count_over_time[10m] no longer includes the last sample (T=58m),
-      # but for:10m pending period has not fully elapsed (needs 10m). No alert.
+      # At 74m: count_over_time[10m] expression is true, but for:10m pending period has not elapsed. No alert.
       - eval_time: 74m
         alertname: KonfluxAlert
 
-      # At 85m: metric absent for 26 minutes (15m expression true + 10m for period elapsed). Alert fires.
-      - eval_time: 85m
+      # At 75m: regression test for for:10m. With for:5m this would FIRE. With for:10m it MUST NOT fire yet (still pending).
+      - eval_time: 75m
+        alertname: KonfluxAlert
+
+      # At 80m: metric absent for 21m (10m expression window + 10m for period elapsed). Alert fires.
+      - eval_time: 80m
         alertname: KonfluxAlert
         exp_alerts:
           - exp_labels:
@@ -59,5 +62,5 @@ tests:
         values: '1x59 _x41'
 
     alert_rule_test:
-      - eval_time: 85m
+      - eval_time: 80m
         alertname: KonfluxAlert


### PR DESCRIPTION
Increase KonfluxAlert 'for' duration from 5m to 10m to reduce alert noise.

### Changes:
- **Alert Rule**: Set `for` duration to 10m.
- **Unit Tests**: Updated test cases and added a check at 75m to ensure the alert stays pending.