### PR TITLE
define tiered Kueue admission wait time SLO alerts (SPRE-6556)

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -236,7 +236,6 @@ spec:
         tier: A
         pipeline_type: PreMerge
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
         summary: "High admission wait time for Pre-merge builds (Tier A)"
         description: "P95 admission wait time for Pre-merge builds is above 5 minutes on cluster {{ $labels.source_cluster }}."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
@@ -258,7 +257,6 @@ spec:
         tier: A
         pipeline_type: PreMerge
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
         summary: "Critical admission wait time for Pre-merge builds (Tier A)"
         description: "P95 admission wait time for Pre-merge builds is above 20 minutes on cluster {{ $labels.source_cluster }}."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
@@ -280,7 +278,6 @@ spec:
         tier: A
         pipeline_type: PostMerge
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
         summary: "High admission wait time for Post-merge builds (Tier A)"
         description: "P95 admission wait time for Post-merge builds is above 20 minutes on cluster {{ $labels.source_cluster }}."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
@@ -302,7 +299,6 @@ spec:
         tier: A
         pipeline_type: PostMerge
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
         summary: "Critical admission wait time for Post-merge builds (Tier A)"
         description: "P95 admission wait time for Post-merge builds is above 1.5 hours on cluster {{ $labels.source_cluster }}."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
@@ -328,7 +324,6 @@ spec:
         tier: B
         pipeline_type: PreMerge
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
         summary: "High admission wait time for Pre-merge builds (Tier B - Constrained)"
         description: "P95 admission wait time for Pre-merge builds is above 30 minutes on constrained cluster {{ $labels.source_cluster }}."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
@@ -350,7 +345,6 @@ spec:
         tier: B
         pipeline_type: PreMerge
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
         summary: "Critical admission wait time for Pre-merge builds (Tier B - Constrained)"
         description: "P95 admission wait time for Pre-merge builds is above 1.5 hours on constrained cluster {{ $labels.source_cluster }}."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
@@ -372,7 +366,6 @@ spec:
         tier: B
         pipeline_type: PostMerge
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
         summary: "High admission wait time for Post-merge builds (Tier B - Constrained)"
         description: "P95 admission wait time for Post-merge builds is above 2 hours on constrained cluster {{ $labels.source_cluster }}."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
@@ -394,7 +387,6 @@ spec:
         tier: B
         pipeline_type: PostMerge
       annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
         summary: "Critical admission wait time for Post-merge builds (Tier B - Constrained)"
         description: "P95 admission wait time for Post-merge builds is above 4 hours on constrained cluster {{ $labels.source_cluster }}."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md

--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -217,39 +217,193 @@ spec:
         alert_team_handle: <!subteam^S05Q1P4Q2TG>
         team: konflux-infra
 
-    - alert: KueueHighAdmissionWaitTimePreMerge
+    # =========================================================================
+    # Tier A: Standard Clusters (excluding stone-prod-p02 & stone-prd-rh01)
+    # =========================================================================
+
+    - alert: KueueAdmissionWaitTimePreMergeTierAWarning
       expr: |
-        histogram_quantile(0.99, sum(increase(kueue_admission_wait_time_seconds_bucket{
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
           cluster_queue="cluster-pipeline-queue",
-          priority_class=~"konflux-pre-merge-.*"
-        }[10m])) by (le, source_cluster)) > 900
-      for: 40m
+          priority_class=~"konflux-pre-merge-.*",
+          source_cluster!~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 300
+      for: 15m
       labels:
-        severity: high
+        severity: warning
         component: kueue
+        slo: "true"
+        tier: A
+        pipeline_type: PreMerge
       annotations:
-        summary: "High admission wait time for Pre-merge builds"
-        description: "99th percentile admission wait time for Pre-merge is {{ $value | humanizeDuration }}, which is above 15 minutes in cluster {{ $labels.source_cluster }}"
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+        summary: "High admission wait time for Pre-merge builds (Tier A)"
+        description: "P95 admission wait time for Pre-merge builds is above 5 minutes on cluster {{ $labels.source_cluster }}."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
         alert_routing_key: infra
         team: konflux-infra
 
-    - alert: KueueHighAdmissionWaitTimePostMerge
+    - alert: KueueAdmissionWaitTimePreMergeTierACritical
       expr: |
-        histogram_quantile(0.99, sum(increase(kueue_admission_wait_time_seconds_bucket{
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
           cluster_queue="cluster-pipeline-queue",
-          priority_class=~"konflux-post-merge-.*"
-        }[10m])) by (le, source_cluster)) > 900
-      for: 45m
+          priority_class=~"konflux-pre-merge-.*",
+          source_cluster!~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 1200
+      for: 15m
       labels:
-        severity: high
+        severity: critical
         component: kueue
+        slo: "true"
+        tier: A
+        pipeline_type: PreMerge
       annotations:
-        summary: "High admission wait time for Post-merge builds"
-        description: "99th percentile admission wait time for Post-merge is {{ $value | humanizeDuration }}, which is above 15 minutes in cluster {{ $labels.source_cluster }}"
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+        summary: "Critical admission wait time for Pre-merge builds (Tier A)"
+        description: "P95 admission wait time for Pre-merge builds is above 20 minutes on cluster {{ $labels.source_cluster }}."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueAdmissionWaitTimePostMergeTierAWarning
+      expr: |
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-post-merge-.*",
+          source_cluster!~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 1200
+      for: 20m
+      labels:
+        severity: warning
+        component: kueue
+        slo: "true"
+        tier: A
+        pipeline_type: PostMerge
+      annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+        summary: "High admission wait time for Post-merge builds (Tier A)"
+        description: "P95 admission wait time for Post-merge builds is above 20 minutes on cluster {{ $labels.source_cluster }}."
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
         alert_routing_key: infra
         team: konflux-infra
+
+    - alert: KueueAdmissionWaitTimePostMergeTierACritical
+      expr: |
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-post-merge-.*",
+          source_cluster!~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 5400
+      for: 15m
+      labels:
+        severity: critical
+        component: kueue
+        slo: "true"
+        tier: A
+        pipeline_type: PostMerge
+      annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+        summary: "Critical admission wait time for Post-merge builds (Tier A)"
+        description: "P95 admission wait time for Post-merge builds is above 1.5 hours on cluster {{ $labels.source_cluster }}."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    # =========================================================================
+    # Tier B: Constrained Clusters (stone-prod-p02 & stone-prd-rh01)
+    # =========================================================================
+
+    - alert: KueueAdmissionWaitTimePreMergeTierBWarning
+      expr: |
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-pre-merge-.*",
+          source_cluster=~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 1800
+      for: 15m
+      labels:
+        severity: warning
+        component: kueue
+        slo: "true"
+        tier: B
+        pipeline_type: PreMerge
+      annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+        summary: "High admission wait time for Pre-merge builds (Tier B - Constrained)"
+        description: "P95 admission wait time for Pre-merge builds is above 30 minutes on constrained cluster {{ $labels.source_cluster }}."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_routing_key: infra
+        team: konflux-infra
+
+    - alert: KueueAdmissionWaitTimePreMergeTierBCritical
+      expr: |
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-pre-merge-.*",
+          source_cluster=~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 5400
+      for: 15m
+      labels:
+        severity: critical
+        component: kueue
+        slo: "true"
+        tier: B
+        pipeline_type: PreMerge
+      annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+        summary: "Critical admission wait time for Pre-merge builds (Tier B - Constrained)"
+        description: "P95 admission wait time for Pre-merge builds is above 1.5 hours on constrained cluster {{ $labels.source_cluster }}."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueAdmissionWaitTimePostMergeTierBWarning
+      expr: |
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-post-merge-.*",
+          source_cluster=~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 7200
+      for: 30m
+      labels:
+        severity: warning
+        component: kueue
+        slo: "true"
+        tier: B
+        pipeline_type: PostMerge
+      annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+        summary: "High admission wait time for Post-merge builds (Tier B - Constrained)"
+        description: "P95 admission wait time for Post-merge builds is above 2 hours on constrained cluster {{ $labels.source_cluster }}."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_routing_key: infra
+        team: konflux-infra
+
+    - alert: KueueAdmissionWaitTimePostMergeTierBCritical
+      expr: |
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-post-merge-.*",
+          source_cluster=~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 14400
+      for: 15m
+      labels:
+        severity: critical
+        component: kueue
+        slo: "true"
+        tier: B
+        pipeline_type: PostMerge
+      annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+        summary: "Critical admission wait time for Post-merge builds (Tier B - Constrained)"
+        description: "P95 admission wait time for Post-merge builds is above 4 hours on constrained cluster {{ $labels.source_cluster }}."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    # =========================================================================
+    # Other Workload Alerts
+    # =========================================================================
 
     - alert: KueueHighAdmissionWaitTimeMintmaker
       expr: |

--- a/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
@@ -232,7 +232,7 @@ spec:
       labels:
         severity: warning
         component: kueue
-        slo: "true"
+        slo: "false"
         tier: A
         pipeline_type: PreMerge
       annotations:
@@ -276,7 +276,7 @@ spec:
       labels:
         severity: warning
         component: kueue
-        slo: "true"
+        slo: "false"
         tier: A
         pipeline_type: PostMerge
       annotations:
@@ -324,7 +324,7 @@ spec:
       labels:
         severity: warning
         component: kueue
-        slo: "true"
+        slo: "false"
         tier: B
         pipeline_type: PreMerge
       annotations:
@@ -368,7 +368,7 @@ spec:
       labels:
         severity: warning
         component: kueue
-        slo: "true"
+        slo: "false"
         tier: B
         pipeline_type: PostMerge
       annotations:

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -3,31 +3,11 @@ rule_files:
   - 'prometheus.kueue_alerts.yaml'
 
 tests:
-  # KueueHighAdmissionWaitTimeMintmaker - should fire: 99th percentile wait time above 12h
-  - interval: 1m
-    input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-dependency-update", le="43200.0", source_cluster="c1"}'
-        values: '0+0x20'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-dependency-update", le="50400.0", source_cluster="c1"}'
-        values: '0+0x20'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-dependency-update", le="+Inf", source_cluster="c1"}'
-        values: '0 10 20 30 40 50 60 70 80 90 100 110 120 130 140'
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: KueueHighAdmissionWaitTimeMintmaker
-        exp_alerts:
-          - exp_labels:
-              severity: high
-              component: kueue
-              source_cluster: c1
-            exp_annotations:
-              summary: "High admission wait time for Mintmaker"
-              description: "99th percentile admission wait time for Mintmaker is 14h 0m 0s, which is above 12 hours in cluster c1"
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-              alert_routing_key: infra
-              team: konflux-infra
+  # =========================================================================
+  # Tier A: Standard Clusters (e.g. source_cluster="c1")
+  # =========================================================================
 
-  # KueueAdmissionWaitTimePreMergeTierAWarning - should fire: P95 wait time above 5m (300s) for 15m
+  # 1. KueueAdmissionWaitTimePreMergeTierAWarning - Fire when P95 > 300s (5m) for 15m
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="900.0", source_cluster="c1"}'
@@ -55,21 +35,35 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # KueueAdmissionWaitTimePreMergeTierAWarning - should NOT fire: eval time (10m) is less than 'for' duration (15m)
+  # 2. KueueAdmissionWaitTimePreMergeTierACritical - Fire when P95 > 1200s (20m) for 15m
   - interval: 1m
     input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="900.0", source_cluster="c1"}'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1200.0", source_cluster="c1"}'
         values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1000.0", source_cluster="c1"}'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1500.0", source_cluster="c1"}'
         values: '0+0x60'
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="c1"}'
         values: '0+10x60'
     alert_rule_test:
-      - eval_time: 10m
-        alertname: KueueAdmissionWaitTimePreMergeTierAWarning
-        exp_alerts: []
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePreMergeTierACritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: kueue
+              slo: "true"
+              tier: A
+              pipeline_type: PreMerge
+              source_cluster: c1
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+              summary: "Critical admission wait time for Pre-merge builds (Tier A)"
+              description: "P95 admission wait time for Pre-merge builds is above 20 minutes on cluster c1."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra
 
