### PR TITLE
feat(PVO11Y-5476): Enable component-level filtering for per-tenant UX dashboard

### DIFF
--- a/dashboards/grafana-dashboard-konflux-ux-metrics-per-tenant.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ux-metrics-per-tenant.configmap.yaml
@@ -2639,6 +2639,7 @@ data:
           },
           {
             "allValue": ".*",
+            "allowCustomValue": true,
             "current": {
               "text": "All",
               "value": [
@@ -2655,6 +2656,7 @@ data:
           },
           {
             "allValue": ".*",
+            "allowCustomValue": true,
             "current": {
               "text": "All",
               "value": [

--- a/dashboards/grafana-dashboard-konflux-ux-metrics-per-tenant.configmap.yaml
+++ b/dashboards/grafana-dashboard-konflux-ux-metrics-per-tenant.configmap.yaml
@@ -170,7 +170,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 0
+                "y": 1
               },
               "id": 55,
               "options": {
@@ -200,7 +200,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    avg by (source_cluster, application, component) (konflux_build_mean_duration_seconds_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n)",
+                  "expr": "sort_desc(\n    avg by (source_cluster, application, component) (konflux_build_mean_duration_seconds_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n)",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "__auto",
@@ -214,7 +214,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    avg by (source_cluster, application, component) (konflux_build_mean_wait_seconds_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n)",
+                  "expr": "sort_desc(\n    avg by (source_cluster, application, component) (konflux_build_mean_wait_seconds_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n)",
                   "format": "table",
                   "hide": false,
                   "instant": true,
@@ -433,7 +433,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 7
+                "y": 8
               },
               "id": 61,
               "options": {
@@ -463,7 +463,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_build_success_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}) * 0\n    )\n    /\n    sum by (source_cluster, application, component) (konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n)",
+                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_build_success_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}) * 0\n    )\n    /\n    sum by (source_cluster, application, component) (konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n)",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "__auto",
@@ -477,7 +477,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_build_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}) * 0\n    )\n    /\n    sum by (source_cluster, application, component) (konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n)",
+                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_build_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}) * 0\n    )\n    /\n    sum by (source_cluster, application, component) (konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n)",
                   "format": "table",
                   "hide": false,
                   "instant": true,
@@ -492,7 +492,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n  (\n    sum by (source_cluster, application, component) (\n      konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", event_type=~\"retest-comment|retest-all-comment\"}\n    ) \n    or \n    sum by (source_cluster, application, component) (\n      konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}\n    ) * 0\n  )\n  /\n  sum by (source_cluster, application, component) (\n    konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}\n  )\n)",
+                  "expr": "sort_desc(\n  (\n    sum by (source_cluster, application, component) (\n      konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\", event_type=~\"retest-comment|retest-all-comment\"}\n    ) \n    or \n    sum by (source_cluster, application, component) (\n      konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}\n    ) * 0\n  )\n  /\n  sum by (source_cluster, application, component) (\n    konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}\n  )\n)",
                   "format": "table",
                   "hide": false,
                   "instant": true,
@@ -566,6 +566,7 @@ data:
                     },
                     "inspect": false
                   },
+                  "decimals": 0,
                   "mappings": [],
                   "min": 0,
                   "thresholds": {
@@ -576,8 +577,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "short",
-                  "decimals": 0
+                  "unit": "short"
                 },
                 "overrides": [
                   {
@@ -622,7 +622,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 14
+                "y": 15
               },
               "id": 118,
               "options": {
@@ -652,7 +652,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    sum by (source_cluster, application, component) (konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n)",
+                  "expr": "sort_desc(\n    sum by (source_cluster, application, component) (konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n)",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "__auto",
@@ -666,7 +666,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_build_success_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}) * 0\n    )\n)",
+                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_build_success_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}) * 0\n    )\n)",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "__auto",
@@ -680,7 +680,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_build_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}) * 0\n    )\n)",
+                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_build_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_build_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}) * 0\n    )\n)",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "__auto",
@@ -716,9 +716,9 @@ data:
                     "includeByName": {},
                     "indexByName": {
                       "Value": 6,
-                      "source_cluster": 0,
                       "application": 1,
-                      "component": 2
+                      "component": 2,
+                      "source_cluster": 0
                     },
                     "renameByName": {
                       "Value #A": "Total Count",
@@ -743,6 +743,8 @@ data:
                   "color": {
                     "mode": "thresholds"
                   },
+                  "decimals": 0,
+                  "displayName": "${__series.name}",
                   "mappings": [],
                   "min": 0,
                   "thresholds": {
@@ -757,8 +759,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "short",
-                  "decimals": 0
+                  "unit": "short"
                 },
                 "overrides": []
               },
