### PR TITLE
feat(KFLUXVNGD-1158): support caching independent namespace performance rules

### DIFF
--- a/rhobs/recording/caching_availability_recording_rules.yaml
+++ b/rhobs/recording/caching_availability_recording_rules.yaml
@@ -38,8 +38,56 @@ spec:
       rules:
         # Record rule: calculate total request rate
         - record: artifact_registry_proxy:http_requests:rate5m
-          expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="caching", service="artifact-registry-proxy"}[5m]))
+          expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace=~"caching|artifact-registry-proxy", service="artifact-registry-proxy"}[5m]))
 
         # Record rule: calculate error rate (5xx responses)
         - record: artifact_registry_proxy:http_errors:rate5m
-          expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="caching", service="artifact-registry-proxy", status=~"5.."}[5m]))
+          expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace=~"caching|artifact-registry-proxy", service="artifact-registry-proxy", status=~"5.."}[5m]))
+
+        # Record rule: calculate cache hit rate
+        - record: artifact_registry_proxy:cache_hits:rate5m
+          expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="artifact-registry-proxy", service="artifact-registry-proxy", cache_status="HIT"}[5m]))
+
+        # Record rule: calculate cache miss rate
+        - record: artifact_registry_proxy:cache_misses:rate5m
+          expr: sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="artifact-registry-proxy", service="artifact-registry-proxy", cache_status="MISS"}[5m]))
+
+        # Record rule: calculate cache hit ratio (percentage)
+        - record: artifact_registry_proxy:cache_hit_ratio:rate5m
+          expr: |
+            (
+              sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="artifact-registry-proxy", service="artifact-registry-proxy", cache_status="HIT"}[5m]))
+              /
+              sum by (source_cluster, namespace, service) (rate(http_requests_total{namespace="artifact-registry-proxy", service="artifact-registry-proxy"}[5m]))
+            ) * 100
+
+    - name: container_image_proxy_performance
+      interval: 1m
+      rules:
+        # Record rule: calculate total request rate
+        - record: container_image_proxy:http_requests:rate5m
+          expr: sum by (source_cluster, namespace, service) (rate(squid_client_http_requests_total{namespace="container-image-proxy", service="squid"}[5m]))
+
+        # Record rule: calculate error rate
+        - record: container_image_proxy:http_errors:rate5m
+          expr: sum by (source_cluster, namespace, service) (rate(squid_client_http_errors_total{namespace="container-image-proxy", service="squid"}[5m]))
+
+        # Record rule: calculate cache hit rate
+        - record: container_image_proxy:cache_hits:rate5m
+          expr: sum by (source_cluster, namespace, service) (rate(squid_client_http_hits_total{namespace="container-image-proxy", service="squid"}[5m]))
+
+        # Record rule: calculate cache miss rate
+        - record: container_image_proxy:cache_misses:rate5m
+          expr: |
+            sum by (source_cluster, namespace, service) (rate(squid_client_http_requests_total{namespace="container-image-proxy", service="squid"}[5m]))
+            -
+            sum by (source_cluster, namespace, service) (rate(squid_client_http_hits_total{namespace="container-image-proxy", service="squid"}[5m]))
+
+        # Record rule: calculate cache hit ratio (percentage)
+        - record: container_image_proxy:cache_hit_ratio:rate5m
+          expr: |
+            (
+              sum by (source_cluster, namespace, service) (rate(squid_client_http_hits_total{namespace="container-image-proxy", service="squid"}[5m]))
+              /
+              sum by (source_cluster, namespace, service) (rate(squid_client_http_requests_total{namespace="container-image-proxy", service="squid"}[5m]))
+            ) * 100

--- a/test/promql/tests/data_plane/artifact_registry_proxy_alerts_test.yaml
+++ b/test/promql/tests/data_plane/artifact_registry_proxy_alerts_test.yaml
@@ -146,6 +146,32 @@ tests:
         alertname: NginxHighErrorRate
         exp_alerts: []
 
