### PR TITLE
feat(KFLUXVNGD-1158): add proxy availability recording and alerting rules

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.artifact_registry_proxy_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.artifact_registry_proxy_alerts.yaml
@@ -29,6 +29,25 @@ spec:
         team: vanguard
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-down.md
 
+    - alert: ArtifactRegistryProxyDown
+      expr: |
+        konflux_up{namespace="artifact-registry-proxy", service="artifact-registry-proxy", check="nginx-proxy"} == 0
+      for: 5m
+      labels:
+        severity: critical
+        slo: "true"
+        component: artifact-registry-proxy
+      annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.artifact_registry_proxy_alerts.yaml#L32
+        summary: >-
+          Artifact Registry proxy is down
+        description: >-
+          Access log exporter cannot scrape the artifact registry proxy successfully in namespace artifact-registry-proxy.
+          The proxy has been down for 5 minutes in cluster {{ $labels.source_cluster }}.
+        alert_team_handle: <!subteam^S07NDQV6A4D>
+        team: vanguard
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-down.md
+
   - name: artifact_registry_proxy_alerts
     interval: 1m
     rules:

--- a/rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.availability_metric_konflux_alerts.yaml
@@ -11,9 +11,9 @@ spec:
     rules:
     - alert: KonfluxAlert
       expr: |
-        (sum by (service, check, source_cluster) (count_over_time(konflux_up[1h])) > 0)
-        unless on(service, check, source_cluster)
-        (sum by (service, check, source_cluster) (count_over_time(konflux_up[10m])) > 0)
+        (sum by (service, check, source_cluster, namespace) (count_over_time(konflux_up[1h])) > 0)
+        unless on(service, check, source_cluster, namespace)
+        (sum by (service, check, source_cluster, namespace) (count_over_time(konflux_up[10m])) > 0)
       for: 10m
       labels:
         severity: warning
@@ -21,6 +21,6 @@ spec:
         summary: Availability metric 'konflux_up' is missing.
         description: >-
           Availability metric 'konflux_up' has not reported for check {{ $labels.check }}
-          on service {{ $labels.service }} and cluster {{ $labels.source_cluster }}
+          on service {{ $labels.service }}{{ if $labels.namespace }} in namespace {{ $labels.namespace }}{{ end }} and cluster {{ $labels.source_cluster }}
           in the last 10 minutes, but was present in the last hour.
         alert_routing_key: 'o11y'

--- a/rhobs/alerting/data_plane/prometheus.caching_squid_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.caching_squid_alerts.yaml
@@ -28,3 +28,22 @@ spec:
         alert_team_handle: <!subteam^S07NDQV6A4D>
         team: vanguard
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/caching-squid-down.md
+
+    - alert: ContainerImageProxyDown
+      expr: |
+        konflux_up{namespace="container-image-proxy", service="squid", check="squid-proxy"} == 0
+      for: 5m
+      labels:
+        severity: critical
+        slo: "true"
+        component: container-image-proxy
+      annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.caching_squid_alerts.yaml#L32
+        summary: >-
+          Container Image Squid proxy is down
+        description: >-
+          Squid exporter cannot scrape the Squid proxy successfully in namespace container-image-proxy.
+          The proxy has been down for 5 minutes in cluster {{ $labels.source_cluster }}.
+        alert_team_handle: <!subteam^S07NDQV6A4D>
+        team: vanguard
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/caching-squid-down.md

--- a/rhobs/recording/caching_availability_recording_rules.yaml
+++ b/rhobs/recording/caching_availability_recording_rules.yaml
@@ -19,6 +19,20 @@ spec:
             min by (namespace, service) (
               nginx_up{namespace="caching", service="artifact-registry-proxy"}
             )