@@ -766,7 +767,7 @@ data:
                 "h": 8,
                 "w": 24,
                 "x": 0,
-                "y": 21
+                "y": 22
               },
               "id": 121,
               "options": {
@@ -801,11 +802,12 @@ data:
                     "uid": "${Datasource}"
                   },
                   "editorMode": "code",
-                  "expr": "topk(5, sum by (reason) (konflux_build_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}))",
-                  "legendFormat": "{{reason}}",
-                  "refId": "A",
+                  "expr": "topk(5, sum by (reason) (konflux_build_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}))",
+                  "format": "time_series",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "{{reason}}",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Top 5 Build Failure Reasons",
@@ -965,7 +967,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 0
+                "y": 2
               },
               "id": 72,
               "options": {
@@ -995,7 +997,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    avg by (source_cluster, application, component, scenario, test_type) (konflux_integration_mean_duration_seconds_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n)",
+                  "expr": "sort_desc(\n    avg by (source_cluster, application, component, scenario, test_type) (konflux_integration_mean_duration_seconds_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n)",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "__auto",
@@ -1009,7 +1011,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    avg by (source_cluster, application, component, scenario, test_type) (konflux_integration_mean_wait_seconds_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n)",
+                  "expr": "sort_desc(\n    avg by (source_cluster, application, component, scenario, test_type) (konflux_integration_mean_wait_seconds_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n)",
                   "format": "table",
                   "hide": false,
                   "instant": true,
@@ -1256,7 +1258,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 7
+                "y": 9
               },
               "id": 73,
               "options": {
@@ -1286,7 +1288,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_success_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n        or \n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}) * 0\n    )\n    /\n    sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n)",
+                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_success_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n        or \n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}) * 0\n    )\n    /\n    sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n)",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "__auto",
@@ -1300,7 +1302,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n        or \n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}) * 0\n    )\n    /\n    sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n)",
+                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n        or \n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}) * 0\n    )\n    /\n    sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n)",
                   "format": "table",
                   "hide": false,
                   "instant": true,
@@ -1315,7 +1317,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n  (\n    sum by (source_cluster, application, component, scenario, test_type) (\n      konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", event_type=~\"retest-comment|retest-all-comment\"}\n    ) \n    or \n    sum by (source_cluster, application, component, scenario, test_type) (\n      konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}\n    ) * 0\n  )\n  /\n  sum by (source_cluster, application, component, scenario, test_type) (\n    konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}\n  )\n)",
+                  "expr": "sort_desc(\n  (\n    sum by (source_cluster, application, component, scenario, test_type) (\n      konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\", event_type=~\"retest-comment|retest-all-comment\"}\n    ) \n    or \n    sum by (source_cluster, application, component, scenario, test_type) (\n      konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}\n    ) * 0\n  )\n  /\n  sum by (source_cluster, application, component, scenario, test_type) (\n    konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}\n  )\n)",
                   "format": "table",
                   "hide": false,
                   "instant": true,
@@ -1392,6 +1394,7 @@ data:
                     },
                     "inspect": false
                   },