-  # KueueAdmissionWaitTimePostMergeTierAWarning - should fire: P95 wait time above 20m (1200s) for 20m
+  # 3. KueueAdmissionWaitTimePostMergeTierAWarning - Fire when P95 > 1200s (20m) for 20m
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1200.0", source_cluster="c1"}'
@@ -97,231 +91,211 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # KueueAdmissionWaitTimePostMergeTierAWarning - should NOT fire: eval time (15m) is less than 'for' duration (20m)
+  # 4. KueueAdmissionWaitTimePostMergeTierACritical - Fire when P95 > 5400s (1.5h) for 15m
   - interval: 1m
     input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1200.0", source_cluster="c1"}'
-        values: '0+0x70'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1300.0", source_cluster="c1"}'
-        values: '0+0x70'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="5400.0", source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="6000.0", source_cluster="c1"}'
+        values: '0+0x60'
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="c1"}'
-        values: '0+10x70'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePostMergeTierACritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: kueue
+              slo: "true"
+              tier: A
+              pipeline_type: PostMerge
+              source_cluster: c1
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+              summary: "Critical admission wait time for Post-merge builds (Tier A)"
+              description: "P95 admission wait time for Post-merge builds is above 1.5 hours on cluster c1."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra
+
+  # =========================================================================
+  # Tier B: Constrained Clusters (e.g. source_cluster="stone-prod-p02")
+  # =========================================================================
+
+  # 5. KueueAdmissionWaitTimePreMergeTierBWarning - Fire when P95 > 1800s (30m) for 15m
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1800.0", source_cluster="stone-prod-p02"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="2000.0", source_cluster="stone-prod-p02"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="stone-prod-p02"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePreMergeTierBWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: kueue
+              slo: "false"
+              tier: B
+              pipeline_type: PreMerge
+              source_cluster: stone-prod-p02
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+              summary: "High admission wait time for Pre-merge builds (Tier B - Constrained)"
+              description: "P95 admission wait time for Pre-merge builds is above 30 minutes on constrained cluster stone-prod-p02."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_routing_key: infra
+              team: konflux-infra
+
+  # 6. KueueAdmissionWaitTimePreMergeTierBCritical - Fire when P95 > 5400s (1.5h) for 15m
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="5400.0", source_cluster="stone-prod-p02"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="6000.0", source_cluster="stone-prod-p02"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="stone-prod-p02"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePreMergeTierBCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: kueue
+              slo: "true"
+              tier: B
+              pipeline_type: PreMerge
+              source_cluster: stone-prod-p02
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+              summary: "Critical admission wait time for Pre-merge builds (Tier B - Constrained)"
+              description: "P95 admission wait time for Pre-merge builds is above 1.5 hours on constrained cluster stone-prod-p02."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra
+
+  # 7. KueueAdmissionWaitTimePostMergeTierBWarning - Fire when P95 > 7200s (2h) for 30m
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="7200.0", source_cluster="stone-prd-rh01"}'
+        values: '0+0x80'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="8000.0", source_cluster="stone-prd-rh01"}'
+        values: '0+0x80'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="stone-prd-rh01"}'
+        values: '0+10x80'
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: KueueAdmissionWaitTimePostMergeTierBWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: kueue
+              slo: "false"
+              tier: B
+              pipeline_type: PostMerge
+              source_cluster: stone-prd-rh01
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+              summary: "High admission wait time for Post-merge builds (Tier B - Constrained)"
+              description: "P95 admission wait time for Post-merge builds is above 2 hours on constrained cluster stone-prd-rh01."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_routing_key: infra
+              team: konflux-infra
+
+  # 8. KueueAdmissionWaitTimePostMergeTierBCritical - Fire when P95 > 14400s (4h) for 15m
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="14400.0", source_cluster="stone-prd-rh01"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="15000.0", source_cluster="stone-prd-rh01"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="stone-prd-rh01"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePostMergeTierBCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: kueue
+              slo: "true"
+              tier: B
+              pipeline_type: PostMerge
+              source_cluster: stone-prd-rh01
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+              summary: "Critical admission wait time for Post-merge builds (Tier B - Constrained)"
+              description: "P95 admission wait time for Post-merge builds is above 4 hours on constrained cluster stone-prd-rh01."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra
+
+  # =========================================================================
+  # Regression / Isolation Tests (Cluster Filtering Validation)
+  # =========================================================================
+
+  # Tier A rules should NOT fire for Tier B clusters (stone-prod-p02)
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="900.0", source_cluster="stone-prod-p02"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1000.0", source_cluster="stone-prod-p02"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="stone-prod-p02"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePreMergeTierAWarning
+        exp_alerts: []
+
+  # Tier B rules should NOT fire for Standard Tier A clusters (c1)
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1800.0", source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="2000.0", source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="c1"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePreMergeTierBWarning
+        exp_alerts: []
+
+  # =========================================================================
+  # Other Workload Alerts
+  # =========================================================================
+
+  # KueueHighAdmissionWaitTimeMintmaker - should fire
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-dependency-update", le="43200.0", source_cluster="c1"}'
+        values: '0+0x20'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-dependency-update", le="50400.0", source_cluster="c1"}'
+        values: '0+0x20'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-dependency-update", le="+Inf", source_cluster="c1"}'
+        values: '0 10 20 30 40 50 60 70 80 90 100 110 120 130 140'
     alert_rule_test:
       - eval_time: 15m
-        alertname: KueueAdmissionWaitTimePostMergeTierAWarning
-        exp_alerts: []
-
-  # TektonKueuePodsCrashLoopBackOff - should fire: pod in CrashLoopBackOff
-  - interval: 1m
-    input_series:
-      - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="CrashLoopBackOff", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
-        values: '1+0x10'
-    alert_rule_test:
-      - eval_time: 6m
-        alertname: TektonKueuePodsCrashLoopBackOff
+        alertname: KueueHighAdmissionWaitTimeMintmaker
         exp_alerts:
           - exp_labels:
               severity: high
-              component: tekton-kueue
-              slo: "false"
-              namespace: tekton-kueue
-              reason: CrashLoopBackOff
-              pod: tekton-kueue-controller-manager-abc123
+              component: kueue
               source_cluster: c1
             exp_annotations:
-              summary: "Tekton Kueue pod is in a crash loop: tekton-kueue-controller-manager-abc123"
-              description: "Pod tekton-kueue-controller-manager-abc123 in namespace tekton-kueue on cluster c1 is in CrashLoopBackOff and is not starting up."
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsCrashLoopBackOff.md
+              summary: "High admission wait time for Mintmaker"
+              description: "99th percentile admission wait time for Mintmaker is 14h 0m 0s, which is above 12 hours in cluster c1"
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
               alert_routing_key: infra
               team: konflux-infra
 
-  # TektonKueuePodsCrashLoopBackOff - should NOT fire: pod not in CrashLoopBackOff
-  - interval: 1m
-    input_series:
-      - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="CrashLoopBackOff", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
-        values: '0+0x10'
-    alert_rule_test:
-      - eval_time: 6m
-        alertname: TektonKueuePodsCrashLoopBackOff
-        exp_alerts: []
-
-  # TektonKueueRolloutStuck - should fire: rollout stuck for 20m
-  - interval: 1m
-    input_series:
-      - series: 'kube_deployment_spec_replicas{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
-        values: '2+0x25'
-      - series: 'kube_deployment_status_replicas_updated{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
-        values: '1+0x25'
-    alert_rule_test:
-      - eval_time: 20m
-        alertname: TektonKueueRolloutStuck
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              component: tekton-kueue
-              namespace: tekton-kueue
-              deployment: tekton-kueue-controller-manager
-              source_cluster: c1
-            exp_annotations:
-              summary: "Tekton Kueue rollout stuck: tekton-kueue-controller-manager"
-              description: "Deployment tekton-kueue-controller-manager in namespace tekton-kueue on cluster c1 update is delayed or stuck (no full health for 20m). Check pod events and logs for the deployment and its ReplicaSets."
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueRolloutStuck.md
-              alert_routing_key: infra
-              team: konflux-infra
-
-  # TektonKueueRolloutStuck - should NOT fire: replicas updated matches spec
-  - interval: 1m
-    input_series:
-      - series: 'kube_deployment_spec_replicas{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
-        values: '2+0x25'
-      - series: 'kube_deployment_status_replicas_updated{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
-        values: '2+0x25'
-    alert_rule_test:
-      - eval_time: 20m
-        alertname: TektonKueueRolloutStuck
-        exp_alerts: []
-
-  # TektonKueuePodStuckInPending - should fire: pod in Pending for 5m
-  - interval: 1m
-    input_series:
-      - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
-        values: '1+0x10'
-    alert_rule_test:
-      - eval_time: 5m
-        alertname: TektonKueuePodStuckInPending
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              component: tekton-kueue
-              namespace: tekton-kueue
-              phase: Pending
-              pod: tekton-kueue-controller-manager-abc123
-              source_cluster: c1
-            exp_annotations:
-              summary: "Tekton Kueue pod is stuck in Pending: tekton-kueue-controller-manager-abc123"
-              description: "Pod tekton-kueue-controller-manager-abc123 in namespace tekton-kueue on cluster c1 has been in Pending state for more than 5 minutes. This may indicate a scheduling issue, resource constraint, or unresolvable volume."
-              alert_routing_key: infra
-              team: konflux-infra
-
-  # TektonKueuePodStuckInPending - should NOT fire: pod not in Pending
-  - interval: 1m
-    input_series:
-      - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
-        values: '0+0x10'
-    alert_rule_test:
-      - eval_time: 5m
-        alertname: TektonKueuePodStuckInPending
-        exp_alerts: []
-
-  # TektonKueuePodStuckInPending - should NOT fire: eval time (4m) is less than 'for' duration (5m)
-  - interval: 1m
-    input_series:
-      - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
-        values: '1+0x10'
-    alert_rule_test:
-      - eval_time: 4m
-        alertname: TektonKueuePodStuckInPending
-        exp_alerts: []
-
-  # TektonKueuePodStuckInCreation - should fire: pod in ContainerCreating for 5m and NOT Running
-  - interval: 1m
-    input_series:
-      - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="ContainerCreating", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
-        values: '1+0x10'
-      - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
-        values: '1+0x10'
-      - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Running", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
-        values: '0+0x10'
-    alert_rule_test:
-      - eval_time: 5m
-        alertname: TektonKueuePodStuckInCreation
-        exp_alerts:
-          - exp_labels:
-              severity: high
-              component: tekton-kueue
-              namespace: tekton-kueue
-              reason: ContainerCreating
-              pod: tekton-kueue-controller-manager-abc123
-              container: manager
-              source_cluster: c1
-            exp_annotations:
-              summary: "Tekton Kueue pod is stuck in ContainerCreating: tekton-kueue-controller-manager-abc123"
-              description: "Container manager in pod tekton-kueue-controller-manager-abc123 in namespace tekton-kueue on cluster c1 is stuck in ContainerCreating for more than 5 minutes. This typically points to infrastructure issues like Volume/Storage mounting failures or Network attachment delays."
-              alert_routing_key: infra
-              team: konflux-infra
-
-  # TektonKueuePodStuckInCreation - should NOT fire: pod not in ContainerCreating
-  - interval: 1m
-    input_series:
-      - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="ContainerCreating", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
-        values: '0+0x10'
-    alert_rule_test:
-      - eval_time: 5m
-        alertname: TektonKueuePodStuckInCreation
-        exp_alerts: []
-
-  # TektonKueuePodStuckInCreation - should NOT fire: stale ContainerCreating metric while pod is Running
-  - interval: 1m
-    input_series:
-      - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="ContainerCreating", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
-        values: '1+0x10'
-      - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Running", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
-        values: '1+0x10'
-    alert_rule_test:
-      - eval_time: 5m
-        alertname: TektonKueuePodStuckInCreation
-        exp_alerts: []
-
-  # TektonKueuePodOOMKilled - should fire: pod OOMKilled
-  - interval: 1m
-    input_series:
-      - series: 'kube_pod_container_status_restarts_total{namespace="tekton-kueue", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
-        values: '0 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_container_status_last_terminated_reason{namespace="tekton-kueue", reason="OOMKilled", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
-        values: '1+0x10'
-    alert_rule_test:
-      - eval_time: 2m
-        alertname: TektonKueuePodOOMKilled
-        exp_alerts:
-          - exp_labels:
-              severity: high
-              component: tekton-kueue
-              namespace: tekton-kueue
-              reason: OOMKilled
-              pod: tekton-kueue-controller-manager-abc123
-              container: manager
-              source_cluster: c1
-            exp_annotations:
-              summary: "Tekton Kueue pod was OOMKilled: tekton-kueue-controller-manager-abc123"
-              description: "Container manager in pod tekton-kueue-controller-manager-abc123 in namespace tekton-kueue on cluster c1 was terminated due to OOM. Memory limits may need to be increased in the deployment spec."
-              alert_routing_key: infra
-              team: konflux-infra
-
-  # TektonKueuePodOOMKilled - should NOT fire: pod not OOMKilled
-  - interval: 1m
-    input_series:
-      - series: 'kube_pod_container_status_restarts_total{namespace="tekton-kueue", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
-        values: '0+0x10'
-      - series: 'kube_pod_container_status_last_terminated_reason{namespace="tekton-kueue", reason="OOMKilled", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
-        values: '1+0x10'
-    alert_rule_test:
-      - eval_time: 2m
-        alertname: TektonKueuePodOOMKilled
-        exp_alerts: []
-
-  # TektonKueueRolloutStuck - should NOT fire: eval time (10m) is less than 'for' duration (20m)
-  - interval: 1m
-    input_series:
-      - series: 'kube_deployment_spec_replicas{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
-        values: '2+0x15'
-      - series: 'kube_deployment_status_replicas_updated{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
-        values: '1+0x15'
-    alert_rule_test:
-      - eval_time: 10m
-        alertname: TektonKueueRolloutStuck
-        exp_alerts: []
-
-  # KueueHighAdmissionWaitTimeReleases - should fire: 99th percentile wait time above 1.33h (4800s) for 20m
+  # KueueHighAdmissionWaitTimeReleases - should fire
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="4800.0", source_cluster="c1"}'
@@ -345,31 +319,3 @@ tests:
               description: "99th percentile admission wait time for konflux and tenant release workloads is 1h 23m 20s, which is above 1.33 hours in cluster c1"
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
-
-  # KueueHighAdmissionWaitTimeReleases - should NOT fire: eval time (15m) is less than 'for' duration (20m)
-  - interval: 1m
-    input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-tenant-release", le="4800.0", source_cluster="c1"}'
-        values: '0+0x30'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-tenant-release", le="5000.0", source_cluster="c1"}'
-        values: '0+0x30'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-tenant-release", le="+Inf", source_cluster="c1"}'
-        values: '0+10x30'
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: KueueHighAdmissionWaitTimeReleases
-        exp_alerts: []
-
-  # KueueHighAdmissionWaitTimeReleases - should NOT fire: wait time below threshold (4800s)
-  - interval: 1m
-    input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="4000.0", source_cluster="c1"}'
-        values: '0+0x30'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="4800.0", source_cluster="c1"}'
-        values: '0+0x30'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="+Inf", source_cluster="c1"}'
-        values: '0+10x30'
-    alert_rule_test:
-      - eval_time: 25m
-        alertname: KueueHighAdmissionWaitTimeReleases
-        exp_alerts: []

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -43,7 +43,7 @@ tests:
           - exp_labels:
               severity: warning
               component: kueue