+        - record: konflux_up
+          expr: |
+            min by (source_cluster, namespace, service) (
+              nginx_up{namespace="artifact-registry-proxy", service="artifact-registry-proxy"}
+            )
+          labels:
+            check: nginx-proxy
+        - record: konflux_up
+          expr: |
+            min by (source_cluster, namespace, service) (
+              squid_up{namespace="container-image-proxy", service="squid"}
+            )
+          labels:
+            check: squid-proxy
     - name: artifact_registry_proxy_performance
       interval: 1m
       rules:

--- a/test/promql/tests/data_plane/artifact_registry_proxy_alerts_test.yaml
+++ b/test/promql/tests/data_plane/artifact_registry_proxy_alerts_test.yaml
@@ -55,6 +55,43 @@ tests:
         alertname: NginxProxyDown
         exp_alerts: []
 
+  - name: ArtifactRegistryProxyDown_Firing
+    interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="artifact-registry-proxy", service="artifact-registry-proxy", check="nginx-proxy", source_cluster="cluster03"}'
+        values: '0x10'
+
+    alert_rule_test:
+      - eval_time: 7m
+        alertname: ArtifactRegistryProxyDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo: "true"
+              component: artifact-registry-proxy
+              check: nginx-proxy
+              namespace: artifact-registry-proxy
+              service: artifact-registry-proxy
+              source_cluster: cluster03
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.artifact_registry_proxy_alerts.yaml#L32
+              summary: "Artifact Registry proxy is down"
+              description: "Access log exporter cannot scrape the artifact registry proxy successfully in namespace artifact-registry-proxy. The proxy has been down for 5 minutes in cluster cluster03."
+              alert_team_handle: "<!subteam^S07NDQV6A4D>"
+              team: vanguard
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-down.md
+
+  - name: ArtifactRegistryProxyDown_NotFiring
+    interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="artifact-registry-proxy", service="artifact-registry-proxy", check="nginx-proxy", source_cluster="cluster03"}'
+        values: '1x10'
+
+    alert_rule_test:
+      - eval_time: 7m
+        alertname: ArtifactRegistryProxyDown
+        exp_alerts: []
+
   # ========================================
   # NginxHighErrorRate Alert Tests
   # ========================================

--- a/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
+++ b/test/promql/tests/data_plane/availability_metric_konflux_test.yaml
@@ -7,9 +7,9 @@ tests:
   # Test 1: Metric disappears after 59 minutes - should alert
   - interval: 1m
     input_series:
-      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", source_cluster="stone-stg-rh01"}'
+      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", namespace="appstudio-grafana", source_cluster="stone-stg-rh01"}'
         values: '1x59 _x41'
-      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", source_cluster="stone-stg-m01"}'
+      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", namespace="appstudio-grafana", source_cluster="stone-stg-m01"}'
         values: '1x100'
 
     alert_rule_test:
@@ -33,20 +33,21 @@ tests:
               severity: warning
               check: prometheus-appstudio-ds
               service: grafana
+              namespace: appstudio-grafana
               source_cluster: stone-stg-rh01
             exp_annotations:
               summary: >-
                 Availability metric 'konflux_up' is missing.
               description: >-
                 Availability metric 'konflux_up' has not reported for check
-                prometheus-appstudio-ds on service grafana and cluster stone-stg-rh01
+                prometheus-appstudio-ds on service grafana in namespace appstudio-grafana and cluster stone-stg-rh01
                 in the last 10 minutes, but was present in the last hour.
               alert_routing_key: 'o11y'
 
   # Test 2: Metric disappears too early (outside 1h lookback) - should NOT alert
   - interval: 1m
     input_series:
-      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", source_cluster="stone-stg-rh01"}'
+      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", namespace="appstudio-grafana", source_cluster="stone-stg-rh01"}'
         values: '1x5 _x115'
 
     alert_rule_test:
@@ -56,11 +57,62 @@ tests:
   # Test 3: Pod label change (pod restart) - should NOT alert
   - interval: 1m
     input_series:
-      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", source_cluster="stone-stg-rh01", pod="grafana-pod1"}'
+      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", namespace="appstudio-grafana", source_cluster="stone-stg-rh01", pod="grafana-pod1"}'
         values: '_x59 1x41'