+                  "decimals": 0,
                   "mappings": [],
                   "min": 0,
                   "thresholds": {
@@ -1402,8 +1405,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "short",
-                  "decimals": 0
+                  "unit": "short"
                 },
                 "overrides": [
                   {
@@ -1448,7 +1450,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 14
+                "y": 16
               },
               "id": 119,
               "options": {
@@ -1478,7 +1480,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n)",
+                  "expr": "sort_desc(\n    sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n)",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "__auto",
@@ -1492,7 +1494,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_success_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n        or \n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}) * 0\n    )\n)",
+                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_success_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n        or \n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}) * 0\n    )\n)",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "__auto",
@@ -1506,7 +1508,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n        or \n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}) * 0\n    )\n)",
+                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n        or \n        sum by (source_cluster, application, component, scenario, test_type) (konflux_integration_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}) * 0\n    )\n)",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "__auto",
@@ -1544,10 +1546,10 @@ data:
                     "includeByName": {},
                     "indexByName": {
                       "Value": 8,
-                      "source_cluster": 0,
                       "application": 1,
                       "component": 2,
                       "scenario": 3,
+                      "source_cluster": 0,
                       "test_type": 4
                     },
                     "renameByName": {
@@ -1556,8 +1558,8 @@ data:
                       "Value #C": "Failure Count",
                       "application": "Application",
                       "component": "Component",
-                      "source_cluster": "Cluster",
                       "scenario": "Scenario",
+                      "source_cluster": "Cluster",
                       "test_type": "Type"
                     }
                   }
@@ -1575,6 +1577,8 @@ data:
                   "color": {
                     "mode": "thresholds"
                   },
+                  "decimals": 0,
+                  "displayName": "${__series.name}",
                   "mappings": [],
                   "min": 0,
                   "thresholds": {
@@ -1589,8 +1593,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "short",
-                  "decimals": 0
+                  "unit": "short"
                 },
                 "overrides": []
               },
@@ -1598,7 +1601,7 @@ data:
                 "h": 8,
                 "w": 24,
                 "x": 0,
-                "y": 21
+                "y": 23
               },
               "id": 122,
               "options": {
@@ -1633,11 +1636,11 @@ data:
                     "uid": "${Datasource}"
                   },
                   "editorMode": "code",
-                  "expr": "topk(5, sum by (reason) (konflux_integration_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}))",
-                  "legendFormat": "{{reason}}",
-                  "refId": "A",
+                  "expr": "topk(5, sum by (reason) (konflux_integration_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}))",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "{{reason}}",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Top 5 Integration Failure Reasons",
@@ -1773,7 +1776,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 0
+                "y": 3
               },
               "id": 75,
               "options": {
@@ -1803,7 +1806,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    avg by (source_cluster, application, component) (konflux_release_cr_mean_duration_seconds_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n)",
+                  "expr": "sort_desc(\n    avg by (source_cluster, application, component) (konflux_release_cr_mean_duration_seconds_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n)",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "__auto",
@@ -1817,7 +1820,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    avg by (source_cluster, application, component) (konflux_release_cr_mean_wait_seconds_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n)",
+                  "expr": "sort_desc(\n    avg by (source_cluster, application, component) (konflux_release_cr_mean_wait_seconds_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n)",
                   "format": "table",
                   "hide": false,
                   "instant": true,
@@ -2036,7 +2039,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 7
+                "y": 10
               },
               "id": 74,
               "options": {
@@ -2066,7 +2069,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_release_cr_success_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}) * 0\n    )\n    /\n    sum by (source_cluster, application, component) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n)",
+                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_release_cr_success_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}) * 0\n    )\n    /\n    sum by (source_cluster, application, component) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n)",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "__auto",
@@ -2080,7 +2083,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_release_cr_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}) * 0\n    )\n    /\n    sum by (source_cluster, application, component) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n)",
+                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_release_cr_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}) * 0\n    )\n    /\n    sum by (source_cluster, application, component) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n)",
                   "format": "table",
                   "hide": false,
                   "instant": true,
