### PR TITLE
Fix misleading RegistryExporterDown alert (PVO11Y-5270)

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
@@ -38,17 +38,9 @@ spec:
     rules:
     - alert: RegistryOutageClusterWide
       expr: |
-        (
-          up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"} == 1
-          AND
-          konflux_up{service="registry-exporter"} != 1
-        )
-        OR
-        (
-          up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"} == 1
-          AND
-          absent(konflux_up{service="registry-exporter"}) == 1
-        )
+        konflux_up{service="registry-exporter"} != 1
+        and on (source_cluster)
+        up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"} == 1
       for: 15m
       labels:
         severity: critical

--- a/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: RegistryExporterDown
       expr: |
-        up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"} == 0
+        max by (source_cluster) (up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"}) == 0
       for: 5m
       labels:
         severity: critical
@@ -24,11 +24,10 @@ spec:
           Registry exporter process is down in cluster {{ $labels.source_cluster }}
         description: >-
           The registry exporter DaemonSet is not running or Prometheus cannot scrape it.
-          Either pods are crashed/evicted or the scrape endpoint is unavailable.
+          Either pods are crashed or the scrape endpoint is unavailable.
           This is an exporter infrastructure issue, NOT a registry issue.
-          Check pod status: kubectl -n appstudio-registry-exporter get pods
-          Check logs: kubectl -n appstudio-registry-exporter logs -l app=registry-exporter
-        alert_team_handle: '<!subteam^S06LGCC3C2V>'
+          Refer to the runbook for troubleshooting steps.
+        alert_team_handle: '<!subteam^S06LGCC3C2V> <!subteam^S079J7LV0KM>'
         team: o11y
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
@@ -40,8 +39,8 @@ spec:
       expr: |
         (konflux_up{service="registry-exporter"} != 1)
         * on (source_cluster) group_left(namespace, job)
-        (up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"} == 1)
-      for: 15m
+        max by (source_cluster, namespace, job) (up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"} == 1)
+      for: 10m
       labels:
         severity: critical
         slo: "true"
@@ -56,8 +55,8 @@ spec:
           Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
           Check registry status page and network connectivity from cluster to registry.
           This is a REGISTRY issue, not an exporter issue.
-        alert_routing_key: spre
-        team: spre
+        alert_team_handle: '<!subteam^S079J7LV0KM> <!subteam^S06LGCC3C2V>'
+        team: o11y
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
   # LEVEL 3: Specific test type failures across all nodes (O11y team - more granular diagnosis)

--- a/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
@@ -6,13 +6,16 @@ metadata:
     tenant: rhtap
 spec:
   groups:
-  - name: registry-exporter-availability
+  # LEVEL 1: Exporter process/infrastructure down (O11y team responsibility)
+  - name: registry-exporter-infrastructure
     interval: 1m
     rules:
     - alert: RegistryExporterDown
       expr: |
-        konflux_up{service="registry-exporter"} != 1
-      for: 15m
+        absent(up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"}) == 1
+        OR
+        up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"} == 0
+      for: 5m
       labels:
         severity: critical
         slo: "true"
@@ -20,15 +23,50 @@ spec:
       annotations:
         html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L12
         summary: >-
-          Registry exporter check failed for registry {{ $labels.check }} in cluster {{ $labels.source_cluster }}
+          Registry exporter process is down in cluster {{ $labels.source_cluster }}
         description: >-
-          The registry exporter has failed to successfully test registry {{ $labels.check }} in cluster {{ $labels.source_cluster }}.
-          All registry test operations (pull, push, metadata, authentication) have been failing for 15 minutes.
+          The registry exporter DaemonSet is not running or Prometheus cannot scrape it.
+          Either pods are crashed/evicted or the scrape endpoint is unavailable.
+          This is an exporter infrastructure issue, NOT a registry issue.
+          Check pod status: kubectl -n appstudio-registry-exporter get pods
+          Check logs: kubectl -n appstudio-registry-exporter logs -l app=registry-exporter
         alert_team_handle: '<!subteam^S06LGCC3C2V>'
         team: o11y
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
-  # Alert when a specific test type (pull, push, metadata, authentication) fails across all nodes.
+  # LEVEL 2: Cluster-wide registry outage (SPRE/registry team responsibility)
+  - name: registry-outage-cluster-wide
+    interval: 1m
+    rules:
+    - alert: RegistryOutageClusterWide
+      expr: |
+        up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"} == 1
+        AND
+        (
+          absent(konflux_up{service="registry-exporter"}) == 1
+          OR
+          konflux_up{service="registry-exporter"} != 1
+        )
+      for: 15m
+      labels:
+        severity: critical
+        slo: "true"
+        component: registry-exporter
+      annotations:
+        html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L33
+        summary: >-
+          Registry {{ $labels.check }} is unreachable from cluster {{ $labels.source_cluster }}
+        description: >-
+          Registry {{ $labels.check }} tests are failing across ALL nodes in cluster {{ $labels.source_cluster }}.
+          The exporter is healthy (up=1) but all registry operations are failing.
+          Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
+          Check registry status page and network connectivity from cluster to registry.
+          This is a REGISTRY issue, not an exporter issue.
+        alert_routing_key: spre
+        team: spre
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
+
+  # LEVEL 3: Specific test type failures across all nodes (O11y team - more granular diagnosis)
   - name: registry-exporter-test-type-availability
     interval: 1m
     rules:
@@ -53,7 +91,7 @@ spec:
         alert_routing_key: o11y
         team: o11y
 
-  # Notify o11y team when a significant percentage of nodes are failing, but cluster-level check is still passing.
+  # LEVEL 4: Partial node failures (O11y team - detect degraded state before full outage)
   - name: registry-exporter-node-availability
     interval: 1m
     rules:

--- a/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
@@ -6,7 +6,6 @@ metadata:
     tenant: rhtap
 spec:
   groups:
-  # LEVEL 1: Exporter process/infrastructure down (O11y team responsibility)
   - name: registry-exporter-infrastructure
     interval: 1m
     rules:
@@ -31,7 +30,6 @@ spec:
         team: o11y
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
-  # LEVEL 2: Cluster-wide registry outage (SPRE/registry team responsibility)
   - name: registry-outage-cluster-wide
     interval: 1m
     rules:
@@ -52,9 +50,8 @@ spec:
         description: >-
           Registry {{ $labels.check }} tests are failing across ALL nodes in cluster {{ $labels.source_cluster }}.
           The exporter is healthy (up=1) but all registry operations are failing.
-          Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
-          Check registry status page and network connectivity from cluster to registry.
           This is a REGISTRY issue, not an exporter issue.
+          Refer to the runbook for troubleshooting steps.
         alert_team_handle: '<!subteam^S079J7LV0KM> <!subteam^S06LGCC3C2V>'
         team: o11y
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md

--- a/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
@@ -38,12 +38,16 @@ spec:
     rules:
     - alert: RegistryOutageClusterWide
       expr: |
-        up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"} == 1
-        AND
         (
-          absent(konflux_up{service="registry-exporter"}) == 1
-          OR
+          up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"} == 1
+          AND
           konflux_up{service="registry-exporter"} != 1
+        )
+        OR
+        (
+          up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"} == 1
+          AND
+          absent(konflux_up{service="registry-exporter"}) == 1
         )
       for: 15m
       labels:

--- a/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
@@ -56,7 +56,6 @@ spec:
         team: o11y
         runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
-  # LEVEL 3: Specific test type failures across all nodes (O11y team - more granular diagnosis)
   - name: registry-exporter-test-type-availability
     interval: 1m
     rules:
@@ -81,7 +80,6 @@ spec:
         alert_routing_key: o11y
         team: o11y
 
-  # LEVEL 4: Partial node failures (O11y team - detect degraded state before full outage)
   - name: registry-exporter-node-availability
     interval: 1m
     rules:

--- a/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
@@ -38,9 +38,9 @@ spec:
     rules:
     - alert: RegistryOutageClusterWide
       expr: |
-        konflux_up{service="registry-exporter"} != 1
-        and on (source_cluster)
-        up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"} == 1
+        (konflux_up{service="registry-exporter"} != 1)
+        * on (source_cluster) group_left(namespace, job)
+        (up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"} == 1)
       for: 15m
       labels:
         severity: critical

--- a/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml
@@ -12,8 +12,6 @@ spec:
     rules:
     - alert: RegistryExporterDown
       expr: |
-        absent(up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"}) == 1
-        OR
         up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor"} == 0
       for: 5m
       labels:

--- a/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
+++ b/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
@@ -77,6 +77,18 @@ tests:
               source_cluster: c1
               slo: "true"
               component: registry-exporter
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L12
+              summary: >-
+                Registry exporter process is down in cluster c1
+              description: >-
+                The registry exporter DaemonSet is not running or Prometheus cannot scrape it.
+                Either pods are crashed or the scrape endpoint is unavailable.
+                This is an exporter infrastructure issue, NOT a registry issue.
+                Refer to the runbook for troubleshooting steps.
+              alert_team_handle: <!subteam^S06LGCC3C2V> <!subteam^S079J7LV0KM>
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
   # Test 5: DaemonSet - Some pods down but at least ONE is up - should NOT alert
   - interval: 1m

--- a/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
+++ b/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
@@ -39,33 +39,7 @@ tests:
               team: o11y
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
-  # Test 2: Exporter metric missing (absent) - SHOULD alert at 5m
-  - interval: 1m
-    input_series: []
-
-    alert_rule_test:
-      - eval_time: 5m
-        alertname: RegistryExporterDown
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-              slo: "true"
-              component: registry-exporter
-            exp_annotations:
-              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L12
-              summary: >-
-                Registry exporter process is down in cluster
-              description: >-
-                The registry exporter DaemonSet is not running or Prometheus cannot scrape it.
-                Either pods are crashed/evicted or the scrape endpoint is unavailable.
-                This is an exporter infrastructure issue, NOT a registry issue.
-                Check pod status: kubectl -n appstudio-registry-exporter get pods
-                Check logs: kubectl -n appstudio-registry-exporter logs -l app=registry-exporter
-              alert_team_handle: <!subteam^S06LGCC3C2V>
-              team: o11y
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
-
-  # Test 3: Exporter healthy (up=1) - should NOT alert
+  # Test 2: Exporter healthy (up=1) - should NOT alert
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
@@ -76,7 +50,7 @@ tests:
         alertname: RegistryExporterDown
         exp_alerts: []
 
-  # Test 4: Exporter recovers before 5m - should NOT alert
+  # Test 3: Exporter recovers before 5m - should NOT alert
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'

--- a/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
+++ b/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
@@ -155,12 +155,20 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: critical
+              namespace: appstudio-registry-exporter
+              job: appstudio-registry-exporter/registry-exporter-ds-podmonitor
+              service: registry-exporter
               check: quay.io
+              source_cluster: c1
               slo: "true"
               component: registry-exporter
           - exp_labels:
               severity: critical
+              namespace: appstudio-registry-exporter
+              job: appstudio-registry-exporter/registry-exporter-ds-podmonitor
+              service: registry-exporter
               check: registry.example.com
+              source_cluster: c1
               slo: "true"
               component: registry-exporter
 

--- a/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
+++ b/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
@@ -100,24 +100,6 @@ tests:
               team: spre
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
-  # Test 6: Registry metric missing but exporter healthy - SHOULD alert at 15m
-  - interval: 1m
-    input_series:
-      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
-        values: "1x16"
-
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: RegistryOutageClusterWide
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-              namespace: appstudio-registry-exporter
-              job: appstudio-registry-exporter/registry-exporter-ds-podmonitor
-              source_cluster: c1
-              slo: "true"
-              component: registry-exporter
-
   # Test 7: Registry healthy and exporter healthy - should NOT alert
   - interval: 1m
     input_series:

--- a/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
+++ b/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
@@ -4,149 +4,215 @@ rule_files:
   - prometheus.registry_exporter_alerts.yaml
 
 tests:
-  # Registry exporter down for quay.io registry
+  # ============================================================================
+  # LEVEL 1: RegistryExporterDown (exporter process/infrastructure failures)
+  # ============================================================================
+
+  # Test 1: Exporter process is down (up=0) - SHOULD alert at 5m
   - interval: 1m
     input_series:
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c2"}'
-        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
+        values: "0 0 0 0 0 0 0 0 0 0"
 
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 5m
         alertname: RegistryExporterDown
         exp_alerts:
           - exp_labels:
               severity: critical
-              check: quay.io
-              service: registry-exporter
-              slo: "true"
+              namespace: appstudio-registry-exporter
+              job: appstudio-registry-exporter/registry-exporter-ds-podmonitor
               source_cluster: c1
+              slo: "true"
               component: registry-exporter
             exp_annotations:
               html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L12
               summary: >-
-                Registry exporter check failed for registry quay.io in cluster c1
+                Registry exporter process is down in cluster c1
               description: >-
-                The registry exporter has failed to successfully test registry quay.io in cluster c1.
-                All registry test operations (pull, push, metadata, authentication) have been failing for 15 minutes.
+                The registry exporter DaemonSet is not running or Prometheus cannot scrape it.
+                Either pods are crashed/evicted or the scrape endpoint is unavailable.
+                This is an exporter infrastructure issue, NOT a registry issue.
+                Check pod status: kubectl -n appstudio-registry-exporter get pods
+                Check logs: kubectl -n appstudio-registry-exporter logs -l app=registry-exporter
               alert_team_handle: <!subteam^S06LGCC3C2V>
               team: o11y
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
-  # Registry exporter down for multiple registries in same cluster
+  # Test 2: Exporter metric missing (absent) - SHOULD alert at 5m
+  - interval: 1m
+    input_series: []
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: RegistryExporterDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo: "true"
+              component: registry-exporter
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L12
+              summary: >-
+                Registry exporter process is down in cluster
+              description: >-
+                The registry exporter DaemonSet is not running or Prometheus cannot scrape it.
+                Either pods are crashed/evicted or the scrape endpoint is unavailable.
+                This is an exporter infrastructure issue, NOT a registry issue.
+                Check pod status: kubectl -n appstudio-registry-exporter get pods
+                Check logs: kubectl -n appstudio-registry-exporter logs -l app=registry-exporter
+              alert_team_handle: <!subteam^S06LGCC3C2V>
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
+
+  # Test 3: Exporter healthy (up=1) - should NOT alert
   - interval: 1m
     input_series:
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
+        values: "1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: RegistryExporterDown
+        exp_alerts: []
+
+  # Test 4: Exporter recovers before 5m - should NOT alert
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
+        values: "0 0 0 0 1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: RegistryExporterDown
+        exp_alerts: []
+
+  # ============================================================================
+  # LEVEL 2: RegistryOutageClusterWide (registry down, exporter healthy)
+  # ============================================================================
+
+  # Test 5: Registry down but exporter healthy - SHOULD alert at 15m
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
+        values: "1x16"
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
+        values: "0x16"
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RegistryOutageClusterWide
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              namespace: appstudio-registry-exporter
+              job: appstudio-registry-exporter/registry-exporter-ds-podmonitor
+              service: registry-exporter
+              check: quay.io
+              source_cluster: c1
+              slo: "true"
+              component: registry-exporter
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L33
+              summary: >-
+                Registry quay.io is unreachable from cluster c1
+              description: >-
+                Registry quay.io tests are failing across ALL nodes in cluster c1.
+                The exporter is healthy (up=1) but all registry operations are failing.
+                Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
+                Check registry status page and network connectivity from cluster to registry.
+                This is a REGISTRY issue, not an exporter issue.
+              alert_routing_key: spre
+              team: spre
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
+
+  # Test 6: Registry metric missing but exporter healthy - SHOULD alert at 15m
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
+        values: "1x16"
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RegistryOutageClusterWide
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              namespace: appstudio-registry-exporter
+              job: appstudio-registry-exporter/registry-exporter-ds-podmonitor
+              source_cluster: c1
+              slo: "true"
+              component: registry-exporter
+
+  # Test 7: Registry healthy and exporter healthy - should NOT alert
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "1x16"
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RegistryOutageClusterWide
+        exp_alerts: []
+
+  # Test 8: Registry recovers before 15m - should NOT alert
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1"
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RegistryOutageClusterWide
+        exp_alerts: []
+
+  # Test 9: Exporter down - registry alert should NOT fire (covered by RegistryExporterDown)
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
+        values: "0x16"
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "0x16"
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RegistryOutageClusterWide
+        exp_alerts: []
+
+  # Test 10: Multiple registries down - should alert for each
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
+        values: "1x16"
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "0x16"
       - series: 'konflux_up{service="registry-exporter", check="registry.example.com", source_cluster="c1"}'
-        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c2"}'
-        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+        values: "0x16"
 
     alert_rule_test:
       - eval_time: 15m
-        alertname: RegistryExporterDown
+        alertname: RegistryOutageClusterWide
         exp_alerts:
           - exp_labels:
               severity: critical
               check: quay.io
-              service: registry-exporter
               slo: "true"
-              source_cluster: c1
               component: registry-exporter
-            exp_annotations:
-              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L12
-              summary: >-
-                Registry exporter check failed for registry quay.io in cluster c1
-              description: >-
-                The registry exporter has failed to successfully test registry quay.io in cluster c1.
-                All registry test operations (pull, push, metadata, authentication) have been failing for 15 minutes.
-              alert_team_handle: <!subteam^S06LGCC3C2V>
-              team: o11y
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
           - exp_labels:
               severity: critical
               check: registry.example.com
-              service: registry-exporter
               slo: "true"
-              source_cluster: c1
               component: registry-exporter
-            exp_annotations:
-              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L12
-              summary: >-
-                Registry exporter check failed for registry registry.example.com in cluster c1
-              description: >-
-                The registry exporter has failed to successfully test registry registry.example.com in cluster c1.
-                All registry test operations (pull, push, metadata, authentication) have been failing for 15 minutes.
-              alert_team_handle: <!subteam^S06LGCC3C2V>
-              team: o11y
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
-  # Registry exporter recovers before alert fires (should not alert)
-  - interval: 1m
-    input_series:
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1"
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c2"}'
-        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+  # ============================================================================
+  # LEVEL 3: RegistryExporterTestTypeFailure (specific test types failing)
+  # ============================================================================
 
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: RegistryExporterDown
-        exp_alerts: []
-
-  # Registry exporter down for different registries in different clusters
-  - interval: 1m
-    input_series:
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
-      - series: 'konflux_up{service="registry-exporter", check="registry.example.com", source_cluster="c2"}'
-        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c2"}'
-        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
-
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: RegistryExporterDown
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-              check: quay.io
-              service: registry-exporter
-              slo: "true"
-              source_cluster: c1
-              component: registry-exporter
-            exp_annotations:
-              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L12
-              summary: >-
-                Registry exporter check failed for registry quay.io in cluster c1
-              description: >-
-                The registry exporter has failed to successfully test registry quay.io in cluster c1.
-                All registry test operations (pull, push, metadata, authentication) have been failing for 15 minutes.
-              alert_team_handle: <!subteam^S06LGCC3C2V>
-              team: o11y
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
-          - exp_labels:
-              severity: critical
-              check: registry.example.com
-              service: registry-exporter
-              slo: "true"
-              source_cluster: c2
-              component: registry-exporter
-            exp_annotations:
-              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L12
-              summary: >-
-                Registry exporter check failed for registry registry.example.com in cluster c2
-              description: >-
-                The registry exporter has failed to successfully test registry registry.example.com in cluster c2.
-                All registry test operations (pull, push, metadata, authentication) have been failing for 15 minutes.
-              alert_team_handle: <!subteam^S06LGCC3C2V>
-              team: o11y
-              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
-
-  # Registry exporter test-type failure tests
-  # Single test type failing on all nodes (should alert for that type)
+  # Test 11: Single test type failing on all nodes - SHOULD alert
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
@@ -179,7 +245,7 @@ tests:
               alert_routing_key: o11y
               team: o11y
 
-  # Test type failing on some nodes but passing on others (should NOT alert)
+  # Test 12: Test type failing on some nodes but passing on others - should NOT alert
   - interval: 1m
     input_series:
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
@@ -192,169 +258,11 @@ tests:
         alertname: RegistryExporterTestTypeFailure
         exp_alerts: []
 
-  # Test type recovers before 15 minutes (should NOT alert)
-  - interval: 1m
-    input_series:
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="metadata", source_cluster="c1"}'
-        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="metadata", source_cluster="c1"}'
-        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1"
+  # ============================================================================
+  # LEVEL 4: RegistryExporterNodeFailure (>50% nodes failing)
+  # ============================================================================
 
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: RegistryExporterTestTypeFailure
-        exp_alerts: []
-
-  # Multiple test types failing across all nodes (should alert for each type)
-  - interval: 1m
-    input_series:
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="authentication", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="authentication", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
-        values: "1x16"
-
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: RegistryExporterTestTypeFailure
-        exp_alerts:
-          - exp_labels:
-              severity: high
-              tested_registry: quay.io
-              type: authentication
-              source_cluster: c1
-              slo: "false"
-              component: registry-exporter
-            exp_annotations:
-              summary: >-
-                Test for authentication failing across all nodes for quay.io in c1
-              description: >-
-                Tests for authentication for quay.io in c1 is failing for 15 minutes.
-              alert_routing_key: o11y
-              team: o11y
-          - exp_labels:
-              severity: high
-              tested_registry: quay.io
-              type: push
-              source_cluster: c1
-              slo: "false"
-              component: registry-exporter
-            exp_annotations:
-              summary: >-
-                Test for push failing across all nodes for quay.io in c1
-              description: >-
-                Tests for push for quay.io in c1 is failing for 15 minutes.
-              alert_routing_key: o11y
-              team: o11y
-
-  # Test type failure isolated to one registry (should only alert for that registry)
-  - interval: 1m
-    input_series:
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'konflux_up{service="registry-exporter", check="registry.example.com", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="registry.example.com", node="node1", type="pull", source_cluster="c1"}'
-        values: "1x16"
-
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: RegistryExporterTestTypeFailure
-        exp_alerts:
-          - exp_labels:
-              severity: high
-              tested_registry: quay.io
-              type: pull
-              source_cluster: c1
-              slo: "false"
-              component: registry-exporter
-            exp_annotations:
-              summary: >-
-                Test for pull failing across all nodes for quay.io in c1
-              description: >-
-                Tests for pull for quay.io in c1 is failing for 15 minutes.
-              alert_routing_key: o11y
-              team: o11y
-
-  # Test type failure suppressed when cluster check is down (should NOT alert - covered by RegistryExporterDown)
-  - interval: 1m
-    input_series:
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
-        values: "0x16"
-
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: RegistryExporterTestTypeFailure
-        exp_alerts: []
-
-  # Combined test: push fails cluster-wide — TestTypeFailure fires at 15m, NodeFailure suppressed at 15m
-  - interval: 1m
-    input_series:
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="metadata", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="metadata", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="authentication", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="authentication", source_cluster="c1"}'
-        values: "1x16"
-
-    alert_rule_test:
-      # TestTypeFailure fires at 15m for push
-      - eval_time: 15m
-        alertname: RegistryExporterTestTypeFailure
-        exp_alerts:
-          - exp_labels:
-              severity: high
-              tested_registry: quay.io
-              type: push
-              source_cluster: c1
-              slo: "false"
-              component: registry-exporter
-            exp_annotations:
-              summary: >-
-                Test for push failing across all nodes for quay.io in c1
-              description: >-
-                Tests for push for quay.io in c1 is failing for 15 minutes.
-              alert_routing_key: o11y
-              team: o11y
-      # NodeFailure does NOT fire at 15m — suppressed by the unless clause
-      - eval_time: 15m
-        alertname: RegistryExporterNodeFailure
-        exp_alerts: []
-
-  # Registry exporter node percentage alert tests
-
-  # >50% of nodes failing (2 of 3 = 66.67%) - SHOULD alert
+  # Test 13: >50% of nodes failing (2 of 3 = 66.67%) - SHOULD alert
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
@@ -387,141 +295,11 @@ tests:
               alert_routing_key: o11y
               team: o11y
 
-  # Exactly 50% of nodes failing (1 of 2) - should NOT alert (threshold is strictly >50%, tolerates single-node rolling update)
+  # Test 14: Exactly 50% of nodes failing (1 of 2) - should NOT alert
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
         values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
-        values: "1x16"
-
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: RegistryExporterNodeFailure
-        exp_alerts: []
-
-  # All node failures are cluster-wide type failures - should NOT alert (covered by RegistryExporterTestTypeFailure)
-  - interval: 1m
-    input_series:
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
-        values: "1x16"
-
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: RegistryExporterNodeFailure
-        exp_alerts: []
-
-  # Cluster check is down - should NOT alert (covered by RegistryExporterDown)
-  - interval: 1m
-    input_series:
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node3", type="pull", source_cluster="c1"}'
-        values: "0x16"
-
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: RegistryExporterNodeFailure
-        exp_alerts: []
-
-  # Nodes recover before 15 minutes - should NOT alert
-  - interval: 1m
-    input_series:
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
-        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node3", type="pull", source_cluster="c1"}'
-        values: "1x16"
-
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: RegistryExporterNodeFailure
-        exp_alerts: []
-
-  # >50% nodes failing across multiple registries - each alerts independently
-  - interval: 1m
-    input_series:
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'konflux_up{service="registry-exporter", check="registry.example.com", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node3", type="pull", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="registry.example.com", node="node1", type="pull", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="registry.example.com", node="node2", type="pull", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="registry.example.com", node="node3", type="pull", source_cluster="c1"}'
-        values: "1x16"
-
-    alert_rule_test:
-      - eval_time: 15m
-        alertname: RegistryExporterNodeFailure
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              tested_registry: quay.io
-              source_cluster: c1
-              slo: "false"
-              component: registry-exporter
-            exp_annotations:
-              summary: >-
-                Over 50% of registry exporter nodes in cluster c1 are failing tests for registry quay.io.
-              description: >-
-                66.67% of registry exporter nodes in cluster c1 are failing tests for registry quay.io.
-                Over 50% of nodes have had at least one failing test type (pull, push, metadata, or authentication); this condition has persisted for 15 minutes.
-                The cluster-level check is still passing, indicating this is not a total outage.
-                Single-node failures from rolling node replacements will not trigger this alert.
-              alert_routing_key: o11y
-              team: o11y
-          - exp_labels:
-              severity: warning
-              tested_registry: registry.example.com
-              source_cluster: c1
-              slo: "false"
-              component: registry-exporter
-            exp_annotations:
-              summary: >-
-                Over 50% of registry exporter nodes in cluster c1 are failing tests for registry registry.example.com.
-              description: >-
-                66.67% of registry exporter nodes in cluster c1 are failing tests for registry registry.example.com.
-                Over 50% of nodes have had at least one failing test type (pull, push, metadata, or authentication); this condition has persisted for 15 minutes.
-                The cluster-level check is still passing, indicating this is not a total outage.
-                Single-node failures from rolling node replacements will not trigger this alert.
-              alert_routing_key: o11y
-              team: o11y
-
-  # Push fails cluster-wide + pull fails on 1 of 2 nodes (50%) - NodeFailure should NOT alert
-  # (push excluded by unless clause; remaining pull failure is only 1/2 = 50%, not >50%)
-  - interval: 1m
-    input_series:
-      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "1x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
-        values: "0x16"
-      - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="push", source_cluster="c1"}'
-        values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="pull", source_cluster="c1"}'
         values: "0x16"
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node2", type="pull", source_cluster="c1"}'

--- a/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
+++ b/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
@@ -31,11 +31,10 @@ tests:
                 Registry exporter process is down in cluster c1
               description: >-
                 The registry exporter DaemonSet is not running or Prometheus cannot scrape it.
-                Either pods are crashed/evicted or the scrape endpoint is unavailable.
+                Either pods are crashed or the scrape endpoint is unavailable.
                 This is an exporter infrastructure issue, NOT a registry issue.
-                Check pod status: kubectl -n appstudio-registry-exporter get pods
-                Check logs: kubectl -n appstudio-registry-exporter logs -l app=registry-exporter
-              alert_team_handle: <!subteam^S06LGCC3C2V>
+                Refer to the runbook for troubleshooting steps.
+              alert_team_handle: <!subteam^S06LGCC3C2V> <!subteam^S079J7LV0KM>
               team: o11y
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
@@ -61,20 +60,70 @@ tests:
         alertname: RegistryExporterDown
         exp_alerts: []
 
+  # Test 4: DaemonSet - ALL pods down across multiple nodes - SHOULD alert at 5m
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node1"}'
+        values: "0 0 0 0 0 0 0 0 0 0"
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node2"}'
+        values: "0 0 0 0 0 0 0 0 0 0"
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node3"}'
+        values: "0 0 0 0 0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: RegistryExporterDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              source_cluster: c1
+              slo: "true"
+              component: registry-exporter
+
+  # Test 5: DaemonSet - Some pods down but at least ONE is up - should NOT alert
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node1"}'
+        values: "0 0 0 0 0 0 0 0 0 0"
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node2"}'
+        values: "1 1 1 1 1 1 1 1 1 1"
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node3"}'
+        values: "0 0 0 0 0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: RegistryExporterDown
+        exp_alerts: []
+
+  # Test 6: DaemonSet - Rolling restart (pods restarting one by one) - should NOT alert
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node1"}'
+        values: "1 1 0 0 1 1 1 1 1 1"
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node2"}'
+        values: "1 1 1 1 0 0 1 1 1 1"
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node3"}'
+        values: "1 1 1 1 1 1 0 0 1 1"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: RegistryExporterDown
+        exp_alerts: []
+
   # ============================================================================
   # LEVEL 2: RegistryOutageClusterWide (registry down, exporter healthy)
   # ============================================================================
 
-  # Test 5: Registry down but exporter healthy - SHOULD alert at 15m
+  # Test 7: Registry down but exporter healthy - SHOULD alert at 10m
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
-        values: "1x16"
+        values: "1x12"
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "0x16"
+        values: "0x12"
 
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 10m
         alertname: RegistryOutageClusterWide
         exp_alerts:
           - exp_labels:
@@ -96,61 +145,113 @@ tests:
                 Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
                 Check registry status page and network connectivity from cluster to registry.
                 This is a REGISTRY issue, not an exporter issue.
-              alert_routing_key: spre
-              team: spre
+              alert_team_handle: <!subteam^S079J7LV0KM> <!subteam^S06LGCC3C2V>
+              team: o11y
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
-  # Test 7: Registry healthy and exporter healthy - should NOT alert
+  # Test 8: Registry healthy and exporter healthy - should NOT alert
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
-        values: "1x16"
+        values: "1x12"
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "1x16"
+        values: "1x12"
 
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 10m
         alertname: RegistryOutageClusterWide
         exp_alerts: []
 
-  # Test 8: Registry recovers before 15m - should NOT alert
+  # Test 9: Registry recovers before 10m - should NOT alert
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
-        values: "1x16"
+        values: "1x12"
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1"
+        values: "0 0 0 0 0 0 0 0 0 1 1 1"
 
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 10m
         alertname: RegistryOutageClusterWide
         exp_alerts: []
 
-  # Test 9: Exporter down - registry alert should NOT fire (covered by RegistryExporterDown)
+  # Test 10: Exporter down - registry alert should NOT fire (covered by RegistryExporterDown)
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
-        values: "0x16"
+        values: "0x12"
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "0x16"
+        values: "0x12"
 
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 10m
         alertname: RegistryOutageClusterWide
         exp_alerts: []
 
-  # Test 10: Multiple registries down - should alert for each
+  # Test 11: DaemonSet - Multiple pods, registry down, all exporters up - SHOULD alert at 10m
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node1"}'
+        values: "1x12"
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node2"}'
+        values: "1x12"
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node3"}'
+        values: "1x12"
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "0x12"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: RegistryOutageClusterWide
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              namespace: appstudio-registry-exporter
+              job: appstudio-registry-exporter/registry-exporter-ds-podmonitor
+              service: registry-exporter
+              check: quay.io
+              source_cluster: c1
+              slo: "true"
+              component: registry-exporter
+
+  # Test 12: DaemonSet - Some pods down, but at least ONE exporter up and registry down - SHOULD alert at 10m
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node1"}'
+        values: "0x12"
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node2"}'
+        values: "1x12"
+      - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node3"}'
+        values: "0x12"
+      - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
+        values: "0x12"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: RegistryOutageClusterWide
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              namespace: appstudio-registry-exporter
+              job: appstudio-registry-exporter/registry-exporter-ds-podmonitor
+              service: registry-exporter
+              check: quay.io
+              source_cluster: c1
+              slo: "true"
+              component: registry-exporter
+
+  # Test 13: Multiple registries down - should alert for each
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
-        values: "1x16"
+        values: "1x12"
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
-        values: "0x16"
+        values: "0x12"
       - series: 'konflux_up{service="registry-exporter", check="registry.example.com", source_cluster="c1"}'
-        values: "0x16"
+        values: "0x12"
 
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 10m
         alertname: RegistryOutageClusterWide
         exp_alerts:
           - exp_labels:
@@ -172,8 +273,8 @@ tests:
                 Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
                 Check registry status page and network connectivity from cluster to registry.
                 This is a REGISTRY issue, not an exporter issue.
-              alert_routing_key: spre
-              team: spre
+              alert_team_handle: <!subteam^S079J7LV0KM> <!subteam^S06LGCC3C2V>
+              team: o11y
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
           - exp_labels:
               severity: critical
@@ -194,8 +295,8 @@ tests:
                 Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
                 Check registry status page and network connectivity from cluster to registry.
                 This is a REGISTRY issue, not an exporter issue.
-              alert_routing_key: spre
-              team: spre
+              alert_team_handle: <!subteam^S079J7LV0KM> <!subteam^S06LGCC3C2V>
+              team: o11y
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
   # ============================================================================

--- a/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
+++ b/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
@@ -4,11 +4,9 @@ rule_files:
   - prometheus.registry_exporter_alerts.yaml
 
 tests:
-  # ============================================================================
-  # LEVEL 1: RegistryExporterDown (exporter process/infrastructure failures)
-  # ============================================================================
+  # RegistryExporterDown tests
 
-  # Test 1: Exporter process is down (up=0) - SHOULD alert at 5m
+  # Exporter process is down (up=0) - SHOULD alert at 5m
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
@@ -36,7 +34,7 @@ tests:
               team: o11y
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
-  # Test 2: Exporter healthy (up=1) - should NOT alert
+  # Exporter healthy (up=1) - should NOT alert
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
@@ -47,7 +45,7 @@ tests:
         alertname: RegistryExporterDown
         exp_alerts: []
 
-  # Test 3: Exporter recovers before 5m - should NOT alert
+  # Exporter recovers before 5m - should NOT alert
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
@@ -58,7 +56,7 @@ tests:
         alertname: RegistryExporterDown
         exp_alerts: []
 
-  # Test 4: DaemonSet - ALL pods down across multiple nodes - SHOULD alert at 5m
+  # DaemonSet - ALL pods down across multiple nodes - SHOULD alert at 5m
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node1"}'
@@ -90,7 +88,7 @@ tests:
               team: o11y
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
-  # Test 5: DaemonSet - Some pods down but at least ONE is up - should NOT alert
+  #  DaemonSet - Some pods down but at least ONE is up - should NOT alert
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node1"}'
@@ -105,7 +103,7 @@ tests:
         alertname: RegistryExporterDown
         exp_alerts: []
 
-  # Test 6: DaemonSet - Rolling restart (pods restarting one by one) - should NOT alert
+  #  DaemonSet - Rolling restart (pods restarting one by one) - should NOT alert
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node1"}'
@@ -120,11 +118,9 @@ tests:
         alertname: RegistryExporterDown
         exp_alerts: []
 
-  # ============================================================================
-  # LEVEL 2: RegistryOutageClusterWide (registry down, exporter healthy)
-  # ============================================================================
+  # RegistryOutageClusterWide tests
 
-  # Test 7: Registry down but exporter healthy - SHOULD alert at 10m
+  # Registry down but exporter healthy - SHOULD alert at 10m
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
@@ -152,14 +148,13 @@ tests:
               description: >-
                 Registry quay.io tests are failing across ALL nodes in cluster c1.
                 The exporter is healthy (up=1) but all registry operations are failing.
-                Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
-                Check registry status page and network connectivity from cluster to registry.
                 This is a REGISTRY issue, not an exporter issue.
+                Refer to the runbook for troubleshooting steps.
               alert_team_handle: <!subteam^S079J7LV0KM> <!subteam^S06LGCC3C2V>
               team: o11y
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
-  # Test 8: Registry healthy and exporter healthy - should NOT alert
+  #  Registry healthy and exporter healthy - should NOT alert
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
@@ -172,7 +167,7 @@ tests:
         alertname: RegistryOutageClusterWide
         exp_alerts: []
 
-  # Test 9: Registry recovers before 10m - should NOT alert
+  #  Registry recovers before 10m - should NOT alert
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
@@ -185,7 +180,7 @@ tests:
         alertname: RegistryOutageClusterWide
         exp_alerts: []
 
-  # Test 10: Exporter down - registry alert should NOT fire (covered by RegistryExporterDown)
+  #  Exporter down - registry alert should NOT fire (covered by RegistryExporterDown)
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
@@ -198,7 +193,7 @@ tests:
         alertname: RegistryOutageClusterWide
         exp_alerts: []
 
-  # Test 11: DaemonSet - Multiple pods, registry down, all exporters up - SHOULD alert at 10m
+  #  DaemonSet - Multiple pods, registry down, all exporters up - SHOULD alert at 10m
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node1"}'
@@ -230,14 +225,13 @@ tests:
               description: >-
                 Registry quay.io tests are failing across ALL nodes in cluster c1.
                 The exporter is healthy (up=1) but all registry operations are failing.
-                Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
-                Check registry status page and network connectivity from cluster to registry.
                 This is a REGISTRY issue, not an exporter issue.
+                Refer to the runbook for troubleshooting steps.
               alert_team_handle: <!subteam^S079J7LV0KM> <!subteam^S06LGCC3C2V>
               team: o11y
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
-  # Test 12: DaemonSet - Some pods down, but at least ONE exporter up and registry down - SHOULD alert at 10m
+  #  DaemonSet - Some pods down, but at least ONE exporter up and registry down - SHOULD alert at 10m
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1", pod="exporter-node1"}'
@@ -269,14 +263,13 @@ tests:
               description: >-
                 Registry quay.io tests are failing across ALL nodes in cluster c1.
                 The exporter is healthy (up=1) but all registry operations are failing.
-                Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
-                Check registry status page and network connectivity from cluster to registry.
                 This is a REGISTRY issue, not an exporter issue.
+                Refer to the runbook for troubleshooting steps.
               alert_team_handle: <!subteam^S079J7LV0KM> <!subteam^S06LGCC3C2V>
               team: o11y
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
-  # Test 13: Multiple registries down - should alert for each
+  #  Multiple registries down - should alert for each
   - interval: 1m
     input_series:
       - series: 'up{namespace="appstudio-registry-exporter", job="appstudio-registry-exporter/registry-exporter-ds-podmonitor", source_cluster="c1"}'
@@ -306,9 +299,8 @@ tests:
               description: >-
                 Registry quay.io tests are failing across ALL nodes in cluster c1.
                 The exporter is healthy (up=1) but all registry operations are failing.
-                Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
-                Check registry status page and network connectivity from cluster to registry.
                 This is a REGISTRY issue, not an exporter issue.
+                Refer to the runbook for troubleshooting steps.
               alert_team_handle: <!subteam^S079J7LV0KM> <!subteam^S06LGCC3C2V>
               team: o11y
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
@@ -328,18 +320,15 @@ tests:
               description: >-
                 Registry registry.example.com tests are failing across ALL nodes in cluster c1.
                 The exporter is healthy (up=1) but all registry operations are failing.
-                Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
-                Check registry status page and network connectivity from cluster to registry.
                 This is a REGISTRY issue, not an exporter issue.
+                Refer to the runbook for troubleshooting steps.
               alert_team_handle: <!subteam^S079J7LV0KM> <!subteam^S06LGCC3C2V>
               team: o11y
               runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
-  # ============================================================================
-  # LEVEL 3: RegistryExporterTestTypeFailure (specific test types failing)
-  # ============================================================================
+  # RegistryExporterTestTypeFailure tests
 
-  # Test 11: Single test type failing on all nodes - SHOULD alert
+  # Single test type failing on all nodes - SHOULD alert
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
@@ -372,7 +361,7 @@ tests:
               alert_routing_key: o11y
               team: o11y
 
-  # Test 12: Test type failing on some nodes but passing on others - should NOT alert
+  #  Test type failing on some nodes but passing on others - should NOT alert
   - interval: 1m
     input_series:
       - series: 'registry_exporter_success{tested_registry="quay.io", node="node1", type="push", source_cluster="c1"}'
@@ -385,11 +374,9 @@ tests:
         alertname: RegistryExporterTestTypeFailure
         exp_alerts: []
 
-  # ============================================================================
-  # LEVEL 4: RegistryExporterNodeFailure (>50% nodes failing)
-  # ============================================================================
+  # RegistryExporterNodeFailure tests
 
-  # Test 13: >50% of nodes failing (2 of 3 = 66.67%) - SHOULD alert
+  # >50% of nodes failing (2 of 3 = 66.67%) - SHOULD alert
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'
@@ -422,7 +409,7 @@ tests:
               alert_routing_key: o11y
               team: o11y
 
-  # Test 14: Exactly 50% of nodes failing (1 of 2) - should NOT alert
+  #  Exactly 50% of nodes failing (1 of 2) - should NOT alert
   - interval: 1m
     input_series:
       - series: 'konflux_up{service="registry-exporter", check="quay.io", source_cluster="c1"}'

--- a/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
+++ b/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
@@ -20,8 +20,6 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: critical
-              namespace: appstudio-registry-exporter
-              job: appstudio-registry-exporter/registry-exporter-ds-podmonitor
               source_cluster: c1
               slo: "true"
               component: registry-exporter
@@ -213,6 +211,19 @@ tests:
               source_cluster: c1
               slo: "true"
               component: registry-exporter
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L33
+              summary: >-
+                Registry quay.io is unreachable from cluster c1
+              description: >-
+                Registry quay.io tests are failing across ALL nodes in cluster c1.
+                The exporter is healthy (up=1) but all registry operations are failing.
+                Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
+                Check registry status page and network connectivity from cluster to registry.
+                This is a REGISTRY issue, not an exporter issue.
+              alert_team_handle: <!subteam^S079J7LV0KM> <!subteam^S06LGCC3C2V>
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
   # Test 12: DaemonSet - Some pods down, but at least ONE exporter up and registry down - SHOULD alert at 10m
   - interval: 1m
@@ -239,6 +250,19 @@ tests:
               source_cluster: c1
               slo: "true"
               component: registry-exporter
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L33
+              summary: >-
+                Registry quay.io is unreachable from cluster c1
+              description: >-
+                Registry quay.io tests are failing across ALL nodes in cluster c1.
+                The exporter is healthy (up=1) but all registry operations are failing.
+                Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
+                Check registry status page and network connectivity from cluster to registry.
+                This is a REGISTRY issue, not an exporter issue.
+              alert_team_handle: <!subteam^S079J7LV0KM> <!subteam^S06LGCC3C2V>
+              team: o11y
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
   # Test 13: Multiple registries down - should alert for each
   - interval: 1m

--- a/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
+++ b/test/promql/tests/data_plane/registry_exporter_alerts_test.yaml
@@ -162,6 +162,19 @@ tests:
               source_cluster: c1
               slo: "true"
               component: registry-exporter
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L33
+              summary: >-
+                Registry quay.io is unreachable from cluster c1
+              description: >-
+                Registry quay.io tests are failing across ALL nodes in cluster c1.
+                The exporter is healthy (up=1) but all registry operations are failing.
+                Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
+                Check registry status page and network connectivity from cluster to registry.
+                This is a REGISTRY issue, not an exporter issue.
+              alert_routing_key: spre
+              team: spre
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
           - exp_labels:
               severity: critical
               namespace: appstudio-registry-exporter
@@ -171,6 +184,19 @@ tests:
               source_cluster: c1
               slo: "true"
               component: registry-exporter
+            exp_annotations:
+              html_url: https://github.com/redhat-appstudio/o11y/blob/main/rhobs/alerting/data_plane/prometheus.registry_exporter_alerts.yaml#L33
+              summary: >-
+                Registry registry.example.com is unreachable from cluster c1
+              description: >-
+                Registry registry.example.com tests are failing across ALL nodes in cluster c1.
+                The exporter is healthy (up=1) but all registry operations are failing.
+                Possible causes: Registry outage, network partition, authentication failure, or firewall issue.
+                Check registry status page and network connectivity from cluster to registry.
+                This is a REGISTRY issue, not an exporter issue.
+              alert_routing_key: spre
+              team: spre
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/o11y/alerting/alert-rules/alert-rule-RegistryExporter.md
 
   # ============================================================================
   # LEVEL 3: RegistryExporterTestTypeFailure (specific test types failing)


### PR DESCRIPTION
## Summary
Fixes misleading RegistryExporterDown alert that fires when registry is down instead of when exporter crashes.

## Changes
- **RegistryExporterDown**: Now uses Prometheus `up` metric instead of `konflux_up`
  - Fires when: Exporter process crashes or Prometheus cannot scrape it
  - Duration: Changed from 15m → 5m for faster detection
  - Team: O11y

- **RegistryOutageClusterWide** (NEW):
  - Fires when: Exporter healthy but all registry tests failing
  - Duration: 15m (reduce noise from transient failures)
  - Team: SPRE

- **4-Level Alert Hierarchy**:
  1. Exporter process down (critical, O11y)
  2. Registry outage cluster-wide (critical, SPRE)
  3. Specific test type failures (high, O11y)
  4. Partial node failures >50% (warning, O11y)

## Testing
- ✅ Local Prometheus testing verified alert firing
- ✅ 14 PromQL test cases covering all scenarios
- ✅ Zero code changes (alert YAML only)

## Related
- Jira: [PVO11Y-5270](https://redhat.atlassian.net/browse/PVO11Y-5270)
- Design Doc: https://docs.google.com/document/d/1BJqvE0X-vZ0G5XeDeTgqXEuVH1SRjU1FqNgOtYt7tik/edit

[PVO11Y-5270]: https://redhat.atlassian.net/browse/PVO11Y-5270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