-      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", source_cluster="stone-stg-rh01", pod="grafana-pod2"}'
+      - series: 'konflux_up{service="grafana", check="prometheus-appstudio-ds", namespace="appstudio-grafana", source_cluster="stone-stg-rh01", pod="grafana-pod2"}'
         values: '1x59 _x41'
 
     alert_rule_test:
       - eval_time: 80m
         alertname: KonfluxAlert
+
+  # Test 4: A signal in another namespace must not mask a missing signal
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="artifact-registry-proxy", check="nginx-proxy", namespace="artifact-registry-proxy", source_cluster="cluster03"}'
+        values: '1x59 _x41'
+      - series: 'konflux_up{service="artifact-registry-proxy", check="nginx-proxy", namespace="caching", source_cluster="cluster03"}'
+        values: '1x100'
+
+    alert_rule_test:
+      - eval_time: 80m
+        alertname: KonfluxAlert
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              check: nginx-proxy
+              service: artifact-registry-proxy
+              namespace: artifact-registry-proxy
+              source_cluster: cluster03
+            exp_annotations:
+              summary: >-
+                Availability metric 'konflux_up' is missing.
+              description: >-
+                Availability metric 'konflux_up' has not reported for check
+                nginx-proxy on service artifact-registry-proxy in namespace artifact-registry-proxy and cluster cluster03
+                in the last 10 minutes, but was present in the last hour.
+              alert_routing_key: 'o11y'
+
+  # Test 5: A signal without a namespace omits the namespace phrase
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{service="github", check="probe", source_cluster="cluster03"}'
+        values: '1x59 _x41'
+
+    alert_rule_test:
+      - eval_time: 80m
+        alertname: KonfluxAlert
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              check: probe
+              service: github
+              source_cluster: cluster03
+            exp_annotations:
+              summary: >-
+                Availability metric 'konflux_up' is missing.
+              description: >-
+                Availability metric 'konflux_up' has not reported for check
+                probe on service github and cluster cluster03
+                in the last 10 minutes, but was present in the last hour.
+              alert_routing_key: 'o11y'

--- a/test/promql/tests/data_plane/caching_squid_alerts_test.yaml
+++ b/test/promql/tests/data_plane/caching_squid_alerts_test.yaml
@@ -38,3 +38,42 @@ tests:
       - eval_time: 7m
         alertname: CachingSquidDown
         exp_alerts: []
+
+  # Test ContainerImageProxyDown alert - FIRING
+  - name: ContainerImageProxyDownFiring
+    interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="container-image-proxy", service="squid", check="squid-proxy", source_cluster="cluster04"}'
+        values: '0x10'
+
+    alert_rule_test:
+      - eval_time: 7m
+        alertname: ContainerImageProxyDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo: "true"
+              component: container-image-proxy
+              check: squid-proxy
+              namespace: "container-image-proxy"
+              service: "squid"
+              source_cluster: "cluster04"
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.caching_squid_alerts.yaml#L32
+              summary: "Container Image Squid proxy is down"
+              description: "Squid exporter cannot scrape the Squid proxy successfully in namespace container-image-proxy. The proxy has been down for 5 minutes in cluster cluster04."
+              alert_team_handle: "<!subteam^S07NDQV6A4D>"
+              team: vanguard
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/caching-squid-down.md
+
+  # Test ContainerImageProxyDown alert - NOT FIRING
+  - name: ContainerImageProxyDownNotFiring
+    interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="container-image-proxy", service="squid", check="squid-proxy", source_cluster="cluster04"}'
+        values: '1x10'
+
+    alert_rule_test:
+      - eval_time: 7m
+        alertname: ContainerImageProxyDown
+        exp_alerts: []

--- a/test/promql/tests/recording/caching_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/caching_availability_recording_rules_test.yaml
@@ -87,3 +87,79 @@ tests:
         exp_samples:
           - labels: 'artifact_registry_proxy:http_errors:rate5m{namespace="caching", service="artifact-registry-proxy", source_cluster="cluster01"}'
             value: 0.08333333333333334