-              slo: "true"
+              slo: "false"
               tier: A
               pipeline_type: PreMerge
               source_cluster: c1
@@ -85,7 +85,7 @@ tests:
           - exp_labels:
               severity: warning
               component: kueue
-              slo: "true"
+              slo: "false"
               tier: A
               pipeline_type: PostMerge
               source_cluster: c1

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -27,7 +27,7 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # KueueHighAdmissionWaitTimePreMerge - should fire: 99th percentile wait time above 15m for 40m
+  # KueueAdmissionWaitTimePreMergeTierAWarning - should fire: P95 wait time above 5m (300s) for 15m
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="900.0", source_cluster="c1"}'
@@ -37,21 +37,25 @@ tests:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="c1"}'
         values: '0+10x60'
     alert_rule_test:
-      - eval_time: 45m
-        alertname: KueueHighAdmissionWaitTimePreMerge
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePreMergeTierAWarning
         exp_alerts:
           - exp_labels:
-              severity: high
+              severity: warning
               component: kueue
+              slo: "true"
+              tier: A
+              pipeline_type: PreMerge
               source_cluster: c1
             exp_annotations:
-              summary: "High admission wait time for Pre-merge builds"
-              description: "99th percentile admission wait time for Pre-merge is 16m 40s, which is above 15 minutes in cluster c1"
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+              summary: "High admission wait time for Pre-merge builds (Tier A)"
+              description: "P95 admission wait time for Pre-merge builds is above 5 minutes on cluster c1."
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
               alert_routing_key: infra
               team: konflux-infra
 
-  # KueueHighAdmissionWaitTimePreMerge - should NOT fire: eval time (35m) is less than 'for' duration (40m)
+  # KueueAdmissionWaitTimePreMergeTierAWarning - should NOT fire: eval time (10m) is less than 'for' duration (15m)
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="900.0", source_cluster="c1"}'
@@ -61,46 +65,50 @@ tests:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="c1"}'
         values: '0+10x60'
     alert_rule_test:
-      - eval_time: 35m
-        alertname: KueueHighAdmissionWaitTimePreMerge
+      - eval_time: 10m
+        alertname: KueueAdmissionWaitTimePreMergeTierAWarning
         exp_alerts: []
 
-  # KueueHighAdmissionWaitTimePostMerge - should fire: 99th percentile wait time above 15m for 45m
+  # KueueAdmissionWaitTimePostMergeTierAWarning - should fire: P95 wait time above 20m (1200s) for 20m
   - interval: 1m
     input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="900.0", source_cluster="c1"}'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1200.0", source_cluster="c1"}'
         values: '0+0x70'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1000.0", source_cluster="c1"}'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1300.0", source_cluster="c1"}'
         values: '0+0x70'
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="c1"}'
         values: '0+10x70'
     alert_rule_test:
-      - eval_time: 50m
-        alertname: KueueHighAdmissionWaitTimePostMerge
+      - eval_time: 25m
+        alertname: KueueAdmissionWaitTimePostMergeTierAWarning
         exp_alerts:
           - exp_labels:
-              severity: high
+              severity: warning
               component: kueue
+              slo: "true"
+              tier: A
+              pipeline_type: PostMerge
               source_cluster: c1
             exp_annotations:
-              summary: "High admission wait time for Post-merge builds"
-              description: "99th percentile admission wait time for Post-merge is 16m 40s, which is above 15 minutes in cluster c1"
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
+              summary: "High admission wait time for Post-merge builds (Tier A)"
+              description: "P95 admission wait time for Post-merge builds is above 20 minutes on cluster c1."
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
               alert_routing_key: infra
               team: konflux-infra
 
-  # KueueHighAdmissionWaitTimePostMerge - should NOT fire: eval time (40m) is less than 'for' duration (45m)
+  # KueueAdmissionWaitTimePostMergeTierAWarning - should NOT fire: eval time (15m) is less than 'for' duration (20m)
   - interval: 1m
     input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="900.0", source_cluster="c1"}'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1200.0", source_cluster="c1"}'
         values: '0+0x70'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1000.0", source_cluster="c1"}'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1300.0", source_cluster="c1"}'
         values: '0+0x70'
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="c1"}'
         values: '0+10x70'
     alert_rule_test:
-      - eval_time: 40m
-        alertname: KueueHighAdmissionWaitTimePostMerge
+      - eval_time: 15m
+        alertname: KueueAdmissionWaitTimePostMergeTierAWarning
         exp_alerts: []
 
   # TektonKueuePodsCrashLoopBackOff - should fire: pod in CrashLoopBackOff

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -1,321 +1,433 @@
-evaluation_interval: 1m
-rule_files:
-  - 'prometheus.kueue_alerts.yaml'
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rhtap-kueue-alerts
+  labels:
+    tenant: rhtap
+spec:
+  groups:
+  - name: kueue.health
+    interval: 30s
+    rules:
+    - alert: TektonKueueControllerDown
+      expr: |
+        konflux_up{
+          namespace="tekton-kueue",
+          check="replicas-available",
+          service="tekton-kueue-controller-manager",
+        } != 1
+      for: 5m
+      labels:
+        severity: critical
+        component: tekton-kueue
+        slo: "true"
+      annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L12
+        summary: "Tekton Kueue controller is down"
+        description: "The Tekton Kueue controller has no available replicas in cluster {{ $labels.source_cluster }}. PipelineRuns will be created in Pending state but cannot be processed, resulting in stuck builds."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueControllerDown.md
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
 
-tests:
-  # =========================================================================
-  # Tier A: Standard Clusters (e.g. source_cluster="c1")
-  # =========================================================================
+    - alert: TektonKueueWebhookDown
+      expr: |
+        konflux_up{
+          namespace="tekton-kueue",
+          check="replicas-available",
+          service="tekton-kueue-webhook",
+        } != 1
+      for: 5m
+      labels:
+        severity: critical
+        component: tekton-kueue
+        slo: "true"
+      annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L32
+        summary: "Tekton Kueue webhook is down"
+        description: "The Tekton Kueue webhook has no available replicas in cluster {{ $labels.source_cluster }}. PipelineRuns may not be created with Pending state and Workload resources, bypassing Kueue admission control."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueWebhookDown.md
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
 
-  # 1. KueueAdmissionWaitTimePreMergeTierAWarning - Fire when P95 > 300s (5m) for 15m
-  - interval: 1m
-    input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="900.0", source_cluster="c1"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1000.0", source_cluster="c1"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="c1"}'
-        values: '0+10x60'
-    alert_rule_test:
-      - eval_time: 20m
-        alertname: KueueAdmissionWaitTimePreMergeTierAWarning
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              component: kueue
-              slo: "false"
-              tier: A
-              pipeline_type: PreMerge
-              source_cluster: c1
-            exp_annotations:
-              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
-              summary: "High admission wait time for Pre-merge builds (Tier A)"
-              description: "P95 admission wait time for Pre-merge builds is above 5 minutes on cluster c1."
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-              alert_routing_key: infra
-              team: konflux-infra
+    - alert: TektonKueuePodsRepeatedRestarts
+      expr: |
+        sum by (source_cluster) (
+          increase(kube_pod_container_status_restarts_total{
+            namespace="tekton-kueue"
+          }[5m])
+        ) > 0
+      for: 5m
+      labels:
+        severity: warning
+        component: tekton-kueue
+      annotations:
+        summary: "Tekton Kueue pods are repeatedly restarting"
+        description: "Tekton Kueue pods have restarted {{ $value }} times in the last 5 minutes in cluster {{ $labels.source_cluster }}. This may indicate resource pressure or application issues."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsRepeatedRestarts.md
+        alert_routing_key: infra
+        team: konflux-infra
 
-  # 2. KueueAdmissionWaitTimePreMergeTierACritical - Fire when P95 > 1200s (20m) for 15m
-  - interval: 1m
-    input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1200.0", source_cluster="c1"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1500.0", source_cluster="c1"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="c1"}'
-        values: '0+10x60'
-    alert_rule_test:
-      - eval_time: 20m
-        alertname: KueueAdmissionWaitTimePreMergeTierACritical
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-              component: kueue
-              slo: "true"
-              tier: A
-              pipeline_type: PreMerge
-              source_cluster: c1
-            exp_annotations:
-              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
-              summary: "Critical admission wait time for Pre-merge builds (Tier A)"
-              description: "P95 admission wait time for Pre-merge builds is above 20 minutes on cluster c1."
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-              alert_team_handle: <!subteam^S05Q1P4Q2TG>
-              team: konflux-infra
+    - alert: TektonKueuePodsCrashLoopBackOff
+      expr: |
+        max_over_time(kube_pod_container_status_waiting_reason{
+          namespace="tekton-kueue",
+          reason="CrashLoopBackOff"
+        }[3m]) > 0
+      for: 3m
+      labels:
+        severity: high
+        component: tekton-kueue
+        slo: "false"
+      annotations:
+        summary: "Tekton Kueue pod is in a crash loop: {{ $labels.pod }}"
+        description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is in CrashLoopBackOff and is not starting up."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsCrashLoopBackOff.md
+        alert_routing_key: infra
+        team: konflux-infra
 
