### PR TITLE
SPRE-6729 Fix pod CPU usage alert calculation

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
@@ -70,9 +70,21 @@ spec:
 
     - alert: PodCPUUsageExceedsRequested
       expr: |
-        avg_over_time(container_cpu_usage_seconds_total{namespace="appstudio-grafana"}[5m])
+        sum by (namespace, pod, container, source_cluster) (
+          rate(container_cpu_usage_seconds_total{
+            namespace="appstudio-grafana",
+            container!="",
+            container!="POD"
+          }[5m])
+        )
         > on(namespace, pod, container, source_cluster)
-        kube_pod_container_resource_requests{resource="cpu", namespace="appstudio-grafana"}
+        sum by (namespace, pod, container, source_cluster) (
+          kube_pod_container_resource_requests{
+            resource="cpu",
+            unit="core",
+            namespace="appstudio-grafana"
+          }
+        )
       for: 5m
       labels:
         severity: warning

--- a/test/promql/tests/data_plane/exceeding_requested_resources_test.yaml
+++ b/test/promql/tests/data_plane/exceeding_requested_resources_test.yaml
@@ -9,9 +9,9 @@ tests:
 
       # CPU exceeding requested
       - series: 'container_cpu_usage_seconds_total{namespace="appstudio-grafana", pod="prod-pod-1", container="test-container-1", source_cluster="cluster01"}'
-        values: '2x10'
+        values: '0+120x10'
 
-      - series: 'kube_pod_container_resource_requests{resource="cpu", namespace="appstudio-grafana", pod="prod-pod-1", container="test-container-1", source_cluster="cluster01"}'
+      - series: 'kube_pod_container_resource_requests{resource="cpu", unit="core", namespace="appstudio-grafana", pod="prod-pod-1", container="test-container-1", source_cluster="cluster01"}'
         values: '1x10'
 
     alert_rule_test:
@@ -32,6 +32,20 @@ tests:
               description: >-
                 Pod prod-pod-1 in namespace appstudio-grafana on cluster
                 cluster01 has been running above the requested cpu resources.
+  - interval: 1m
+    input_series:
+
+      # A large cumulative CPU value with usage below the request must not alert.
+      - series: 'container_cpu_usage_seconds_total{namespace="appstudio-grafana", pod="prod-pod-low-cpu", container="test-container", source_cluster="cluster01"}'
+        values: '10000+30x10'
+
+      - series: 'kube_pod_container_resource_requests{resource="cpu", unit="core", namespace="appstudio-grafana", pod="prod-pod-low-cpu", container="test-container", source_cluster="cluster01"}'
+        values: '1x10'
+
+    alert_rule_test:
+      - alertname: PodCPUUsageExceedsRequested
+        eval_time: 10m
+        exp_alerts: []
   - interval: 1m
     input_series:
 


### PR DESCRIPTION
## Summary
- calculate CPU usage with `rate()` instead of averaging a cumulative counter
- aggregate usage and requests using identical labels, excluding empty and `POD` container series
- add tests for CPU usage above and below the requested amount