### PR TITLE
Add Codecov configuration (80% patch coverage, informational)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        informational: true
+
+comment: false


### PR DESCRIPTION
## Summary
Add Codecov configuration to enable code coverage tracking for this repository.

## Context
This repo has been identified as a **core production repo for Konflux** to be tracked for code coverage and approved by the repo maintainer or tech-lead.

The configuration is set to **informational mode** (advisory only) with an 80% patch coverage target, meaning:
- Coverage reports will be posted on PRs
- The check will **not block** merges if coverage falls below 80%
- This provides visibility without disrupting current workflows

## Configuration details
- **Patch coverage target**: 80% (informational)
- **Project coverage target**: auto (informational)
- **CI requirement**: disabled (coverage check won't block on CI failures)
- **Comments**: disabled (reduces PR noise)

## Related
- Epic: KFLUXDP-1172
- Rollout plan: https://docs.google.com/document/d/1sD30ZXkDTqkdXY5upXXDhQVJQJHQNEkdxriyekoJFI0/edit