-  # 3. KueueAdmissionWaitTimePostMergeTierAWarning - Fire when P95 > 1200s (20m) for 20m
-  - interval: 1m
-    input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1200.0", source_cluster="c1"}'
-        values: '0+0x70'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1300.0", source_cluster="c1"}'
-        values: '0+0x70'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="c1"}'
-        values: '0+10x70'
-    alert_rule_test:
-      - eval_time: 25m
-        alertname: KueueAdmissionWaitTimePostMergeTierAWarning
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              component: kueue
-              slo: "false"
-              tier: A
-              pipeline_type: PostMerge
-              source_cluster: c1
-            exp_annotations:
-              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
-              summary: "High admission wait time for Post-merge builds (Tier A)"
-              description: "P95 admission wait time for Post-merge builds is above 20 minutes on cluster c1."
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-              alert_routing_key: infra
-              team: konflux-infra
+    - alert: TektonKueuePodStuckInPending
+      expr: |
+        kube_pod_status_phase{
+          namespace="tekton-kueue",
+          phase="Pending"
+        } == 1
+      for: 5m
+      labels:
+        severity: warning
+        component: tekton-kueue
+      annotations:
+        summary: "Tekton Kueue pod is stuck in Pending: {{ $labels.pod }}"
+        description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} has been in Pending state for more than 5 minutes. This may indicate a scheduling issue, resource constraint, or unresolvable volume."
+        alert_routing_key: infra
+        team: konflux-infra
 
-  # 4. KueueAdmissionWaitTimePostMergeTierACritical - Fire when P95 > 5400s (1.5h) for 15m
-  - interval: 1m
-    input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="5400.0", source_cluster="c1"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="6000.0", source_cluster="c1"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="c1"}'
-        values: '0+10x60'
-    alert_rule_test:
-      - eval_time: 20m
-        alertname: KueueAdmissionWaitTimePostMergeTierACritical
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-              component: kueue
-              slo: "true"
-              tier: A
-              pipeline_type: PostMerge
-              source_cluster: c1
-            exp_annotations:
-              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
-              summary: "Critical admission wait time for Post-merge builds (Tier A)"
-              description: "P95 admission wait time for Post-merge builds is above 1.5 hours on cluster c1."
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-              alert_team_handle: <!subteam^S05Q1P4Q2TG>
-              team: konflux-infra
+    - alert: TektonKueuePodStuckInCreation
+      expr: |
+        kube_pod_container_status_waiting_reason{
+          namespace="tekton-kueue",
+          reason="ContainerCreating"
+        } == 1
+        unless on (pod, namespace, source_cluster)
+        kube_pod_status_phase{
+          namespace="tekton-kueue",
+          phase="Running"
+        } == 1
+      for: 5m
+      labels:
+        severity: high
+        component: tekton-kueue
+      annotations:
+        summary: "Tekton Kueue pod is stuck in ContainerCreating: {{ $labels.pod }}"
+        description: "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is stuck in ContainerCreating for more than 5 minutes. This typically points to infrastructure issues like Volume/Storage mounting failures or Network attachment delays."
+        alert_routing_key: infra
+        team: konflux-infra
 
-  # =========================================================================
-  # Tier B: Constrained Clusters (e.g. source_cluster="stone-prod-p02")
-  # =========================================================================
+    - alert: TektonKueuePodOOMKilled
+      expr: |
+        (
+          increase(kube_pod_container_status_restarts_total{namespace="tekton-kueue"}[15m]) > 0
+        ) * on (pod, container, namespace, source_cluster) group_left(reason)
+        (
+          kube_pod_container_status_last_terminated_reason{
+            namespace="tekton-kueue",
+            reason="OOMKilled"
+          } == 1
+        )
+      for: 1m
+      labels:
+        severity: high
+        component: tekton-kueue
+      annotations:
+        summary: "Tekton Kueue pod was OOMKilled: {{ $labels.pod }}"
+        description: "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} was terminated due to OOM. Memory limits may need to be increased in the deployment spec."
+        alert_routing_key: infra
+        team: konflux-infra
 
-  # 5. KueueAdmissionWaitTimePreMergeTierBWarning - Fire when P95 > 1800s (30m) for 15m
-  - interval: 1m
-    input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1800.0", source_cluster="stone-prod-p02"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="2000.0", source_cluster="stone-prod-p02"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="stone-prod-p02"}'
-        values: '0+10x60'
-    alert_rule_test:
-      - eval_time: 20m
-        alertname: KueueAdmissionWaitTimePreMergeTierBWarning
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              component: kueue
-              slo: "false"
-              tier: B
-              pipeline_type: PreMerge
-              source_cluster: stone-prod-p02
-            exp_annotations:
-              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
-              summary: "High admission wait time for Pre-merge builds (Tier B - Constrained)"
-              description: "P95 admission wait time for Pre-merge builds is above 30 minutes on constrained cluster stone-prod-p02."
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-              alert_routing_key: infra
-              team: konflux-infra
+    - alert: KueueCELEvaluationFailures
+      expr: increase(tekton_kueue_cel_evaluations_total{result="failure"}[5m]) > 0
+      for: 1m
+      labels:
+        severity: critical
+        component: tekton-kueue
+        slo: "true"
+      annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L146
+        summary: "Tekton Kueue CEL evaluation failures detected"
+        description: "{{ $value }} CEL evaluation failures occurred in the last 5 minutes in cluster {{ $labels.source_cluster }}"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-KueueCELEvaluationFailures.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
 
-  # 6. KueueAdmissionWaitTimePreMergeTierBCritical - Fire when P95 > 5400s (1.5h) for 15m
-  - interval: 1m
-    input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="5400.0", source_cluster="stone-prod-p02"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="6000.0", source_cluster="stone-prod-p02"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="stone-prod-p02"}'
-        values: '0+10x60'
-    alert_rule_test:
-      - eval_time: 20m
-        alertname: KueueAdmissionWaitTimePreMergeTierBCritical
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-              component: kueue
-              slo: "true"
-              tier: B
-              pipeline_type: PreMerge
-              source_cluster: stone-prod-p02
-            exp_annotations:
-              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
-              summary: "Critical admission wait time for Pre-merge builds (Tier B - Constrained)"
-              description: "P95 admission wait time for Pre-merge builds is above 1.5 hours on constrained cluster stone-prod-p02."
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-              alert_team_handle: <!subteam^S05Q1P4Q2TG>
-              team: konflux-infra
+    - alert: TektonKueueRolloutStuck
+      expr: |
+        kube_deployment_status_replicas_updated{namespace="tekton-kueue"}
+          <
+        kube_deployment_spec_replicas{namespace="tekton-kueue"}
+      for: 20m
+      labels:
+        severity: warning
+        component: tekton-kueue
+      annotations:
+        summary: "Tekton Kueue rollout stuck: {{ $labels.deployment }}"
+        description: >-
+          Deployment {{ $labels.deployment }} in namespace {{ $labels.namespace }} on cluster
+          {{ $labels.source_cluster }} update is delayed or stuck (no full health for 20m).
+          Check pod events and logs for the deployment and its ReplicaSets.
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueRolloutStuck.md
+        alert_routing_key: infra
+        team: konflux-infra
 
-  # 7. KueueAdmissionWaitTimePostMergeTierBWarning - Fire when P95 > 7200s (2h) for 30m
-  - interval: 1m
-    input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="7200.0", source_cluster="stone-prd-rh01"}'
-        values: '0+0x80'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="8000.0", source_cluster="stone-prd-rh01"}'
-        values: '0+0x80'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="stone-prd-rh01"}'
-        values: '0+10x80'
-    alert_rule_test:
-      - eval_time: 35m
-        alertname: KueueAdmissionWaitTimePostMergeTierBWarning
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              component: kueue
-              slo: "false"
-              tier: B
-              pipeline_type: PostMerge
-              source_cluster: stone-prd-rh01
-            exp_annotations:
-              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
-              summary: "High admission wait time for Post-merge builds (Tier B - Constrained)"
-              description: "P95 admission wait time for Post-merge builds is above 2 hours on constrained cluster stone-prd-rh01."
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-              alert_routing_key: infra
-              team: konflux-infra
+    - alert: KueueMutatingWebhookLowSuccessRate
+      expr: |
+        100 * sum by (instance, source_cluster) (increase(apiserver_admission_webhook_request_total{
+          name="pipelinerun-kueue-defaulter.tekton-kueue.io", code=~"2..|400"
+        }[10m]))
+        /
+        sum by (instance, source_cluster) (increase(apiserver_admission_webhook_request_total{
+          name="pipelinerun-kueue-defaulter.tekton-kueue.io"
+        }[10m]))
+        < 99
+      for: 10m
+      labels:
+        severity: high
+        component: kueue
+        slo: "false"
+      annotations:
+        summary: "Kueue mutating webhook success rate is below 99%"
+        description: "The mutating webhook 'pipelinerun-kueue-defaulter.tekton-kueue.io' has had a success rate below 99% over the past 10 minutes in cluster {{ $labels.source_cluster }}. Possible causes include webhook errors, rejections, or unreachability (e.g., code=600)."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md?ref_type=heads
+        alert_routing_key: infra
+        team: konflux-infra
 
-  # 8. KueueAdmissionWaitTimePostMergeTierBCritical - Fire when P95 > 14400s (4h) for 15m
-  - interval: 1m
-    input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="14400.0", source_cluster="stone-prd-rh01"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="15000.0", source_cluster="stone-prd-rh01"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="stone-prd-rh01"}'
-        values: '0+10x60'
-    alert_rule_test:
-      - eval_time: 20m
-        alertname: KueueAdmissionWaitTimePostMergeTierBCritical
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-              component: kueue
-              slo: "true"
-              tier: B
-              pipeline_type: PostMerge
-              source_cluster: stone-prd-rh01
-            exp_annotations:
-              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml
-              summary: "Critical admission wait time for Post-merge builds (Tier B - Constrained)"
-              description: "P95 admission wait time for Post-merge builds is above 4 hours on constrained cluster stone-prd-rh01."
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-              alert_team_handle: <!subteam^S05Q1P4Q2TG>
-              team: konflux-infra
+  - name: kueue.queue
+    interval: 30s
+    rules:
+    - alert: KueueClusterQueueNotActive
+      expr: max by (status, source_cluster) (kueue_cluster_queue_status{cluster_queue="cluster-pipeline-queue", status="active"}) != 1
+      for: 2m
+      labels:
+        severity: critical
+        component: kueue
+        slo: "true"
+      annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L205
+        summary: "Kueue cluster queue is not active"
+        description: "Cluster queue 'cluster-pipeline-queue' is not in active state in cluster {{ $labels.source_cluster }}"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
 
-  # =========================================================================
-  # Regression / Isolation Tests (Cluster Filtering Validation)
-  # =========================================================================
+    # =========================================================================
+    # Tier A: Standard Clusters (excluding stone-prod-p02 & stone-prd-rh01)
+    # =========================================================================
 
-  # Tier A rules should NOT fire for Tier B clusters (stone-prod-p02)
-  - interval: 1m
-    input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="900.0", source_cluster="stone-prod-p02"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1000.0", source_cluster="stone-prod-p02"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="stone-prod-p02"}'
-        values: '0+10x60'
-    alert_rule_test:
-      - eval_time: 20m
-        alertname: KueueAdmissionWaitTimePreMergeTierAWarning
-        exp_alerts: []
+    - alert: KueueAdmissionWaitTimePreMergeTierAWarning
+      expr: |
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-pre-merge-.*",
+          source_cluster!~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 300
+      for: 15m
+      labels:
+        severity: warning
+        component: kueue
+        slo: "false"
+        tier: A
+        pipeline_type: PreMerge
+      annotations:
+        summary: "High admission wait time for Pre-merge builds (Tier A)"
+        description: "P95 admission wait time for Pre-merge builds is above 5 minutes on cluster {{ $labels.source_cluster }}."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_routing_key: infra
+        team: konflux-infra
 
-  # Tier B rules should NOT fire for Standard Tier A clusters (c1)
-  - interval: 1m
-    input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1800.0", source_cluster="c1"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="2000.0", source_cluster="c1"}'
-        values: '0+0x60'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="c1"}'
-        values: '0+10x60'
-    alert_rule_test:
-      - eval_time: 20m
-        alertname: KueueAdmissionWaitTimePreMergeTierBWarning
-        exp_alerts: []
+    - alert: KueueAdmissionWaitTimePreMergeTierACritical
+      expr: |
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-pre-merge-.*",
+          source_cluster!~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 1200
+      for: 15m
+      labels:
+        severity: critical
+        component: kueue
+        slo: "true"
+        tier: A
+        pipeline_type: PreMerge
+      annotations:
+        summary: "Critical admission wait time for Pre-merge builds (Tier A)"
+        description: "P95 admission wait time for Pre-merge builds is above 20 minutes on cluster {{ $labels.source_cluster }}."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
 
