### PR TITLE
SPRE-6783: Fix Grafana pod memory usage alert

### DIFF
--- a/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
+++ b/rhobs/alerting/data_plane/prometheus.pod_alerts.yaml
@@ -52,10 +52,21 @@ spec:
 
     - alert: PodMemoryUsageExceedsRequested
       expr: |
-        avg_over_time(container_memory_usage_bytes{namespace="appstudio-grafana"}[5m])
+        sum by (namespace, pod, container, source_cluster) (
+          container_memory_usage_bytes{
+            namespace="appstudio-grafana",
+            container!="",
+            container!="POD"
+          }
+        )
         > on(namespace, pod, container, source_cluster)
-        kube_pod_container_resource_requests{resource="memory", namespace="appstudio-grafana"}
-      for: 5m
+        sum by (namespace, pod, container, source_cluster) (
+          kube_pod_container_resource_requests{
+            resource="memory",
+            namespace="appstudio-grafana"
+          }
+        )
+      for: 10m
       labels:
         severity: warning
       annotations:

--- a/test/promql/tests/data_plane/exceeding_requested_resources_test.yaml
+++ b/test/promql/tests/data_plane/exceeding_requested_resources_test.yaml
@@ -51,14 +51,14 @@ tests:
 
       # Memory exceeding requested
       - series: 'container_memory_usage_bytes{namespace="appstudio-grafana", pod="prod-pod-2", container="test-container-2", source_cluster="cluster01"}'
-        values: '2x10'
+        values: '2x15'
 
       - series: 'kube_pod_container_resource_requests{resource="memory", namespace="appstudio-grafana", pod="prod-pod-2", container="test-container-2", source_cluster="cluster01"}'
-        values: '1x10'
+        values: '1x15'
 
     alert_rule_test:
       - alertname: PodMemoryUsageExceedsRequested
-        eval_time: 10m
+        eval_time: 15m
         exp_alerts:
           - exp_labels:
               severity: warning
@@ -74,3 +74,31 @@ tests:
               description: >-
                 Pod prod-pod-2 in namespace appstudio-grafana on cluster
                 cluster01 has been running above the requested memory resources.
+  - interval: 1m
+    input_series:
+
+      # Memory usage below the request must not alert.
+      - series: 'container_memory_usage_bytes{namespace="appstudio-grafana", pod="prod-pod-low-memory", container="test-container", source_cluster="cluster01"}'
+        values: '1x15'
+
+      - series: 'kube_pod_container_resource_requests{resource="memory", namespace="appstudio-grafana", pod="prod-pod-low-memory", container="test-container", source_cluster="cluster01"}'
+        values: '2x15'
+
+    alert_rule_test:
+      - alertname: PodMemoryUsageExceedsRequested
+        eval_time: 15m
+        exp_alerts: []
+  - interval: 1m
+    input_series:
+
+      # A spike shorter than the alert duration must not alert after usage drops.
+      - series: 'container_memory_usage_bytes{namespace="appstudio-grafana", pod="prod-pod-memory-spike", container="test-container", source_cluster="cluster01"}'
+        values: '20x8 0x7'
+
+      - series: 'kube_pod_container_resource_requests{resource="memory", namespace="appstudio-grafana", pod="prod-pod-memory-spike", container="test-container", source_cluster="cluster01"}'
+        values: '1x15'
+
+    alert_rule_test:
+      - alertname: PodMemoryUsageExceedsRequested
+        eval_time: 12m
+        exp_alerts: []


### PR DESCRIPTION
## Summary
- compare current container memory usage with memory requests using identical labels
- exclude empty and `POD` infrastructure containers
- require usage to remain above the request continuously for 10 minutes
- add positive, low-usage, and temporary-spike regression tests

Jira: https://redhat.atlassian.net/browse/SPRE-6783