+
+  - interval: 1m
+    # All replicas up in artifact-registry-proxy namespace → konflux_up = 1
+    input_series:
+      - series: 'nginx_up{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03", job="uwm/scrape", instance="10.0.1.1:9113", pod="nginx-0"}'
+        values: '1 1 1'
+      - series: 'nginx_up{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03", job="uwm/scrape", instance="10.0.1.2:9113", pod="nginx-1"}'
+        values: '1 1 1'
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 2m
+        exp_samples:
+          - labels: 'konflux_up{check="nginx-proxy", namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03"}'
+            value: 1
+
+  - interval: 1m
+    # One replica down in artifact-registry-proxy namespace → konflux_up = 0
+    input_series:
+      - series: 'nginx_up{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03", job="uwm/scrape", instance="10.0.1.1:9113", pod="nginx-0"}'
+        values: '1 1 1'
+      - series: 'nginx_up{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03", job="uwm/scrape", instance="10.0.1.2:9113", pod="nginx-1"}'
+        values: '1 0 0'
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 2m
+        exp_samples:
+          - labels: 'konflux_up{check="nginx-proxy", namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03"}'
+            value: 0
+
+  - interval: 1m
+    # A matching service in another namespace must not produce this availability signal
+    input_series:
+      - series: 'nginx_up{namespace="other", service="artifact-registry-proxy", source_cluster="cluster03"}'
+        values: '1 1 1'
+    promql_expr_test:
+      - expr: 'konflux_up{namespace="other", service="artifact-registry-proxy"}'
+        eval_time: 2m
+        exp_samples: []
+
+  - interval: 1m
+    # All replicas up in container-image-proxy namespace → konflux_up = 1
+    input_series:
+      - series: 'squid_up{namespace="container-image-proxy", service="squid", source_cluster="cluster04", job="uwm/scrape", instance="10.0.2.1:9301", pod="squid-0"}'
+        values: '1 1 1'
+      - series: 'squid_up{namespace="container-image-proxy", service="squid", source_cluster="cluster04", job="uwm/scrape", instance="10.0.2.2:9301", pod="squid-1"}'
+        values: '1 1 1'
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 2m
+        exp_samples:
+          - labels: 'konflux_up{check="squid-proxy", namespace="container-image-proxy", service="squid", source_cluster="cluster04"}'
+            value: 1
+
+  - interval: 1m
+    # One replica down in container-image-proxy namespace → konflux_up = 0
+    input_series:
+      - series: 'squid_up{namespace="container-image-proxy", service="squid", source_cluster="cluster04", job="uwm/scrape", instance="10.0.2.1:9301", pod="squid-0"}'
+        values: '1 1 1'
+      - series: 'squid_up{namespace="container-image-proxy", service="squid", source_cluster="cluster04", job="uwm/scrape", instance="10.0.2.2:9301", pod="squid-1"}'
+        values: '1 0 0'
+    promql_expr_test:
+      - expr: konflux_up
+        eval_time: 2m
+        exp_samples:
+          - labels: 'konflux_up{check="squid-proxy", namespace="container-image-proxy", service="squid", source_cluster="cluster04"}'
+            value: 0
+
+  - interval: 1m
+    # A matching service in another namespace must not produce this availability signal
+    input_series:
+      - series: 'squid_up{namespace="other", service="squid", source_cluster="cluster04"}'
+        values: '1 1 1'
+    promql_expr_test:
+      - expr: 'konflux_up{namespace="other", service="squid"}'
+        eval_time: 2m
+        exp_samples: []


### PR DESCRIPTION
### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

---
Add `konflux_up` recording rules  and alerting rules for:
- Artifact Registry Proxy in the `artifact-registry-proxy` namespace
- Container Image Proxy in the `container-image-proxy` namespace

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1158
Assisted-By: Codex

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [x] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