-  # =========================================================================
-  # Other Workload Alerts
-  # =========================================================================
+    - alert: KueueAdmissionWaitTimePostMergeTierAWarning
+      expr: |
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-post-merge-.*",
+          source_cluster!~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 1200
+      for: 20m
+      labels:
+        severity: warning
+        component: kueue
+        slo: "false"
+        tier: A
+        pipeline_type: PostMerge
+      annotations:
+        summary: "High admission wait time for Post-merge builds (Tier A)"
+        description: "P95 admission wait time for Post-merge builds is above 20 minutes on cluster {{ $labels.source_cluster }}."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_routing_key: infra
+        team: konflux-infra
 
-  # KueueHighAdmissionWaitTimeMintmaker - should fire
-  - interval: 1m
-    input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-dependency-update", le="43200.0", source_cluster="c1"}'
-        values: '0+0x20'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-dependency-update", le="50400.0", source_cluster="c1"}'
-        values: '0+0x20'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-dependency-update", le="+Inf", source_cluster="c1"}'
-        values: '0 10 20 30 40 50 60 70 80 90 100 110 120 130 140'
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: KueueHighAdmissionWaitTimeMintmaker
-        exp_alerts:
-          - exp_labels:
-              severity: high
-              component: kueue
-              source_cluster: c1
-            exp_annotations:
-              summary: "High admission wait time for Mintmaker"
-              description: "99th percentile admission wait time for Mintmaker is 14h 0m 0s, which is above 12 hours in cluster c1"
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-              alert_routing_key: infra
-              team: konflux-infra
+    - alert: KueueAdmissionWaitTimePostMergeTierACritical
+      expr: |
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-post-merge-.*",
+          source_cluster!~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 5400
+      for: 15m
+      labels:
+        severity: critical
+        component: kueue
+        slo: "true"
+        tier: A
+        pipeline_type: PostMerge
+      annotations:
+        summary: "Critical admission wait time for Post-merge builds (Tier A)"
+        description: "P95 admission wait time for Post-merge builds is above 1.5 hours on cluster {{ $labels.source_cluster }}."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
 
-  # KueueHighAdmissionWaitTimeReleases - should fire
-  - interval: 1m
-    input_series:
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="4800.0", source_cluster="c1"}'
-        values: '0+0x30'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="5000.0", source_cluster="c1"}'
-        values: '0+0x30'
-      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="+Inf", source_cluster="c1"}'
-        values: '0+10x30'
-    alert_rule_test:
-      - eval_time: 25m
-        alertname: KueueHighAdmissionWaitTimeReleases
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-              component: kueue
-              slo: "true"
-              source_cluster: c1
-            exp_annotations:
-              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L271
-              summary: "High admission wait time for Release workloads"
-              description: "99th percentile admission wait time for konflux and tenant release workloads is 1h 23m 20s, which is above 1.33 hours in cluster c1"
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-              alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
+    # =========================================================================
+    # Tier B: Constrained Clusters (stone-prod-p02 & stone-prd-rh01)
+    # =========================================================================
+
+    - alert: KueueAdmissionWaitTimePreMergeTierBWarning
+      expr: |
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-pre-merge-.*",
+          source_cluster=~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 1800
+      for: 15m
+      labels:
+        severity: warning
+        component: kueue
+        slo: "false"
+        tier: B
+        pipeline_type: PreMerge
+      annotations:
+        summary: "High admission wait time for Pre-merge builds (Tier B - Constrained)"
+        description: "P95 admission wait time for Pre-merge builds is above 30 minutes on constrained cluster {{ $labels.source_cluster }}."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_routing_key: infra
+        team: konflux-infra
+
+    - alert: KueueAdmissionWaitTimePreMergeTierBCritical
+      expr: |
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-pre-merge-.*",
+          source_cluster=~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 5400
+      for: 15m
+      labels:
+        severity: critical
+        component: kueue
+        slo: "true"
+        tier: B
+        pipeline_type: PreMerge
+      annotations:
+        summary: "Critical admission wait time for Pre-merge builds (Tier B - Constrained)"
+        description: "P95 admission wait time for Pre-merge builds is above 1.5 hours on constrained cluster {{ $labels.source_cluster }}."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueAdmissionWaitTimePostMergeTierBWarning
+      expr: |
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-post-merge-.*",
+          source_cluster=~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 7200
+      for: 30m
+      labels:
+        severity: warning
+        component: kueue
+        slo: "false"
+        tier: B
+        pipeline_type: PostMerge
+      annotations:
+        summary: "High admission wait time for Post-merge builds (Tier B - Constrained)"
+        description: "P95 admission wait time for Post-merge builds is above 2 hours on constrained cluster {{ $labels.source_cluster }}."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_routing_key: infra
+        team: konflux-infra
+
+    - alert: KueueAdmissionWaitTimePostMergeTierBCritical
+      expr: |
+        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-post-merge-.*",
+          source_cluster=~"stone-prod-p02|stone-prd-rh01"
+        }[10m])) by (le, source_cluster)) > 14400
+      for: 15m
+      labels:
+        severity: critical
+        component: kueue
+        slo: "true"
+        tier: B
+        pipeline_type: PostMerge
+      annotations:
+        summary: "Critical admission wait time for Post-merge builds (Tier B - Constrained)"
+        description: "P95 admission wait time for Post-merge builds is above 4 hours on constrained cluster {{ $labels.source_cluster }}."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    # =========================================================================
+    # Other Workload Alerts
+    # =========================================================================
+
+    - alert: KueueHighAdmissionWaitTimeMintmaker
+      expr: |
+        histogram_quantile(0.99, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class="konflux-dependency-update"
+        }[10m])) by (le, source_cluster)) > 43200
+      for: 5m
+      labels:
+        severity: high
+        component: kueue
+      annotations:
+        summary: "High admission wait time for Mintmaker"
+        description: "99th percentile admission wait time for Mintmaker is {{ $value | humanizeDuration }}, which is above 12 hours in cluster {{ $labels.source_cluster }}"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_routing_key: infra
+        team: konflux-infra
+
+    - alert: KueueHighAdmissionWaitTimeReleases
+      expr: |
+        histogram_quantile(0.99, sum(increase(kueue_admission_wait_time_seconds_bucket{
+          cluster_queue="cluster-pipeline-queue",
+          priority_class=~"konflux-release|konflux-tenant-release"
+        }[10m])) by (le, source_cluster)) > 4800
+      for: 20m
+      labels:
+        severity: critical
+        component: kueue
+        slo: "true"
+      annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L271
+        summary: "High admission wait time for Release workloads"
+        description: "99th percentile admission wait time for konflux and tenant release workloads is {{ $value | humanizeDuration }}, which is above 1.33 hours in cluster {{ $labels.source_cluster }}"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+        alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -1,433 +1,313 @@
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  name: rhtap-kueue-alerts
-  labels:
-    tenant: rhtap
-spec:
-  groups:
-  - name: kueue.health
-    interval: 30s
-    rules:
-    - alert: TektonKueueControllerDown
-      expr: |
-        konflux_up{
-          namespace="tekton-kueue",
-          check="replicas-available",
-          service="tekton-kueue-controller-manager",
-        } != 1
-      for: 5m
-      labels:
-        severity: critical
-        component: tekton-kueue
-        slo: "true"
-      annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L12
-        summary: "Tekton Kueue controller is down"
-        description: "The Tekton Kueue controller has no available replicas in cluster {{ $labels.source_cluster }}. PipelineRuns will be created in Pending state but cannot be processed, resulting in stuck builds."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueControllerDown.md
-        alert_team_handle: <!subteam^S05Q1P4Q2TG>
-        team: konflux-infra
+evaluation_interval: 1m
+rule_files:
+  - 'prometheus.kueue_alerts.yaml'
 
-    - alert: TektonKueueWebhookDown
-      expr: |
-        konflux_up{
-          namespace="tekton-kueue",
-          check="replicas-available",
-          service="tekton-kueue-webhook",
-        } != 1
-      for: 5m
-      labels:
-        severity: critical
-        component: tekton-kueue
-        slo: "true"
-      annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L32
-        summary: "Tekton Kueue webhook is down"
-        description: "The Tekton Kueue webhook has no available replicas in cluster {{ $labels.source_cluster }}. PipelineRuns may not be created with Pending state and Workload resources, bypassing Kueue admission control."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueWebhookDown.md
-        alert_team_handle: <!subteam^S05Q1P4Q2TG>
-        team: konflux-infra
+tests:
+  # =========================================================================
+  # Tier A: Standard Clusters (e.g. source_cluster="c1")
+  # =========================================================================
 
-    - alert: TektonKueuePodsRepeatedRestarts
-      expr: |
-        sum by (source_cluster) (
-          increase(kube_pod_container_status_restarts_total{
-            namespace="tekton-kueue"
-          }[5m])
-        ) > 0
-      for: 5m
-      labels:
-        severity: warning
-        component: tekton-kueue
-      annotations:
-        summary: "Tekton Kueue pods are repeatedly restarting"
-        description: "Tekton Kueue pods have restarted {{ $value }} times in the last 5 minutes in cluster {{ $labels.source_cluster }}. This may indicate resource pressure or application issues."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsRepeatedRestarts.md
-        alert_routing_key: infra
-        team: konflux-infra
+  # 1. KueueAdmissionWaitTimePreMergeTierAWarning - Fire when P95 > 300s (5m) for 15m
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="900.0", source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1000.0", source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="c1"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePreMergeTierAWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: kueue
+              slo: "false"
+              tier: A
+              pipeline_type: PreMerge
+              source_cluster: c1
+            exp_annotations:
+              summary: "High admission wait time for Pre-merge builds (Tier A)"
+              description: "P95 admission wait time for Pre-merge builds is above 5 minutes on cluster c1."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_routing_key: infra
+              team: konflux-infra
 
-    - alert: TektonKueuePodsCrashLoopBackOff
-      expr: |
-        max_over_time(kube_pod_container_status_waiting_reason{
-          namespace="tekton-kueue",
-          reason="CrashLoopBackOff"
-        }[3m]) > 0
-      for: 3m
-      labels:
-        severity: high
-        component: tekton-kueue
-        slo: "false"
-      annotations:
-        summary: "Tekton Kueue pod is in a crash loop: {{ $labels.pod }}"
-        description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is in CrashLoopBackOff and is not starting up."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsCrashLoopBackOff.md
-        alert_routing_key: infra
-        team: konflux-infra
+  # 2. KueueAdmissionWaitTimePreMergeTierACritical - Fire when P95 > 1200s (20m) for 15m
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1200.0", source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1500.0", source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="c1"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePreMergeTierACritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: kueue
+              slo: "true"
+              tier: A
+              pipeline_type: PreMerge
+              source_cluster: c1
+            exp_annotations:
+              summary: "Critical admission wait time for Pre-merge builds (Tier A)"
+              description: "P95 admission wait time for Pre-merge builds is above 20 minutes on cluster c1."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra
 
-    - alert: TektonKueuePodStuckInPending
-      expr: |
-        kube_pod_status_phase{
-          namespace="tekton-kueue",
-          phase="Pending"
-        } == 1
-      for: 5m
-      labels:
-        severity: warning
-        component: tekton-kueue
-      annotations:
-        summary: "Tekton Kueue pod is stuck in Pending: {{ $labels.pod }}"
-        description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} has been in Pending state for more than 5 minutes. This may indicate a scheduling issue, resource constraint, or unresolvable volume."
-        alert_routing_key: infra
-        team: konflux-infra
+  # 3. KueueAdmissionWaitTimePostMergeTierAWarning - Fire when P95 > 1200s (20m) for 20m
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1200.0", source_cluster="c1"}'
+        values: '0+0x70'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1300.0", source_cluster="c1"}'
+        values: '0+0x70'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="c1"}'
+        values: '0+10x70'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: KueueAdmissionWaitTimePostMergeTierAWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: kueue
+              slo: "false"
+              tier: A
+              pipeline_type: PostMerge
+              source_cluster: c1
+            exp_annotations:
+              summary: "High admission wait time for Post-merge builds (Tier A)"
+              description: "P95 admission wait time for Post-merge builds is above 20 minutes on cluster c1."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_routing_key: infra
+              team: konflux-infra
 