+  - name: NginxHighErrorRate_IndependentNamespace_Firing
+    interval: 1m
+    input_series:
+      - series: 'artifact_registry_proxy:http_requests:rate5m{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03"}'
+        values: '0 0.5 0.5 0.5 0.5 0.5 0.5+0x20'
+      - series: 'artifact_registry_proxy:http_errors:rate5m{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03"}'
+        values: '0 0.05 0.05 0.05 0.05 0.05 0.05+0x20'
+
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: NginxHighErrorRate
+        exp_alerts:
+          - exp_labels:
+              severity: high
+              slo: "false"
+              component: artifact-registry-proxy
+              source_cluster: cluster03
+              namespace: artifact-registry-proxy
+              service: artifact-registry-proxy
+            exp_annotations:
+              summary: "Artifact Registry Nginx proxy has high error rate"
+              description: "More than 5% of requests to the artifact registry proxy are returning 5xx errors in cluster cluster03. Current error rate: 10%."
+              alert_team_handle: "<!subteam^S07NDQV6A4D>"
+              team: vanguard
+              runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/vanguard/sre/artifact-registry-proxy-high-error-rate.md
+
   - name: NginxHighErrorRate_NotFiring_NoErrors
     interval: 1m
     input_series:

--- a/test/promql/tests/recording/caching_availability_recording_rules_test.yaml
+++ b/test/promql/tests/recording/caching_availability_recording_rules_test.yaml
@@ -163,3 +163,139 @@ tests:
       - expr: 'konflux_up{namespace="other", service="squid"}'
         eval_time: 2m
         exp_samples: []
