### PR TITLE
fix(PVO11Y-5565): preserve rolling data across UTC date changes

### DIFF
--- a/exporters/kaexporter/rolling_store.go
+++ b/exporters/kaexporter/rolling_store.go
@@ -63,9 +63,17 @@ type DailyBucket struct {
 	FailureReasons           map[string]int64 `json:"failure_reasons"`              // Failure count by reason
 }
 
-// MetricWindow is a fixed 30-day circular buffer indexed by day offset.
+// MetricWindow is a fixed 30-day circular buffer indexed by UTC calendar day.
 type MetricWindow struct {
 	Buckets [30]DailyBucket `json:"buckets"`
+}
+
+// dailyBucketIndex returns a stable ring-buffer slot for a UTC calendar day.
+// The same date always maps to the same slot, which is reused 30 days later.
+func dailyBucketIndex(day time.Time) int {
+	const secondsPerDay = int64(24 * time.Hour / time.Second)
+	dayNumber := day.UTC().Unix() / secondsPerDay
+	return int((dayNumber%30 + 30) % 30)
 }
 
 // Store holds 30-day rolling aggregates and a seen-set for deduplication.
@@ -93,11 +101,29 @@ func (s *Store) RecordObservation(
 	succeeded bool,
 	failureReason string,
 ) bool {
+	return s.recordObservationAt(
+		time.Now(), metricName, dedupeKey, completionTime, labelSet,
+		durationSeconds, waitSeconds, succeeded, failureReason,
+	)
+}
+
+// recordObservationAt contains RecordObservation's aggregation logic with an
+// explicit current time so date-boundary behavior can be tested deterministically.
+func (s *Store) recordObservationAt(
+	now time.Time,
+	metricName, dedupeKey string,
+	completionTime time.Time,
+	labelSet LabelSet,
+	durationSeconds float64,
+	waitSeconds float64,
+	succeeded bool,
+	failureReason string,
+) bool {
 	if durationSeconds < 0 {
 		return false
 	}
 
-	now := time.Now().UTC().Truncate(24 * time.Hour)
+	now = now.UTC().Truncate(24 * time.Hour)
 	bucketDay := completionTime.UTC().Truncate(24 * time.Hour)
 	dayOffset := int(now.Sub(bucketDay).Hours() / 24)
 	if dayOffset < 0 || dayOffset >= 30 {
@@ -113,7 +139,7 @@ func (s *Store) RecordObservation(
 	s.SeenKeys[dedupeKey] = completionTime
 
 	window := s.getOrCreateLocked(metricName, labelSet)
-	bucket := &window.Buckets[29-dayOffset]
+	bucket := &window.Buckets[dailyBucketIndex(bucketDay)]
 
 	completionDay := bucketDay.Format("2006-01-02")
 	if bucket.Day != "" && bucket.Day != completionDay {
@@ -469,4 +495,3 @@ const (
 	minSuccessCountForSLO = 10   // minimum observations before evaluating SLO
 	minDaysWithDataForSLO = 3    // minimum days with successful observations before evaluating SLO
 )
-

--- a/exporters/kaexporter/rolling_store_test.go
+++ b/exporters/kaexporter/rolling_store_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStoreRetainsDailyBucketsAcrossUTCDateChange(t *testing.T) {
+	store := NewStore()
+	labels := LabelSet{
+		Cluster:     "test-cluster",
+		Namespace:   "test-tenant",
+		Application: "test-app",
+		Component:   "test-component",
+	}
+	dayOne := time.Date(2026, time.September, 11, 12, 0, 0, 0, time.UTC)
+	dayTwo := dayOne.Add(24 * time.Hour)
+
+	observations := []struct {
+		now        time.Time
+		key        string
+		completion time.Time
+		duration   float64
+	}{
+		{now: dayOne, key: "previous-day", completion: dayOne.Add(-24 * time.Hour), duration: 60},
+		{now: dayOne, key: "day-one", completion: dayOne, duration: 120},
+		{now: dayTwo, key: "day-two", completion: dayTwo, duration: 600},
+	}
+
+	for _, observation := range observations {
+		if recorded := store.recordObservationAt(
+			observation.now,
+			metricBuildDuration,
+			observation.key,
+			observation.completion,
+			labels,
+			observation.duration,
+			0,
+			true,
+			"",
+		); !recorded {
+			t.Fatalf("observation %q was not recorded", observation.key)
+		}
+	}
+
+	window := store.Data[metricBuildDuration][labels]
+	cutoff := dayTwo.AddDate(0, 0, -30).Format("2006-01-02")
+	if got, want := window.ComputeTotalCount(cutoff), int64(len(observations)); got != want {
+		t.Fatalf("total count after UTC date change = %d, want %d; a daily bucket was overwritten", got, want)
+	}
+	if _, got := window.CountBreachingDays(cutoff, 0); got != len(observations) {
+		t.Fatalf("success day count after UTC date change = %d, want %d", got, len(observations))
+	}
+	if got, want := window.ComputeSuccessMean(cutoff), 260.0; got != want {
+		t.Fatalf("success mean after UTC date change = %f, want %f", got, want)
+	}
+}


### PR DESCRIPTION
### Description

<!-- Please provide a description of the changes. What is being changed (and why)? -->

Index daily buckets by their absolute UTC calendar day instead of their relative offset from the current date. This prevents a new day's data from overwriting the preceding day's bucket after midnight.

Add a deterministic regression test covering observations collected across consecutive UTC dates.

Jira: [PVO11Y-5565](https://redhat.atlassian.net/browse/PVO11Y-5565)

---

### Pre-Submission Checklist

<!-- Before you submit the PR for review, please go through this checklist. -->

- [X] **Jira Ticket:** If a corresponding Jira ticket exists, it is linked in the description above, in the PR name, and/or in the commit message.
- [X] **Contribution Guides:** This submission follows the guidelines in our [`CONTRIBUTING.md`](https://github.com/redhat-appstudio/o11y/blob/main/CONTRIBUTING.md) - specifically about the commit conventions and PR instructions - together with our [`README.md`](https://github.com/redhat-appstudio/o11y/blob/main/README.md) which explains contents of this repository with useful examples for contribution.
- [X] **Pipeline Finished Successfully**

---

### Deployment Notice

- [X] **Production Deployment:** For any changes to [alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L40), [recording rules](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-rhtap-rules.yaml#L54) or [dashboards](https://gitlab.cee.redhat.com/service/app-interface/-/blame/26fc0f896636ab30fda8718216804295422514a5/data/services/stonesoup/cicd/saas-stonesoup-dashboards.yml#L38), I understand that the deployment of changes to production requires updating the commit reference to o11y in app-interface repository.

---

### Review

Once your PR is ready please let us know in the [#forum-konflux-o11y](https://redhat.enterprise.slack.com/archives/C04FDFTF8EB) slack channel. Tag `@konflux-o11y-ic` for assistance.


[PVO11Y-5565]: https://redhat.atlassian.net/browse/PVO11Y-5565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