-    - alert: TektonKueuePodStuckInCreation
-      expr: |
-        kube_pod_container_status_waiting_reason{
-          namespace="tekton-kueue",
-          reason="ContainerCreating"
-        } == 1
-        unless on (pod, namespace, source_cluster)
-        kube_pod_status_phase{
-          namespace="tekton-kueue",
-          phase="Running"
-        } == 1
-      for: 5m
-      labels:
-        severity: high
-        component: tekton-kueue
-      annotations:
-        summary: "Tekton Kueue pod is stuck in ContainerCreating: {{ $labels.pod }}"
-        description: "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} is stuck in ContainerCreating for more than 5 minutes. This typically points to infrastructure issues like Volume/Storage mounting failures or Network attachment delays."
-        alert_routing_key: infra
-        team: konflux-infra
+  # 4. KueueAdmissionWaitTimePostMergeTierACritical - Fire when P95 > 5400s (1.5h) for 15m
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="5400.0", source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="6000.0", source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="c1"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePostMergeTierACritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: kueue
+              slo: "true"
+              tier: A
+              pipeline_type: PostMerge
+              source_cluster: c1
+            exp_annotations:
+              summary: "Critical admission wait time for Post-merge builds (Tier A)"
+              description: "P95 admission wait time for Post-merge builds is above 1.5 hours on cluster c1."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra
 
-    - alert: TektonKueuePodOOMKilled
-      expr: |
-        (
-          increase(kube_pod_container_status_restarts_total{namespace="tekton-kueue"}[15m]) > 0
-        ) * on (pod, container, namespace, source_cluster) group_left(reason)
-        (
-          kube_pod_container_status_last_terminated_reason{
-            namespace="tekton-kueue",
-            reason="OOMKilled"
-          } == 1
-        )
-      for: 1m
-      labels:
-        severity: high
-        component: tekton-kueue
-      annotations:
-        summary: "Tekton Kueue pod was OOMKilled: {{ $labels.pod }}"
-        description: "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} on cluster {{ $labels.source_cluster }} was terminated due to OOM. Memory limits may need to be increased in the deployment spec."
-        alert_routing_key: infra
-        team: konflux-infra
+  # =========================================================================
+  # Tier B: Constrained Clusters (e.g. source_cluster="stone-prod-p02")
+  # =========================================================================
 
-    - alert: KueueCELEvaluationFailures
-      expr: increase(tekton_kueue_cel_evaluations_total{result="failure"}[5m]) > 0
-      for: 1m
-      labels:
-        severity: critical
-        component: tekton-kueue
-        slo: "true"
-      annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L146
-        summary: "Tekton Kueue CEL evaluation failures detected"
-        description: "{{ $value }} CEL evaluation failures occurred in the last 5 minutes in cluster {{ $labels.source_cluster }}"
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-KueueCELEvaluationFailures.md?ref_type=heads
-        alert_team_handle: <!subteam^S05Q1P4Q2TG>
-        team: konflux-infra
+  # 5. KueueAdmissionWaitTimePreMergeTierBWarning - Fire when P95 > 1800s (30m) for 15m
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1800.0", source_cluster="stone-prod-p02"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="2000.0", source_cluster="stone-prod-p02"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="stone-prod-p02"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePreMergeTierBWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: kueue
+              slo: "false"
+              tier: B
+              pipeline_type: PreMerge
+              source_cluster: stone-prod-p02
+            exp_annotations:
+              summary: "High admission wait time for Pre-merge builds (Tier B - Constrained)"
+              description: "P95 admission wait time for Pre-merge builds is above 30 minutes on constrained cluster stone-prod-p02."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_routing_key: infra
+              team: konflux-infra
 
-    - alert: TektonKueueRolloutStuck
-      expr: |
-        kube_deployment_status_replicas_updated{namespace="tekton-kueue"}
-          <
-        kube_deployment_spec_replicas{namespace="tekton-kueue"}
-      for: 20m
-      labels:
-        severity: warning
-        component: tekton-kueue
-      annotations:
-        summary: "Tekton Kueue rollout stuck: {{ $labels.deployment }}"
-        description: >-
-          Deployment {{ $labels.deployment }} in namespace {{ $labels.namespace }} on cluster
-          {{ $labels.source_cluster }} update is delayed or stuck (no full health for 20m).
-          Check pod events and logs for the deployment and its ReplicaSets.
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueRolloutStuck.md
-        alert_routing_key: infra
-        team: konflux-infra
+  # 6. KueueAdmissionWaitTimePreMergeTierBCritical - Fire when P95 > 5400s (1.5h) for 15m
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="5400.0", source_cluster="stone-prod-p02"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="6000.0", source_cluster="stone-prod-p02"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="stone-prod-p02"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePreMergeTierBCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: kueue
+              slo: "true"
+              tier: B
+              pipeline_type: PreMerge
+              source_cluster: stone-prod-p02
+            exp_annotations:
+              summary: "Critical admission wait time for Pre-merge builds (Tier B - Constrained)"
+              description: "P95 admission wait time for Pre-merge builds is above 1.5 hours on constrained cluster stone-prod-p02."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra
 
-    - alert: KueueMutatingWebhookLowSuccessRate
-      expr: |
-        100 * sum by (instance, source_cluster) (increase(apiserver_admission_webhook_request_total{
-          name="pipelinerun-kueue-defaulter.tekton-kueue.io", code=~"2..|400"
-        }[10m]))
-        /
-        sum by (instance, source_cluster) (increase(apiserver_admission_webhook_request_total{
-          name="pipelinerun-kueue-defaulter.tekton-kueue.io"
-        }[10m]))
-        < 99
-      for: 10m
-      labels:
-        severity: high
-        component: kueue
-        slo: "false"
-      annotations:
-        summary: "Kueue mutating webhook success rate is below 99%"
-        description: "The mutating webhook 'pipelinerun-kueue-defaulter.tekton-kueue.io' has had a success rate below 99% over the past 10 minutes in cluster {{ $labels.source_cluster }}. Possible causes include webhook errors, rejections, or unreachability (e.g., code=600)."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md?ref_type=heads
-        alert_routing_key: infra
-        team: konflux-infra
+  # 7. KueueAdmissionWaitTimePostMergeTierBWarning - Fire when P95 > 7200s (2h) for 30m
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="7200.0", source_cluster="stone-prd-rh01"}'
+        values: '0+0x80'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="8000.0", source_cluster="stone-prd-rh01"}'
+        values: '0+0x80'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="stone-prd-rh01"}'
+        values: '0+10x80'
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: KueueAdmissionWaitTimePostMergeTierBWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: kueue
+              slo: "false"
+              tier: B
+              pipeline_type: PostMerge
+              source_cluster: stone-prd-rh01
+            exp_annotations:
+              summary: "High admission wait time for Post-merge builds (Tier B - Constrained)"
+              description: "P95 admission wait time for Post-merge builds is above 2 hours on constrained cluster stone-prd-rh01."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_routing_key: infra
+              team: konflux-infra
 
-  - name: kueue.queue
-    interval: 30s
-    rules:
-    - alert: KueueClusterQueueNotActive
-      expr: max by (status, source_cluster) (kueue_cluster_queue_status{cluster_queue="cluster-pipeline-queue", status="active"}) != 1
-      for: 2m
-      labels:
-        severity: critical
-        component: kueue
-        slo: "true"
-      annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L205
-        summary: "Kueue cluster queue is not active"
-        description: "Cluster queue 'cluster-pipeline-queue' is not in active state in cluster {{ $labels.source_cluster }}"
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md?ref_type=heads
-        alert_team_handle: <!subteam^S05Q1P4Q2TG>
-        team: konflux-infra
+  # 8. KueueAdmissionWaitTimePostMergeTierBCritical - Fire when P95 > 14400s (4h) for 15m
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="14400.0", source_cluster="stone-prd-rh01"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="15000.0", source_cluster="stone-prd-rh01"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="stone-prd-rh01"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePostMergeTierBCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: kueue
+              slo: "true"
+              tier: B
+              pipeline_type: PostMerge
+              source_cluster: stone-prd-rh01
+            exp_annotations:
+              summary: "Critical admission wait time for Post-merge builds (Tier B - Constrained)"
+              description: "P95 admission wait time for Post-merge builds is above 4 hours on constrained cluster stone-prd-rh01."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra
 
-    # =========================================================================
-    # Tier A: Standard Clusters (excluding stone-prod-p02 & stone-prd-rh01)
-    # =========================================================================
+  # =========================================================================
+  # Regression / Isolation Tests (Cluster Filtering Validation)
+  # =========================================================================
 
-    - alert: KueueAdmissionWaitTimePreMergeTierAWarning
-      expr: |
-        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
-          cluster_queue="cluster-pipeline-queue",
-          priority_class=~"konflux-pre-merge-.*",
-          source_cluster!~"stone-prod-p02|stone-prd-rh01"
-        }[10m])) by (le, source_cluster)) > 300
-      for: 15m
-      labels:
-        severity: warning
-        component: kueue
-        slo: "false"
-        tier: A
-        pipeline_type: PreMerge
-      annotations:
-        summary: "High admission wait time for Pre-merge builds (Tier A)"
-        description: "P95 admission wait time for Pre-merge builds is above 5 minutes on cluster {{ $labels.source_cluster }}."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-        alert_routing_key: infra
-        team: konflux-infra
+  # Tier A rules should NOT fire for Tier B clusters (stone-prod-p02)
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="900.0", source_cluster="stone-prod-p02"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1000.0", source_cluster="stone-prod-p02"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="stone-prod-p02"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePreMergeTierAWarning
+        exp_alerts: []
 
-    - alert: KueueAdmissionWaitTimePreMergeTierACritical
-      expr: |
-        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
-          cluster_queue="cluster-pipeline-queue",
-          priority_class=~"konflux-pre-merge-.*",
-          source_cluster!~"stone-prod-p02|stone-prd-rh01"
-        }[10m])) by (le, source_cluster)) > 1200
-      for: 15m
-      labels:
-        severity: critical
-        component: kueue
-        slo: "true"
-        tier: A
-        pipeline_type: PreMerge
-      annotations:
-        summary: "Critical admission wait time for Pre-merge builds (Tier A)"
-        description: "P95 admission wait time for Pre-merge builds is above 20 minutes on cluster {{ $labels.source_cluster }}."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-        alert_team_handle: <!subteam^S05Q1P4Q2TG>
-        team: konflux-infra
+  # Tier B rules should NOT fire for Standard Tier A clusters (c1)
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1800.0", source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="2000.0", source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="c1"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KueueAdmissionWaitTimePreMergeTierBWarning
+        exp_alerts: []
 
-    - alert: KueueAdmissionWaitTimePostMergeTierAWarning
-      expr: |
-        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
-          cluster_queue="cluster-pipeline-queue",
-          priority_class=~"konflux-post-merge-.*",
-          source_cluster!~"stone-prod-p02|stone-prd-rh01"
-        }[10m])) by (le, source_cluster)) > 1200
-      for: 20m
-      labels:
-        severity: warning
-        component: kueue
-        slo: "false"
-        tier: A
-        pipeline_type: PostMerge
-      annotations:
-        summary: "High admission wait time for Post-merge builds (Tier A)"
-        description: "P95 admission wait time for Post-merge builds is above 20 minutes on cluster {{ $labels.source_cluster }}."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-        alert_routing_key: infra
-        team: konflux-infra
+  # =========================================================================
+  # Other Workload Alerts
+  # =========================================================================
 
-    - alert: KueueAdmissionWaitTimePostMergeTierACritical
-      expr: |
-        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
-          cluster_queue="cluster-pipeline-queue",
-          priority_class=~"konflux-post-merge-.*",
-          source_cluster!~"stone-prod-p02|stone-prd-rh01"
-        }[10m])) by (le, source_cluster)) > 5400
-      for: 15m
-      labels:
-        severity: critical
-        component: kueue
-        slo: "true"
-        tier: A
-        pipeline_type: PostMerge
-      annotations:
-        summary: "Critical admission wait time for Post-merge builds (Tier A)"
-        description: "P95 admission wait time for Post-merge builds is above 1.5 hours on cluster {{ $labels.source_cluster }}."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-        alert_team_handle: <!subteam^S05Q1P4Q2TG>
-        team: konflux-infra
+  # KueueHighAdmissionWaitTimeMintmaker - should fire
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-dependency-update", le="43200.0", source_cluster="c1"}'
+        values: '0+0x20'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-dependency-update", le="50400.0", source_cluster="c1"}'
+        values: '0+0x20'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-dependency-update", le="+Inf", source_cluster="c1"}'
+        values: '0 10 20 30 40 50 60 70 80 90 100 110 120 130 140'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: KueueHighAdmissionWaitTimeMintmaker
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              component: kueue
+              source_cluster: c1
+            exp_annotations:
+              summary: "High admission wait time for Mintmaker"
+              description: "99th percentile admission wait time for Mintmaker is 14h 0m 0s, which is above 12 hours in cluster c1"
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_routing_key: infra
+              team: konflux-infra
 