@@ -2095,7 +2098,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n  (\n    sum by (source_cluster, application, component) (\n      konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", event_type=~\"retest-comment|retest-all-comment\"}\n    ) \n    or \n    sum by (source_cluster, application, component) (\n      konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}\n    ) * 0\n  )\n  /\n  sum by (source_cluster, application, component) (\n    konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}\n  )\n)",
+                  "expr": "sort_desc(\n  (\n    sum by (source_cluster, application, component) (\n      konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\", event_type=~\"retest-comment|retest-all-comment\"}\n    ) \n    or \n    sum by (source_cluster, application, component) (\n      konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}\n    ) * 0\n  )\n  /\n  sum by (source_cluster, application, component) (\n    konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}\n  )\n)",
                   "format": "table",
                   "hide": false,
                   "instant": true,
@@ -2169,6 +2172,7 @@ data:
                     },
                     "inspect": false
                   },
+                  "decimals": 0,
                   "mappings": [],
                   "min": 0,
                   "thresholds": {
@@ -2179,8 +2183,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "short",
-                  "decimals": 0
+                  "unit": "short"
                 },
                 "overrides": [
                   {
@@ -2225,7 +2228,7 @@ data:
                 "h": 7,
                 "w": 24,
                 "x": 0,
-                "y": 14
+                "y": 17
               },
               "id": 120,
               "options": {
@@ -2255,7 +2258,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    sum by (source_cluster, application, component) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n)",
+                  "expr": "sort_desc(\n    sum by (source_cluster, application, component) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n)",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "__auto",
@@ -2269,7 +2272,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_release_cr_success_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}) * 0\n    )\n)",
+                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_release_cr_success_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}) * 0\n    )\n)",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "__auto",
@@ -2283,7 +2286,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": false,
-                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_release_cr_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}) * 0\n    )\n)",
+                  "expr": "sort_desc(\n    (\n        sum by (source_cluster, application, component) (konflux_release_cr_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})\n        or \n        sum by (source_cluster, application, component) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}) * 0\n    )\n)",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "__auto",
@@ -2319,9 +2322,9 @@ data:
                     "includeByName": {},
                     "indexByName": {
                       "Value": 6,
-                      "source_cluster": 0,
                       "application": 1,
-                      "component": 2
+                      "component": 2,
+                      "source_cluster": 0
                     },
                     "renameByName": {
                       "Value #A": "Total Count",
@@ -2346,6 +2349,8 @@ data:
                   "color": {
                     "mode": "thresholds"
                   },
+                  "decimals": 0,
+                  "displayName": "${__series.name}",
                   "mappings": [],
                   "min": 0,
                   "thresholds": {
@@ -2360,8 +2365,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "short",
-                  "decimals": 0
+                  "unit": "short"
                 },
                 "overrides": []
               },
@@ -2369,7 +2373,7 @@ data:
                 "h": 8,
                 "w": 24,
                 "x": 0,
-                "y": 21
+                "y": 24
               },
               "id": 123,
               "options": {
@@ -2404,11 +2408,11 @@ data:
                     "uid": "${Datasource}"
                   },
                   "editorMode": "code",
-                  "expr": "topk(5, sum by (reason) (konflux_release_cr_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"}))",
-                  "legendFormat": "{{reason}}",
-                  "refId": "A",
+                  "expr": "topk(5, sum by (reason) (konflux_release_cr_failure_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"}))",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "{{reason}}",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Top 5 Release Failure Reasons",
@@ -2424,6 +2428,7 @@ data:
                   "color": {
                     "mode": "thresholds"
                   },
+                  "decimals": 1,
                   "mappings": [],
                   "thresholds": {
                     "mode": "absolute",
@@ -2433,8 +2438,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "percentunit",
-                  "decimals": 1
+                  "unit": "percentunit"
                 },
                 "overrides": []
               },
@@ -2442,7 +2446,7 @@ data:
                 "h": 6,
                 "w": 12,
                 "x": 0,
