### PR TITLE
fix(PVO11Y-5456): exclude Failed phase from PodNotReady

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
@@ -36,7 +36,7 @@ spec:
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-crashLoopBackOff.md
     - alert: PodNotReady
       expr: |
-            kube_pod_status_phase{phase=~"Pending|Unknown|Failed", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci|mintmaker|multi-platform-.*|appstudio-kanary-exporter|clusters|clusters-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|tekton-kueue)"} == 1
+            kube_pod_status_phase{phase=~"Pending|Unknown", namespace!~"(.*-tenant|.*-env|openshift-.*|kube-.*|default|tekton-ci|build-templates-e2e|konflux-ci|mintmaker|multi-platform-.*|appstudio-kanary-exporter|clusters|clusters-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|tekton-kueue)"} == 1
             unless ignoring (phase) (kube_pod_status_unschedulable == 1)
       for: 30m
       labels:

--- a/test/promql/tests/data_plane/notready_pods_test.yaml
+++ b/test/promql/tests/data_plane/notready_pods_test.yaml
@@ -78,7 +78,8 @@ tests:
 
   - interval: 1m
     input_series:
-      # Pod is in the Failed state and scheduled, so it will be alerted.
+      # Failed is a terminal phase (Evicted leftovers, completed-failed Jobs/TaskRuns).
+      # PodNotReady must not fire; use CrashLoopBackOff / PodOOMKilled / UnschedulablePods.
       - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-3", phase="Pending", source_cluster="cluster03"}'
         values: '0x29'
       - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-3", phase="Unknown", source_cluster="cluster03"}'
@@ -95,21 +96,7 @@ tests:
     alert_rule_test:
       - eval_time: 30m
         alertname: PodNotReady
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              namespace: ns-3
-              pod: pod-1
-              phase: Failed
-              source_cluster: cluster03
-            exp_annotations:
-              summary: >-
-                Pod pod-1 is not ready
-              description: >-
-                Pod pod-1 in namespace ns-3 on cluster cluster03 is
-                not ready for more than 30 minutes.
-              alert_routing_key: ns-3
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-PodNotReady.md
+        exp_alerts: []
 
   - interval: 1m
     input_series:
@@ -144,8 +131,8 @@ tests:
       - series: 'kube_pod_status_unschedulable{namespace="ns-5", pod="pod-1", source_cluster="cluster05"}'
         values: '0x29'
 
-      # Pod is in the Running state for the first 14 min, then it's in the Failed state
-      # for the last 1 min and unscheduled, so it will not be alerted.
+      # Pod is in the Running state for the first 14 min, then Failed for 1 min.
+      # Failed is excluded from PodNotReady, so it will not be alerted.
       - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-7", phase="Running"}'
         values: '1x28 0'
       - series: 'kube_pod_status_phase{pod="pod-1", namespace="ns-7", phase="Failed"}'


### PR DESCRIPTION
## Summary
- Stop `PodNotReady` from matching `Failed` pods (Evicted leftovers and other terminal corpses waiting for GC).
- Keep alerting on `Pending` and `Unknown` (unschedulable pods still excluded via `unless`).
- Flip the Failed-phase unit test to expect no alert.

Genuine controller failures remain covered by `CrashLoopBackOff`, `PodOOMKilled` / `ControllerPodOOMKilled`, and `UnschedulablePods`. Do not block this on forwarding `kube_pod_status_reason`.

Fixes [PVO11Y-5456](https://redhat.atlassian.net/browse/PVO11Y-5456)

## Test plan
- [x] `promtool test rules` on `notready_pods_test.yaml` (Pending/Unknown still fire; Failed does not)
- [ ] CI `make check-and-test` / PromQL unit tests on the PR
- [ ] After merge, confirm `#konflux-misc-alerts` no longer pages Evicted leftover pods

[PVO11Y-5456]: https://redhat.atlassian.net/browse/PVO11Y-5456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