-    # =========================================================================
-    # Tier B: Constrained Clusters (stone-prod-p02 & stone-prd-rh01)
-    # =========================================================================
-
-    - alert: KueueAdmissionWaitTimePreMergeTierBWarning
-      expr: |
-        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
-          cluster_queue="cluster-pipeline-queue",
-          priority_class=~"konflux-pre-merge-.*",
-          source_cluster=~"stone-prod-p02|stone-prd-rh01"
-        }[10m])) by (le, source_cluster)) > 1800
-      for: 15m
-      labels:
-        severity: warning
-        component: kueue
-        slo: "false"
-        tier: B
-        pipeline_type: PreMerge
-      annotations:
-        summary: "High admission wait time for Pre-merge builds (Tier B - Constrained)"
-        description: "P95 admission wait time for Pre-merge builds is above 30 minutes on constrained cluster {{ $labels.source_cluster }}."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-        alert_routing_key: infra
-        team: konflux-infra
-
-    - alert: KueueAdmissionWaitTimePreMergeTierBCritical
-      expr: |
-        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
-          cluster_queue="cluster-pipeline-queue",
-          priority_class=~"konflux-pre-merge-.*",
-          source_cluster=~"stone-prod-p02|stone-prd-rh01"
-        }[10m])) by (le, source_cluster)) > 5400
-      for: 15m
-      labels:
-        severity: critical
-        component: kueue
-        slo: "true"
-        tier: B
-        pipeline_type: PreMerge
-      annotations:
-        summary: "Critical admission wait time for Pre-merge builds (Tier B - Constrained)"
-        description: "P95 admission wait time for Pre-merge builds is above 1.5 hours on constrained cluster {{ $labels.source_cluster }}."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-        alert_team_handle: <!subteam^S05Q1P4Q2TG>
-        team: konflux-infra
-
-    - alert: KueueAdmissionWaitTimePostMergeTierBWarning
-      expr: |
-        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
-          cluster_queue="cluster-pipeline-queue",
-          priority_class=~"konflux-post-merge-.*",
-          source_cluster=~"stone-prod-p02|stone-prd-rh01"
-        }[10m])) by (le, source_cluster)) > 7200
-      for: 30m
-      labels:
-        severity: warning
-        component: kueue
-        slo: "false"
-        tier: B
-        pipeline_type: PostMerge
-      annotations:
-        summary: "High admission wait time for Post-merge builds (Tier B - Constrained)"
-        description: "P95 admission wait time for Post-merge builds is above 2 hours on constrained cluster {{ $labels.source_cluster }}."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-        alert_routing_key: infra
-        team: konflux-infra
-
-    - alert: KueueAdmissionWaitTimePostMergeTierBCritical
-      expr: |
-        histogram_quantile(0.95, sum(increase(kueue_admission_wait_time_seconds_bucket{
-          cluster_queue="cluster-pipeline-queue",
-          priority_class=~"konflux-post-merge-.*",
-          source_cluster=~"stone-prod-p02|stone-prd-rh01"
-        }[10m])) by (le, source_cluster)) > 14400
-      for: 15m
-      labels:
-        severity: critical
-        component: kueue
-        slo: "true"
-        tier: B
-        pipeline_type: PostMerge
-      annotations:
-        summary: "Critical admission wait time for Post-merge builds (Tier B - Constrained)"
-        description: "P95 admission wait time for Post-merge builds is above 4 hours on constrained cluster {{ $labels.source_cluster }}."
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-        alert_team_handle: <!subteam^S05Q1P4Q2TG>
-        team: konflux-infra
-
-    # =========================================================================
-    # Other Workload Alerts
-    # =========================================================================
-
-    - alert: KueueHighAdmissionWaitTimeMintmaker
-      expr: |
-        histogram_quantile(0.99, sum(increase(kueue_admission_wait_time_seconds_bucket{
-          cluster_queue="cluster-pipeline-queue",
-          priority_class="konflux-dependency-update"
-        }[10m])) by (le, source_cluster)) > 43200
-      for: 5m
-      labels:
-        severity: high
-        component: kueue
-      annotations:
-        summary: "High admission wait time for Mintmaker"
-        description: "99th percentile admission wait time for Mintmaker is {{ $value | humanizeDuration }}, which is above 12 hours in cluster {{ $labels.source_cluster }}"
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-        alert_routing_key: infra
-        team: konflux-infra
-
-    - alert: KueueHighAdmissionWaitTimeReleases
-      expr: |
-        histogram_quantile(0.99, sum(increase(kueue_admission_wait_time_seconds_bucket{
-          cluster_queue="cluster-pipeline-queue",
-          priority_class=~"konflux-release|konflux-tenant-release"
-        }[10m])) by (le, source_cluster)) > 4800
-      for: 20m
-      labels:
-        severity: critical
-        component: kueue
-        slo: "true"
-      annotations:
-        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L271
-        summary: "High admission wait time for Release workloads"
-        description: "99th percentile admission wait time for konflux and tenant release workloads is {{ $value | humanizeDuration }}, which is above 1.33 hours in cluster {{ $labels.source_cluster }}"
-        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
-        alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
+  # KueueHighAdmissionWaitTimeReleases - should fire
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="4800.0", source_cluster="c1"}'
+        values: '0+0x30'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="5000.0", source_cluster="c1"}'
+        values: '0+0x30'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="+Inf", source_cluster="c1"}'
+        values: '0+10x30'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: KueueHighAdmissionWaitTimeReleases
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: kueue
+              slo: "true"
+              source_cluster: c1
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L271
+              summary: "High admission wait time for Release workloads"
+              description: "99th percentile admission wait time for konflux and tenant release workloads is 1h 23m 20s, which is above 1.33 hours in cluster c1"
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
+              alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'

--- a/test/promql/tests/data_plane/kueue_alerts_test.yaml
+++ b/test/promql/tests/data_plane/kueue_alerts_test.yaml
@@ -4,10 +4,364 @@ rule_files:
 
 tests:
   # =========================================================================
-  # Tier A: Standard Clusters (e.g. source_cluster="c1")
+  # TektonKueue Controller & Webhook Health Alerts
   # =========================================================================
 