+
+  - interval: 1m
+    # Test artifact_registry_proxy namespace cache hit ratio
+    input_series:
+      - series: 'http_requests_total{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03", cache_status="HIT"}'
+        values: '0+60x10'
+      - series: 'http_requests_total{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03", cache_status="MISS"}'
+        values: '0+20x10'
+      - series: 'http_requests_total{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03", cache_status="BYPASS"}'
+        values: '0+10x10'
+    promql_expr_test:
+      - expr: artifact_registry_proxy:cache_hit_ratio:rate5m
+        eval_time: 6m
+        exp_samples:
+          - labels: 'artifact_registry_proxy:cache_hit_ratio:rate5m{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03"}'
+            value: 66.66666666666666
+
+  - interval: 1m
+    # Test artifact_registry_proxy namespace cache hits
+    input_series:
+      - series: 'http_requests_total{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03", cache_status="HIT"}'
+        values: '0+60x10'
+      - series: 'http_requests_total{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03", cache_status="MISS"}'
+        values: '0+20x10'
+    promql_expr_test:
+      - expr: artifact_registry_proxy:cache_hits:rate5m
+        eval_time: 6m
+        exp_samples:
+          - labels: 'artifact_registry_proxy:cache_hits:rate5m{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03"}'
+            value: 1
+
+  - interval: 1m
+    # Test artifact_registry_proxy namespace cache misses
+    input_series:
+      - series: 'http_requests_total{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03", cache_status="HIT"}'
+        values: '0+60x10'
+      - series: 'http_requests_total{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03", cache_status="MISS"}'
+        values: '0+20x10'
+    promql_expr_test:
+      - expr: artifact_registry_proxy:cache_misses:rate5m
+        eval_time: 6m
+        exp_samples:
+          - labels: 'artifact_registry_proxy:cache_misses:rate5m{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03"}'
+            value: 0.33333333333333337
+
+  - interval: 1m
+    # Test artifact_registry_proxy namespace total requests
+    input_series:
+      - series: 'http_requests_total{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03", status="200"}'
+        values: '0+50x10'
+      - series: 'http_requests_total{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03", status="500"}'
+        values: '0+10x10'
+    promql_expr_test:
+      - expr: artifact_registry_proxy:http_requests:rate5m
+        eval_time: 6m
+        exp_samples:
+          - labels: 'artifact_registry_proxy:http_requests:rate5m{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03"}'
+            value: 1
+
+  - interval: 1m
+    # Test artifact_registry_proxy namespace errors
+    input_series:
+      - series: 'http_requests_total{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03", status="200"}'
+        values: '0+50x10'
+      - series: 'http_requests_total{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03", status="500"}'
+        values: '0+10x10'
+    promql_expr_test:
+      - expr: artifact_registry_proxy:http_errors:rate5m
+        eval_time: 6m
+        exp_samples:
+          - labels: 'artifact_registry_proxy:http_errors:rate5m{namespace="artifact-registry-proxy", service="artifact-registry-proxy", source_cluster="cluster03"}'
+            value: 0.16666666666666669
+
+  - interval: 1m
+    # Test container_image_proxy namespace cache hit ratio
+    input_series:
+      - series: 'squid_client_http_requests_total{namespace="container-image-proxy", service="squid", source_cluster="cluster04"}'
+        values: '0+100x10'
+      - series: 'squid_client_http_hits_total{namespace="container-image-proxy", service="squid", source_cluster="cluster04"}'
+        values: '0+80x10'
+    promql_expr_test:
+      - expr: container_image_proxy:cache_hit_ratio:rate5m
+        eval_time: 6m
+        exp_samples:
+          - labels: 'container_image_proxy:cache_hit_ratio:rate5m{namespace="container-image-proxy", service="squid", source_cluster="cluster04"}'
+            value: 80
+
+  - interval: 1m
+    # Test container_image_proxy namespace cache hits
+    input_series:
+      - series: 'squid_client_http_hits_total{namespace="container-image-proxy", service="squid", source_cluster="cluster04"}'
+        values: '0+80x10'
+    promql_expr_test:
+      - expr: container_image_proxy:cache_hits:rate5m
+        eval_time: 6m
+        exp_samples:
+          - labels: 'container_image_proxy:cache_hits:rate5m{namespace="container-image-proxy", service="squid", source_cluster="cluster04"}'
+            value: 1.3333333333333335
+
+  - interval: 1m
+    # Test container_image_proxy namespace cache misses
+    input_series:
+      - series: 'squid_client_http_requests_total{namespace="container-image-proxy", service="squid", source_cluster="cluster04"}'
+        values: '0+100x10'
+      - series: 'squid_client_http_hits_total{namespace="container-image-proxy", service="squid", source_cluster="cluster04"}'
+        values: '0+80x10'
+    promql_expr_test:
+      - expr: container_image_proxy:cache_misses:rate5m
+        eval_time: 6m
+        exp_samples:
+          - labels: 'container_image_proxy:cache_misses:rate5m{namespace="container-image-proxy", service="squid", source_cluster="cluster04"}'
+            value: 0.33333333333333326
+
+  - interval: 1m
+    # Test container_image_proxy namespace total requests
+    input_series:
+      - series: 'squid_client_http_requests_total{namespace="container-image-proxy", service="squid", source_cluster="cluster04"}'
+        values: '0+85x10'
+    promql_expr_test:
+      - expr: container_image_proxy:http_requests:rate5m
+        eval_time: 6m
+        exp_samples:
+          - labels: 'container_image_proxy:http_requests:rate5m{namespace="container-image-proxy", service="squid", source_cluster="cluster04"}'
+            value: 1.4166666666666667
+
+  - interval: 1m
+    # Test container_image_proxy namespace errors
+    input_series:
+      - series: 'squid_client_http_errors_total{namespace="container-image-proxy", service="squid", source_cluster="cluster04"}'
+        values: '0+15x10'
+    promql_expr_test:
+      - expr: container_image_proxy:http_errors:rate5m
+        eval_time: 6m
+        exp_samples:
+          - labels: 'container_image_proxy:http_errors:rate5m{namespace="container-image-proxy", service="squid", source_cluster="cluster04"}'
+            value: 0.25


### PR DESCRIPTION
### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

 The caching services are migrating from the shared `caching` namespace into independent `artifact-registry-proxy` and `container-image-proxy` namespaces.

  The newly added recording rules provideper-cluster performance signals for the independent namespaces, including request rate, error rate, cache hits, cache misses, and cache-hit ratio. Both dashboards expose corresponding performance and cache information.

  Existing Artifact Registry request and error recordings continue to support `caching` during the migration. Newly added cache and Container Image Proxy recordings target only the independent namespaces. The legacy rules will be removed after the production migration is complete.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1304
Assisted-By: Codex

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [x] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [x] **Alert Tests:** New or modified alerts include tests to ensure they function correctly.
- [x] **SOP / Runbook:** Any required SOP has been created or updated as needed. If it has direct connection to the dashboard or alert - It should be included within the dashboard or alert's runbook label respectively. 
- [ ] **Dashboards Addition:** New dashboards or significant changes to them should have a link to the [staging instance](https://grafana.stage.devshift.net/dashboards) for validation purposes.
- [ ] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [ ] **Pipeline Finished Successfully**

---

### Deployment Notice

- [x] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.