-                "y": 29
+                "y": 32
               },
               "id": 124,
               "options": {
@@ -2450,6 +2454,7 @@ data:
                 "graphMode": "area",
                 "justifyMode": "auto",
                 "orientation": "auto",
+                "percentChangeColorMode": "standard",
                 "reduceOptions": {
                   "calcs": [
                     "lastNotNull"
@@ -2457,6 +2462,7 @@ data:
                   "fields": "",
                   "values": false
                 },
+                "showPercentChange": false,
                 "textMode": "auto",
                 "wideLayout": true
               },
@@ -2468,11 +2474,11 @@ data:
                     "uid": "${Datasource}"
                   },
                   "editorMode": "code",
-                  "expr": "sum(\n    konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", automated=\"true\"}\n    or\n    konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"} * 0\n)\n/\nsum(konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})",
-                  "legendFormat": "",
-                  "refId": "A",
+                  "expr": "sum(\n    konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\", automated=\"true\"}\n    or\n    konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"} * 0\n)\n/\nsum(konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Release Automation Adoption %",
@@ -2488,6 +2494,13 @@ data:
                   "color": {
                     "mode": "palette-classic"
                   },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  },
                   "mappings": [],
                   "unit": "short"
                 },
@@ -2497,7 +2510,7 @@ data:
                 "h": 6,
                 "w": 12,
                 "x": 12,
-                "y": 29
+                "y": 32
               },
               "id": 125,
               "options": {
@@ -2533,11 +2546,11 @@ data:
                     "uid": "${Datasource}"
                   },
                   "editorMode": "code",
-                  "expr": "sum by (automated) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\"})",
-                  "legendFormat": "{{automated}}",
-                  "refId": "A",
+                  "expr": "sum by (automated) (konflux_release_cr_total_count_30d{source_cluster=~\"$Cluster\", exported_namespace=~\"${Tenant}\", application=~\"${Application}\", component=~\"${Component}\"})",
                   "instant": true,
-                  "range": false
+                  "legendFormat": "{{automated}}",
+                  "range": false,
+                  "refId": "A"
                 }
               ],
               "title": "Automated vs. Manual Releases",
@@ -2569,7 +2582,9 @@ data:
           {
             "allowCustomValue": false,
             "current": {
-              "text": "All",
+              "text": [
+                "All"
+              ],
               "value": [
                 "$__all"
               ]
@@ -2594,12 +2609,10 @@ data:
             "type": "query"
           },
           {
-            "allowCustomValue": false,
             "allValue": ".*",
+            "allowCustomValue": false,
             "current": {
-              "text": [
-                "All"
-              ],
+              "text": "All",
               "value": [
                 "$__all"
               ]
@@ -2623,6 +2636,38 @@ data:
             "regex": "",
             "sort": 1,
             "type": "query"
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "text": "All",
+              "value": [
+                "$__all"
+              ]
+            },
+            "description": "Filter by Application(s)\n---\nEnter desired application(s) text manually in this box. Fetching all possible values for selection will take too long and has been disabled.",
+            "includeAll": true,
+            "multi": true,
+            "name": "Application",
+            "options": [],
+            "query": "",
+            "type": "custom"
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "text": "All",
+              "value": [
+                "$__all"
+              ]
+            },
+            "description": "Filter by Component(s)\n---\nEnter desired component(s) text manually in this box. Fetching all possible values for selection will take too long and has been disabled.",
+            "includeAll": true,
+            "multi": true,
+            "name": "Component",
+            "options": [],
+            "query": "",
+            "type": "custom"
           }
         ]
       },


### PR DESCRIPTION

### Description

Enabled component-level granularity for filtering in the "Konflux Tenant-Level UX Metrics - Per-Tenant" dashboard:
- Added application and component dashboard variables and included filtering for them in all panels.
- Corrected cases where the "Top 5 Failure Reasons" panel omit the failure reason name if it is displaying a single reason.

Changes can be previewed at https://grafana.stage.devshift.net/d/dfx2k4o2tq800c/konflux-tenant-level-ux-metrics-per-tenant-pacho

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [x] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [x] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [x] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [x] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