-  # 1. KueueAdmissionWaitTimePreMergeTierAWarning - Fire when P95 > 300s (5m) for 15m
+  # 1. TektonKueueControllerDown - should fire
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="tekton-kueue", check="replicas-available", service="tekton-kueue-controller-manager", source_cluster="c1"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: TektonKueueControllerDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: tekton-kueue
+              slo: "true"
+              check: replicas-available
+              namespace: tekton-kueue
+              service: tekton-kueue-controller-manager
+              source_cluster: c1
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L12
+              summary: "Tekton Kueue controller is down"
+              description: "The Tekton Kueue controller has no available replicas in cluster c1. PipelineRuns will be created in Pending state but cannot be processed, resulting in stuck builds."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueControllerDown.md
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra
+
+  # 2. TektonKueueWebhookDown - should fire
+  - interval: 1m
+    input_series:
+      - series: 'konflux_up{namespace="tekton-kueue", check="replicas-available", service="tekton-kueue-webhook", source_cluster="c1"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: TektonKueueWebhookDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: tekton-kueue
+              slo: "true"
+              check: replicas-available
+              namespace: tekton-kueue
+              service: tekton-kueue-webhook
+              source_cluster: c1
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L32
+              summary: "Tekton Kueue webhook is down"
+              description: "The Tekton Kueue webhook has no available replicas in cluster c1. PipelineRuns may not be created with Pending state and Workload resources, bypassing Kueue admission control."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueWebhookDown.md
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra
+
+  # 3. TektonKueuePodsRepeatedRestarts - should fire
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_restarts_total{namespace="tekton-kueue", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: TektonKueuePodsRepeatedRestarts
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: tekton-kueue
+              source_cluster: c1
+            exp_annotations:
+              summary: "Tekton Kueue pods are repeatedly restarting"
+              description: "Tekton Kueue pods have restarted 5 times in the last 5 minutes in cluster c1. This may indicate resource pressure or application issues."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsRepeatedRestarts.md
+              alert_routing_key: infra
+              team: konflux-infra
+
+  # 4. TektonKueuePodsCrashLoopBackOff - should fire
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="CrashLoopBackOff", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: TektonKueuePodsCrashLoopBackOff
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              component: tekton-kueue
+              slo: "false"
+              namespace: tekton-kueue
+              reason: CrashLoopBackOff
+              pod: tekton-kueue-controller-manager-abc123
+              source_cluster: c1
+            exp_annotations:
+              summary: "Tekton Kueue pod is in a crash loop: tekton-kueue-controller-manager-abc123"
+              description: "Pod tekton-kueue-controller-manager-abc123 in namespace tekton-kueue on cluster c1 is in CrashLoopBackOff and is not starting up."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueuePodsCrashLoopBackOff.md
+              alert_routing_key: infra
+              team: konflux-infra
+
+  # TektonKueuePodsCrashLoopBackOff - should NOT fire: pod not in CrashLoopBackOff
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="CrashLoopBackOff", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: TektonKueuePodsCrashLoopBackOff
+        exp_alerts: []
+
+  # 5. TektonKueuePodStuckInPending - should fire
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: TektonKueuePodStuckInPending
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: tekton-kueue
+              namespace: tekton-kueue
+              phase: Pending
+              pod: tekton-kueue-controller-manager-abc123
+              source_cluster: c1
+            exp_annotations:
+              summary: "Tekton Kueue pod is stuck in Pending: tekton-kueue-controller-manager-abc123"
+              description: "Pod tekton-kueue-controller-manager-abc123 in namespace tekton-kueue on cluster c1 has been in Pending state for more than 5 minutes. This may indicate a scheduling issue, resource constraint, or unresolvable volume."
+              alert_routing_key: infra
+              team: konflux-infra
+
+  # TektonKueuePodStuckInPending - should NOT fire: pod not in Pending
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: TektonKueuePodStuckInPending
+        exp_alerts: []
+
+  # TektonKueuePodStuckInPending - should NOT fire: eval time (4m) is less than 'for' duration (5m)
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: TektonKueuePodStuckInPending
+        exp_alerts: []
+
+  # 6. TektonKueuePodStuckInCreation - should fire
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="ContainerCreating", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
+        values: '1+0x10'
+      - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Pending", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
+        values: '1+0x10'
+      - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Running", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: TektonKueuePodStuckInCreation
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              component: tekton-kueue
+              namespace: tekton-kueue
+              reason: ContainerCreating
+              pod: tekton-kueue-controller-manager-abc123
+              container: manager
+              source_cluster: c1
+            exp_annotations:
+              summary: "Tekton Kueue pod is stuck in ContainerCreating: tekton-kueue-controller-manager-abc123"
+              description: "Container manager in pod tekton-kueue-controller-manager-abc123 in namespace tekton-kueue on cluster c1 is stuck in ContainerCreating for more than 5 minutes. This typically points to infrastructure issues like Volume/Storage mounting failures or Network attachment delays."
+              alert_routing_key: infra
+              team: konflux-infra
+
+  # TektonKueuePodStuckInCreation - should NOT fire: pod not in ContainerCreating
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="ContainerCreating", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: TektonKueuePodStuckInCreation
+        exp_alerts: []
+
+  # TektonKueuePodStuckInCreation - should NOT fire: stale ContainerCreating metric while pod is Running
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_waiting_reason{namespace="tekton-kueue", reason="ContainerCreating", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
+        values: '1+0x10'
+      - series: 'kube_pod_status_phase{namespace="tekton-kueue", phase="Running", pod="tekton-kueue-controller-manager-abc123", source_cluster="c1"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: TektonKueuePodStuckInCreation
+        exp_alerts: []
+
+  # 7. TektonKueuePodOOMKilled - should fire
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_restarts_total{namespace="tekton-kueue", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
+        values: '0 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_container_status_last_terminated_reason{namespace="tekton-kueue", reason="OOMKilled", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: TektonKueuePodOOMKilled
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              component: tekton-kueue
+              namespace: tekton-kueue
+              reason: OOMKilled
+              pod: tekton-kueue-controller-manager-abc123
+              container: manager
+              source_cluster: c1
+            exp_annotations:
+              summary: "Tekton Kueue pod was OOMKilled: tekton-kueue-controller-manager-abc123"
+              description: "Container manager in pod tekton-kueue-controller-manager-abc123 in namespace tekton-kueue on cluster c1 was terminated due to OOM. Memory limits may need to be increased in the deployment spec."
+              alert_routing_key: infra
+              team: konflux-infra
+
+  # TektonKueuePodOOMKilled - should NOT fire: pod not OOMKilled
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_restarts_total{namespace="tekton-kueue", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
+        values: '0+0x10'
+      - series: 'kube_pod_container_status_last_terminated_reason{namespace="tekton-kueue", reason="OOMKilled", pod="tekton-kueue-controller-manager-abc123", container="manager", source_cluster="c1"}'
+        values: '1+0x10'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: TektonKueuePodOOMKilled
+        exp_alerts: []
+
+  # 8. KueueCELEvaluationFailures - should fire
+  - interval: 1m
+    input_series:
+      - series: 'tekton_kueue_cel_evaluations_total{result="failure", source_cluster="c1"}'
+        values: '0 1 2 3 4 5 6'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: KueueCELEvaluationFailures
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: tekton-kueue
+              slo: "true"
+              result: failure
+              source_cluster: c1
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L146
+              summary: "Tekton Kueue CEL evaluation failures detected"
+              description: "2 CEL evaluation failures occurred in the last 5 minutes in cluster c1"
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-KueueCELEvaluationFailures.md?ref_type=heads
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra
+
+  # 9. TektonKueueRolloutStuck - should fire
+  - interval: 1m
+    input_series:
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
+        values: '2+0x25'
+      - series: 'kube_deployment_status_replicas_updated{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
+        values: '1+0x25'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: TektonKueueRolloutStuck
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: tekton-kueue
+              namespace: tekton-kueue
+              deployment: tekton-kueue-controller-manager
+              source_cluster: c1
+            exp_annotations:
+              summary: "Tekton Kueue rollout stuck: tekton-kueue-controller-manager"
+              description: "Deployment tekton-kueue-controller-manager in namespace tekton-kueue on cluster c1 update is delayed or stuck (no full health for 20m). Check pod events and logs for the deployment and its ReplicaSets."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/alert-TektonKueueRolloutStuck.md
+              alert_routing_key: infra
+              team: konflux-infra
+
+  # TektonKueueRolloutStuck - should NOT fire: replicas updated matches spec
+  - interval: 1m
+    input_series:
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
+        values: '2+0x25'
+      - series: 'kube_deployment_status_replicas_updated{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
+        values: '2+0x25'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: TektonKueueRolloutStuck
+        exp_alerts: []
+
+  # TektonKueueRolloutStuck - should NOT fire: eval time (10m) is less than 'for' duration (20m)
+  - interval: 1m
+    input_series:
+      - series: 'kube_deployment_spec_replicas{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
+        values: '2+0x15'
+      - series: 'kube_deployment_status_replicas_updated{namespace="tekton-kueue", deployment="tekton-kueue-controller-manager", source_cluster="c1"}'
+        values: '1+0x15'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: TektonKueueRolloutStuck
+        exp_alerts: []
+
+  # 10. KueueMutatingWebhookLowSuccessRate - should fire
+  - interval: 1m
+    input_series:
+      - series: 'apiserver_admission_webhook_request_total{name="pipelinerun-kueue-defaulter.tekton-kueue.io", code="200", instance="i1", source_cluster="c1"}'
+        values: '0+10x20'
+      - series: 'apiserver_admission_webhook_request_total{name="pipelinerun-kueue-defaulter.tekton-kueue.io", code="500", instance="i1", source_cluster="c1"}'
+        values: '0+10x20'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: KueueMutatingWebhookLowSuccessRate
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              component: kueue
+              slo: "false"
+              instance: i1
+              source_cluster: c1
+            exp_annotations:
+              summary: "Kueue mutating webhook success rate is below 99%"
+              description: "The mutating webhook 'pipelinerun-kueue-defaulter.tekton-kueue.io' has had a success rate below 99% over the past 10 minutes in cluster c1. Possible causes include webhook errors, rejections, or unreachability (e.g., code=600)."
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md?ref_type=heads
+              alert_routing_key: infra
+              team: konflux-infra
+
+  # 11. KueueClusterQueueNotActive - should fire
+  - interval: 1m
+    input_series:
+      - series: 'kueue_cluster_queue_status{cluster_queue="cluster-pipeline-queue", status="active", source_cluster="c1"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: KueueClusterQueueNotActive
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: kueue
+              slo: "true"
+              status: active
+              source_cluster: c1
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L205
+              summary: "Kueue cluster queue is not active"
+              description: "Cluster queue 'cluster-pipeline-queue' is not in active state in cluster c1"
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md?ref_type=heads
+              alert_team_handle: <!subteam^S05Q1P4Q2TG>
+              team: konflux-infra
+
+  # =========================================================================
+  # Tier A: Standard Clusters (Wait Time Alerts)
+  # =========================================================================
+
+  # 12. KueueAdmissionWaitTimePreMergeTierAWarning - Fire when P95 > 300s (5m) for 15m
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="900.0", source_cluster="c1"}'
@@ -34,7 +388,21 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # 2. KueueAdmissionWaitTimePreMergeTierACritical - Fire when P95 > 1200s (20m) for 15m
+  # KueueAdmissionWaitTimePreMergeTierAWarning - should NOT fire: eval time (10m) is less than 'for' duration (15m)
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="900.0", source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1000.0", source_cluster="c1"}'
+        values: '0+0x60'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="+Inf", source_cluster="c1"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: KueueAdmissionWaitTimePreMergeTierAWarning
+        exp_alerts: []
+
+  # 13. KueueAdmissionWaitTimePreMergeTierACritical - Fire when P95 > 1200s (20m) for 15m
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1200.0", source_cluster="c1"}'
@@ -61,7 +429,7 @@ tests:
               alert_team_handle: <!subteam^S05Q1P4Q2TG>
               team: konflux-infra
 
-  # 3. KueueAdmissionWaitTimePostMergeTierAWarning - Fire when P95 > 1200s (20m) for 20m
+  # 14. KueueAdmissionWaitTimePostMergeTierAWarning - Fire when P95 > 1200s (20m) for 20m
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1200.0", source_cluster="c1"}'
@@ -88,7 +456,21 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # 4. KueueAdmissionWaitTimePostMergeTierACritical - Fire when P95 > 5400s (1.5h) for 15m
+  # KueueAdmissionWaitTimePostMergeTierAWarning - should NOT fire: eval time (15m) is less than 'for' duration (20m)
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1200.0", source_cluster="c1"}'
+        values: '0+0x70'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="1300.0", source_cluster="c1"}'
+        values: '0+0x70'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="+Inf", source_cluster="c1"}'
+        values: '0+10x70'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: KueueAdmissionWaitTimePostMergeTierAWarning
+        exp_alerts: []
+
+  # 15. KueueAdmissionWaitTimePostMergeTierACritical - Fire when P95 > 5400s (1.5h) for 15m
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="5400.0", source_cluster="c1"}'
@@ -116,10 +498,10 @@ tests:
               team: konflux-infra
 
   # =========================================================================
-  # Tier B: Constrained Clusters (e.g. source_cluster="stone-prod-p02")
+  # Tier B: Constrained Clusters (Wait Time Alerts)
   # =========================================================================
 
-  # 5. KueueAdmissionWaitTimePreMergeTierBWarning - Fire when P95 > 1800s (30m) for 15m
+  # 16. KueueAdmissionWaitTimePreMergeTierBWarning - Fire when P95 > 1800s (30m) for 15m
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="1800.0", source_cluster="stone-prod-p02"}'
@@ -146,7 +528,7 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # 6. KueueAdmissionWaitTimePreMergeTierBCritical - Fire when P95 > 5400s (1.5h) for 15m
+  # 17. KueueAdmissionWaitTimePreMergeTierBCritical - Fire when P95 > 5400s (1.5h) for 15m
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-pre-merge-test", le="5400.0", source_cluster="stone-prod-p02"}'
@@ -173,7 +555,7 @@ tests:
               alert_team_handle: <!subteam^S05Q1P4Q2TG>
               team: konflux-infra
 
-  # 7. KueueAdmissionWaitTimePostMergeTierBWarning - Fire when P95 > 7200s (2h) for 30m
+  # 18. KueueAdmissionWaitTimePostMergeTierBWarning - Fire when P95 > 7200s (2h) for 30m
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="7200.0", source_cluster="stone-prd-rh01"}'
@@ -200,7 +582,7 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # 8. KueueAdmissionWaitTimePostMergeTierBCritical - Fire when P95 > 14400s (4h) for 15m
+  # 19. KueueAdmissionWaitTimePostMergeTierBCritical - Fire when P95 > 14400s (4h) for 15m
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-post-merge-build", le="14400.0", source_cluster="stone-prd-rh01"}'
@@ -263,7 +645,7 @@ tests:
   # Other Workload Alerts
   # =========================================================================
 
-  # KueueHighAdmissionWaitTimeMintmaker - should fire
+  # 20. KueueHighAdmissionWaitTimeMintmaker - should fire
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-dependency-update", le="43200.0", source_cluster="c1"}'
@@ -287,7 +669,7 @@ tests:
               alert_routing_key: infra
               team: konflux-infra
 
-  # KueueHighAdmissionWaitTimeReleases - should fire
+  # 21. KueueHighAdmissionWaitTimeReleases - should fire
   - interval: 1m
     input_series:
       - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="4800.0", source_cluster="c1"}'
@@ -311,3 +693,31 @@ tests:
               description: "99th percentile admission wait time for konflux and tenant release workloads is 1h 23m 20s, which is above 1.33 hours in cluster c1"
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue/queue.md
               alert_team_handle: '<!subteam^S06V06A36F5> <!subteam^S05Q1P4Q2TG>'
+
+  # KueueHighAdmissionWaitTimeReleases - should NOT fire: eval time (15m) is less than 'for' duration (20m)
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-tenant-release", le="4800.0", source_cluster="c1"}'
+        values: '0+0x30'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-tenant-release", le="5000.0", source_cluster="c1"}'
+        values: '0+0x30'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-tenant-release", le="+Inf", source_cluster="c1"}'
+        values: '0+10x30'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: KueueHighAdmissionWaitTimeReleases
+        exp_alerts: []
+
+  # KueueHighAdmissionWaitTimeReleases - should NOT fire: wait time below threshold (4800s)
+  - interval: 1m
+    input_series:
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="4000.0", source_cluster="c1"}'
+        values: '0+0x30'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="4800.0", source_cluster="c1"}'
+        values: '0+0x30'
+      - series: 'kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue", priority_class="konflux-release", le="+Inf", source_cluster="c1"}'
+        values: '0+10x30'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: KueueHighAdmissionWaitTimeReleases
+        exp_alerts: []


### PR DESCRIPTION
## Summary
This PR introduces tiered Kueue Admission Wait Time SLO alerts across Konflux clusters to reduce alert noise and accurately distinguish between capacity-constrained clusters and standard healthy ones.

Ref: **SPRE-6556**
https://redhat.atlassian.net/issues?filter=-1&selectedIssue=SPRE-6556
https://redhat-internal.slack.com/archives/C04F4NE15U1/p1787039508402109


## Key Changes
- **Cluster Tiering:** Split clusters into **Tier A** (Standard/Healthy) and **Tier B** (Capacity-constrained: `stone-prod-p02`, `stone-prd-rh01`).
- **Workload Prioritization:** Differentiated thresholds for **PreMerge** (PRs - tighter feedback loops) vs. **PostMerge** (Main/Batch).
- **Threshold Definitions:**
  - **Tier A (PreMerge):** Warning @ 5m | Critical @ 20m
  - **Tier A (PostMerge):** Warning @ 20m | Critical @ 1.5h
  - **Tier B (PreMerge):** Warning @ 30m | Critical @ 1.5h
  - **Tier B (PostMerge):** Warning @ 2h | Critical @ 4h
- **Exclusions:** Mintmaker background scans remain excluded from SLO alerting.
- **Alert Cleanup:** Removed legacy generic wait-time alerts that triggered indiscriminately.

## Verification
- Added PromQL unit test coverage in `test/promql/tests/data_plane/kueue_alerts_test.yaml`.
- Validated via `make check-and-test` (all tests passed locally).